### PR TITLE
Setup docker volume for shared file access

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ App to show district level estimates of HIV indicators
 Docker images are built on travis, if on master branch run via:
 ```
 docker run --rm -d --network=host --name hintr_redis redis
-docker run --rm -d --network=host --name hintr mrcide/hintr:latest
+docker run --rm -d --network=host --mount type=volume,src=upload_volume,dst=/uploads \
+  --name hintr mrcide/hintr:latest
 ```
 
 Test that container is working by using:
@@ -33,6 +34,17 @@ curl -X POST -H 'Content-Type: application/json' \
 Docker container can be cleaned up using
 ```
 docker rm -f hintr
+```
+
+### Input data
+
+Input data should be written to `/uploads` directory in the docker container, then when requesting validation pass the absolute path to the file in the request JSON e.g.
+
+```
+{
+  "type": "pjnz",
+  "path": "uploads/Botswana.pjnz"
+}
 ```
 
 ## Validating JSON against schema

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ docker rm -f hintr
 
 ### Input data
 
-Input data should be written to `/uploads` directory in the docker container, then when requesting validation pass the absolute path to the file in the request JSON e.g.
+Input data should be written to the shared `upload_volume`. When requesting validation pass the absolute path to the file in the request JSON e.g.
 
 ```
 {
   "type": "pjnz",
-  "path": "uploads/Botswana.pjnz"
+  "path": "/uploads/Botswana.pjnz"
 }
 ```
 


### PR DESCRIPTION
This PR will

* Add note to readme about shared docker volume for uploads

I'm not sure if I'm missing something here as this seems pretty simple, let me know if I have misunderstood.

We said we needed:
1. configurable location for files (so that in local dev or tests you can be expecting them in some local folder, whereas inside the docker container a volume will appear at an absolute path)
1. when building the docker image, configure the above location to some absolute path, e.g. /uploads
1. document what this path is ^
1. whoever runs the image appends -v my_volume_name:/uploads to the run command

This doesn't include any actual configuration, what I'm expecting to receive in the request is JSON like
```
{
  "type": "pjnz",
  "path": "path/to/file"
}
```

Where the path will be available in the docker container. Doing it this way means we don't have to have any directory configured in the code itself? 

If we had a configured location when we went to read the file for validation we would look for the file at `<configured location>/<path from JSON>`?

So this PR only includes notes about use volume called `/uploads`. Also used `--mount` arg instead of `-v` as https://docs.docker.com/storage/volumes/ notes 

> New users should try `--mount` syntax which is simpler than `--volume` syntax.

but I'm happy to amend that if you guys feel strongly the other way