### PR TITLE
Improve schema validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ env:
 r_packages:
   - covr
 r_github_packages:
-  - ropensci/jsonvalidate@i20
+  - ropensci/jsonvalidate@i25
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ RoxygenNote: 6.1.1
 Additional_repositories: https://mrc-ide.github.io/drat
 Imports:
     context,
-    jsonlite,
+    jsonlite (>= 1.2.2),
     plumber,
     redux,
     rrq,

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -37,7 +37,7 @@ endpoint_validate_input <- function(req, res, type, path) {
     response$errors <- hintr_errors(list("INVALID_FILE" = response$message))
     res$status <- 400
   }
-  hintr_response(response)
+  hintr_response(response, "ValidateInputResponse")
 }
 
 #' Format a hintr response and validate against schema.
@@ -49,7 +49,7 @@ endpoint_validate_input <- function(req, res, type, path) {
 #'
 #' @return Formatted hintr response.
 #' @keywords internal
-hintr_response <- function(value) {
+hintr_response <- function(value, schema) {
   if (value$success) {
     status <- "success"
   } else {
@@ -58,9 +58,11 @@ hintr_response <- function(value) {
   ret <- jsonlite::toJSON(list(
     "status" = scalar(status),
     "errors" = value$errors,
-    "data" = value$value
-  ))
+    "data" = value$value))
   validate_json_schema(ret, "Response")
+  if (value$success) {
+    validate_json_schema(ret, schema, query = "data")
+  }
   ret
 }
 

--- a/R/json.R
+++ b/R/json.R
@@ -9,18 +9,19 @@
 #'
 #' @return True if JSON adheres to schema.
 #' @keywords internal
-validate_json_schema <- function(json, schema) {
+validate_json_schema <- function(json, schema, query = NULL) {
   if (!validate_schemas()) {
     return(invisible(TRUE))
   }
-  valid <- validate(json, schema)
+  valid <- validate(json, schema, query)
   invisible(valid)
 }
 
-validate <- function(json, schema) {
+validate <- function(json, schema, query = NULL) {
   schema <- system_file("schema", paste0(schema, ".schema.json"),
                         package = "hintr")
-  jsonvalidate::json_validate(json, schema, engine = "ajv", error = TRUE)
+  jsonvalidate::json_validate(json, schema, engine = "ajv",
+                              query = query, error = TRUE)
 }
 
 validate_schemas <- function() {

--- a/inst/schema/Error.schema.json
+++ b/inst/schema/Error.schema.json
@@ -2,7 +2,7 @@
 	"type": "object",
 	"properties": {
 	  "error" : { "$ref": "ErrorTypes.schema.json" },
-	  "detail" : { "type": ["string", "null"] },
+	  "detail" : { "type": ["string", "null"] }
 	},
 	"additionalProperties": false
 }

--- a/inst/schema/InitialiseModelRunRequest.schema.json
+++ b/inst/schema/InitialiseModelRunRequest.schema.json
@@ -1,12 +1,12 @@
 {
 	"type": "object",
 	"properties": {
-		"pjnz" : { "$ref": "File.schema.json" },
-		"shape" : { "$ref": "File.schema.json" },
-		"population" : { "$ref": "File.schema.json" },
-		"survey" : { "$ref": "File.schema.json" },
-		"programme" : { "$ref": "File.schema.json" },
-		"anc" : { "$ref": "File.schema.json" },
+		"pjnz" : { "$ref": "FilePath.schema.json" },
+		"shape" : { "$ref": "FilePath.schema.json" },
+		"population" : { "$ref": "FilePath.schema.json" },
+		"survey" : { "$ref": "FilePath.schema.json" },
+		"programme" : { "$ref": "FilePath.schema.json" },
+		"anc" : { "$ref": "FilePath.schema.json" },
 		"options": { "$ref": "ModelRunOptions.schema.json" }
 	},
 	"additionalProperties": false,

--- a/inst/schema/ModelRunInputData.schema.json
+++ b/inst/schema/ModelRunInputData.schema.json
@@ -1,12 +1,12 @@
 {
-	"type": "object",
-	"properties": {
-		"programme": { "type": "bool" },
-    "anc": { "type": "bool" },
-	},
-	"additionalProperties": false,
-	"required": [
-    "programme",
-    "anc"
-	]
+    "type": "object",
+    "properties": {
+        "programme": { "type": "bool" },
+        "anc": { "type": "bool" }
+    },
+    "additionalProperties": false,
+    "required": [
+        "programme",
+        "anc"
+    ]
 }

--- a/inst/schema/ValidateInputRequest.schema.json
+++ b/inst/schema/ValidateInputRequest.schema.json
@@ -2,7 +2,7 @@
 	"type": "object",
 	"properties": {
 		"type" : { "$ref": "InputType.schema.json" },
-		"path" : { "$ref": "FilePath.schema.json" },
+		"path" : { "$ref": "FilePath.schema.json" }
 	},
 	"additionalProperties": false,
 	"required": [

--- a/man/hintr_response.Rd
+++ b/man/hintr_response.Rd
@@ -4,7 +4,7 @@
 \alias{hintr_response}
 \title{Format a hintr response and validate against schema.}
 \usage{
-hintr_response(value)
+hintr_response(value, schema)
 }
 \arguments{
 \item{value}{List containing an indication of success, any errors and the

--- a/man/validate_json_schema.Rd
+++ b/man/validate_json_schema.Rd
@@ -4,7 +4,7 @@
 \alias{validate_json_schema}
 \title{Validate string of JSON against specified schema.}
 \usage{
-validate_json_schema(json, schema)
+validate_json_schema(json, schema, query = NULL)
 }
 \arguments{
 \item{json}{The JSON to validate.}

--- a/tests/testthat/helper-endpoint.R
+++ b/tests/testthat/helper-endpoint.R
@@ -1,3 +1,6 @@
+## Always validate schemas in tests
+Sys.setenv("VALIDATE_JSON_SCHEMAS" = "true")
+
 build_validate_request <- function(pjnz) {
   list(
     "pjnz" = list(

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -32,11 +32,13 @@ test_that("endpoint_validate_input validates the input and response", {
                                    MockPlumberResponse$new(), "pjnz", pjnz)
   })
 
-  mockery::expect_called(mock_validate_json_schema, 2)
+  mockery::expect_called(mock_validate_json_schema, 3)
   mockery::expect_args(mock_validate_json_schema, 1, "request",
                        "ValidateInputRequest")
   mockery::expect_args(mock_validate_json_schema, 2, ret,
                        "Response")
+  mockery::expect_args(mock_validate_json_schema, 3, ret,
+                       "ValidateInputResponse", "data")
 })
 
 test_that("hintr_response correctly prepares response", {

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -45,7 +45,9 @@ test_that("hintr_response correctly prepares response", {
     value = scalar("Passed")
   )
   expected_response <- '{"status":"success","errors":{},"data":"Passed"}'
-  response <- hintr_response(value)
+  ## NOTE: using a schema here that will work for now at least, but if
+  ## that gets stricter it won't!
+  response <- hintr_response(value, "URI")
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "success")
   expect_equal(response$data, "Passed")
@@ -57,7 +59,7 @@ test_that("hintr_response correctly prepares response", {
                   list(error = scalar("OTHER_ERROR"),
                        detail = scalar("Second example")))
   )
-  response <- hintr_response(value)
+  response <- hintr_response(value, "ValidateInputRequest")
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "failure")
   expect_length(response$errors, 2)
@@ -69,8 +71,22 @@ test_that("hintr_response correctly prepares response", {
   expect_equal(response$errors[[2]]$error[[1]], "OTHER_ERROR")
   expect_length(response$errors[[2]]$detail, 1)
   expect_equal(response$errors[[2]]$detail[[1]], "Second example")
-
 })
+
+test_that("hintr_response distinguishes incorrect data schema", {
+  ## This is a correct value for the ValidateInputResponse schema
+  value <- list(
+    success = TRUE,
+    value = scalar("Botswana"))
+
+  expect_error(
+    hintr_response(value, "ValidateInputResponse"),
+    NA)
+  expect_error(
+    hintr_response(value, "ModelRunResultResponse"),
+    class = "validation_error")
+})
+
 
 test_that("with_success correctly builds success message", {
   expr <- "Passed validation"


### PR DESCRIPTION
This PR will update #6 to improve the schema validation by

* removing trailing commas so that the schemas can be used from Kotlin (5c0da2f)
* always run the schema validation in tests (5252b4a)
* fix path references (1362e5d)
* test the specific data schema used in a response (4b26d30) - note that this last change requires the `i25` branch of jsonvalidate, which I will create a PR for once https://github.com/ropensci/jsonvalidate/pull/24 is merged