### PR TITLE
MRC-381 (for #12) Allow splicing geojson into responses

### DIFF
--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1,7 +1,7 @@
 api_build <- function() {
   pr <- plumber::plumber$new()
   pr$handle("POST", "/validate", endpoint_validate_input,
-            serializer = plumber::serializer_content_type("application/json"))
+            serializer = serializer_json_hintr)
   pr$handle("GET", "/", api_root)
   pr
 }
@@ -38,15 +38,13 @@ endpoint_validate_input <- function(req, res, type, path) {
     response$errors <- hintr_errors(list("INVALID_FILE" = response$message))
     res$status <- 400
   }
-  auto_unbox <- type == "shape"
-  hintr_response(response, "ValidateInputResponse", auto_unbox = auto_unbox)
+  hintr_response(response, "ValidateInputResponse")
 }
 
 
 input_response <- function(data, path, type) {
   ret <- list(filename = scalar(basename(path)), data = data)
-  validate_json_schema(jsonlite::toJSON(ret, auto_unbox = TRUE),
-                       get_input_response_schema(type), "data")
+  validate_json_schema(to_json(ret), get_input_response_schema(type), "data")
   ret
 }
 
@@ -59,17 +57,16 @@ input_response <- function(data, path, type) {
 #'
 #' @return Formatted hintr response.
 #' @keywords internal
-hintr_response <- function(value, schema, auto_unbox = FALSE) {
+hintr_response <- function(value, schema) {
   if (value$success) {
     status <- "success"
   } else {
     status <- "failure"
   }
-  ret <- jsonlite::toJSON(list(
-    "status" = scalar(status),
-    "errors" = value$errors,
-    "data" = value$value),
-    auto_unbox = auto_unbox)
+  ret <- to_json(list(
+    status = scalar(status),
+    errors = value$errors,
+    data = value$value))
   validate_json_schema(ret, "Response")
   if (value$success) {
     validate_json_schema(ret, schema, query = "data")
@@ -96,5 +93,38 @@ with_success <- function(expr) {
 }
 
 api_root <- function() {
-  jsonlite::unbox("Welcome to hintr")
+  scalar("Welcome to hintr")
+}
+
+# This serialiser allows us to splice in objects with a class "json"
+# into list structures, without converting these structures into
+# strings.  So if we have
+#
+#   list(a = scalar("foo"), b = json_verbatim('{"x": 1, "y": 2}'))
+#
+# We'll end up with the json string
+#
+#   {"a": "foo", "b": {"x": 1, "y": 2}}
+#
+# This is a suitable drop-in replacement for all responses as it is
+# otherwise compatible with the default 'json' serialiser.
+serializer_json_hintr <- function() {
+  function(val, req, res, errorHandler) {
+    tryCatch({
+      res$setHeader("Content-Type", "application/json")
+      res$body <- to_json(val)
+      return(res$toResponse())
+    }, error = function(e) {
+      errorHandler(req, res, e)
+    })
+  }
+}
+
+json_verbatim <- function(x) {
+  class(x) <- "json"
+  x
+}
+
+to_json <- function(x) {
+  jsonlite::toJSON(x, json_verbatim = TRUE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,3 +10,8 @@ system_file <- function(...) {
 is_empty <- function(x) {
   is.null(x) || is.na(x) || length(x) == 0 || trimws(x) == ""
 }
+
+
+read_string <- function(path) {
+  paste(readLines(path, warn = FALSE, encoding = "UTF-8"), collapse = "\n")
+}

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -25,10 +25,19 @@ read_country <- function(pjnz) {
 #' @return An error if invalid or the geojson if valid.
 #' @keywords internal
 do_validate_shape <- function(shape) {
+  # In general, we're going to be reading something other than geojson
+  # most likely - something like a shapefile.  That's good news
+  # because these are super slow to read in (~3s for the sample file
+  # and it's only 2.5MB large).  A caching layer will help, but this
+  # is going to lock things up enough we might need to do it
+  # asynchronously.
   json <- geojsonio::geojson_read(shape, method = "local")
   assert_single_country(json)
   assert_area_id_exists(json)
-  json
+  # Then we have to *reread* the file now that we know that it is
+  # valid, but but this is not too slow, especially as the file is now
+  # in cache (but still ~1/20s)
+  json_verbatim(read_string(shape))
 }
 
 assert_single_country <- function(json) {

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -41,7 +41,5 @@ test_that("assert fails if a feature is missing an area id", {
 test_that("do_validate_shape validates shape and returns geojson as list", {
   shape <- system.file("testdata", "malawi.geojson", package = "hintr")
   json <- do_validate_shape(shape)
-  expect_type(json, "list")
-  expect_equal(names(json), c("type", "name", "crs", "features"))
-  expect_equal(length(json$features), 502)
+  expect_type(json, "json")
 })


### PR DESCRIPTION
Note that this is a PR into #12, not into master

* Uses the `json_verbatim` option in `jsonlite::toJSON`, which seems
  to be documented only in the NEWS file!
* Creates a custom serialiser that we can use everywhere for json outputs
* Creates a little wrapper function `json_verbatim` for marking verbatim
  json entries
* Removes all `jsonlite::toJSON` calls so that they route through a
  `to_json` wrapper (I find this reduces a class of tedious bugs)
* Removes all unbox/auto_unbox references