### PR TITLE
mrc-432: validate schemas

### DIFF
--- a/inst/schema/ModelRunInputData.schema.json
+++ b/inst/schema/ModelRunInputData.schema.json
@@ -2,8 +2,8 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
-    "programme": { "type": "bool" },
-    "anc": { "type": "bool" }
+    "programme": { "type": "boolean" },
+    "anc": { "type": "boolean" }
   },
   "additionalProperties": false,
   "required": [

--- a/inst/schema/ModelRunResultResponse.schema.json
+++ b/inst/schema/ModelRunResultResponse.schema.json
@@ -7,7 +7,7 @@
         "processId" : { "$ref": "URI.schema.json" },
         "complete": {
           "type": "string",
-          "enum": false
+          "enum": [false]
         },
         "progress": { "type": "integer" },
         "timeRemaining": { "type": "integer" }

--- a/inst/schema/ModelRunResultResponse.schema.json
+++ b/inst/schema/ModelRunResultResponse.schema.json
@@ -6,7 +6,8 @@
       "properties": {
         "processId" : { "$ref": "URI.schema.json" },
         "complete": {
-          "const": true
+          "type": "string",
+          "enum": false
         },
         "progress": { "type": "integer" },
         "timeRemaining": { "type": "integer" }
@@ -23,7 +24,8 @@
       "properties": {
         "processId": { "$ref": "URI.schema.json" },
         "complete": {
-          "const": true
+          "type": "string",
+          "enum": [true]
         },
         "result": { "$ref": "ModelRunResult.schema.json" }
       },

--- a/inst/schema/Response.schema.json
+++ b/inst/schema/Response.schema.json
@@ -6,7 +6,8 @@
       "type": "object",
       "properties": {
         "status": {
-          "const": "success"
+          "type": "string",
+          "enum": ["success"]
         },
         "data": {
           "oneOf": [
@@ -27,7 +28,8 @@
       "type": "object",
       "properties": {
         "status": {
-          "const": "failure"
+          "type": "string",
+          "enum": ["failure"]
         },
         "data": {
           "type": "object"

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -161,3 +161,31 @@ test_that("format_response_data correctly formats data and validates it", {
   expect_equal(args[[2]], "PjnzResponseData")
   expect_equal(args[[3]], "data")
 })
+
+test_that("Schemas are draft-04", {
+  meta <- readLines("http://json-schema.org/draft-04/schema")
+  path <- system.file("schema", package = "hintr", mustWork = TRUE)
+  files <- dir(path, full.names = TRUE, pattern = "\\.schema\\.json$")
+  for (f in files) {
+    expect_true(jsonvalidate::json_validate(f, meta), label = f)
+  }
+})
+
+test_that("Schemas do not use const", {
+  path <- system.file("schema", package = "hintr", mustWork = TRUE)
+  files <- dir(path, full.names = TRUE, pattern = "\\.schema\\.json$")
+
+  check1 <- function(x) {
+    if ("const" %in% names(x)) {
+      stop("Schema uses 'const' property and is not supported in draft-04")
+    }
+    if (is.recursive(x)) {
+      lapply(x, check1)
+    }
+  }
+
+  files <- dir(path, full.names = TRUE, pattern = "\\.schema\\.json$")
+  for (f in files) {
+    expect_error(check1(jsonlite::fromJSON(f)), NA, label = f)
+  }
+})


### PR DESCRIPTION
This PR introduces two tests:
    
* check that schemas are all draft-04 compliant
* check that they do not use the const keyword
    
The latter is additional to the former, as the draft-04 schema just ignores the const.

Minor fixes to a 3 schemas are included - I've tried to copy the existing behaviour directly, but I feel that the `ModelRunResultResponse.schema.json` change could be better modelled as a boolean
