### PR TITLE
MRC-436: Fix the serialiser, adding tests for the whole server

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,5 @@
 ^LICENSE\.md$
 ^\.travis\.yml$
 ^codecov\.yml$
+^example$
+^docker$

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ addons:
       - redis-server
 services:
   - redis-server
+before_script:
+  - R CMD INSTALL .
 cache: packages
 env:
   - VALIDATE_JSON_SCHEMAS=true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     rrq,
     specio
 Suggests:
+    callr,
     covr,
     jsonvalidate,
     mockery,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
 Suggests:
     callr,
     covr,
+    httr,
     jsonvalidate,
     mockery,
     R6,

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -6,12 +6,12 @@ api_build <- function() {
   pr
 }
 
-api_run <- function(pr) {
-  pr$run(host = "0.0.0.0", port = 8888) # nocov
+api_run <- function(pr, port = 8888) {
+  pr$run(host = "0.0.0.0", port = port)
 }
 
-api <- function() {
-  api_run(api_build()) # nocov
+api <- function(port = 8888) {
+  api_run(api_build(), port)
 }
 
 #' Validate an input file and return an indication of success and

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -7,11 +7,11 @@ api_build <- function() {
 }
 
 api_run <- function(pr, port = 8888) {
-  pr$run(host = "0.0.0.0", port = port)
+  pr$run(host = "0.0.0.0", port = port) # nocov
 }
 
 api <- function(port = 8888) {
-  api_run(api_build(), port)
+  api_run(api_build(), port) # nocov
 }
 
 #' Validate an input file and return an indication of success and

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -1,7 +1,7 @@
 api_build <- function() {
   pr <- plumber::plumber$new()
   pr$handle("POST", "/validate", endpoint_validate_input,
-            serializer = serializer_json_hintr)
+            serializer = serializer_json_hintr())
   pr$handle("GET", "/", api_root)
   pr
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,7 +11,10 @@ is_empty <- function(x) {
   is.null(x) || is.na(x) || length(x) == 0 || trimws(x) == ""
 }
 
-
 read_string <- function(path) {
   paste(readLines(path, warn = FALSE, encoding = "UTF-8"), collapse = "\n")
+}
+
+`%||%` <- function(a, b) {
+  if (is.null(a)) b else a
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,3 @@ is_empty <- function(x) {
 read_string <- function(path) {
   paste(readLines(path, warn = FALSE, encoding = "UTF-8"), collapse = "\n")
 }
-
-`%||%` <- function(a, b) {
-  if (is.null(a)) b else a
-}

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -1,0 +1,67 @@
+free_port <- function(start, max_tries = 20) {
+  force(start)
+  force(max_tries)
+  function() {
+    port <- find_free_port(start, max_tries)
+    start <<- start + 1
+    port
+  }
+}
+
+find_free_port <- function(start, max_tries = 20) {
+  port <- seq(start, length.out = max_tries)
+  for (p in port) {
+    if (check_port(p)) {
+      return(p)
+    }
+  }
+  stop(sprintf("Did not find a free port between %d..%d",
+               min(port), max(port)),
+       call. = FALSE)
+}
+
+check_port <- function(port) {
+  timeout <- 0.1
+  con <- tryCatch(suppressWarnings(socketConnection(
+    "localhost", port = port, timeout = timeout, open = "r")),
+    error = function(e) NULL)
+  if (is.null(con)) {
+    return(TRUE)
+  }
+  close(con)
+  FALSE
+}
+
+get_free_port <- free_port(9000)
+
+hintr_server <- function(port = NULL, n_tries = 10, poll = 0.1) {
+  skip_if_not_installed("processx")
+
+  port <- port %||% get_free_port()
+
+
+  process <- callr::r_bg(function(port) hintr:::api(port),
+                         args = list(port = port))
+  url <- sprintf("http://localhost:%d", port)
+
+  for (i in seq_len(n_tries)) {
+    ok <-  tryCatch({
+      httr::stop_for_status(httr::GET(url))
+      TRUE
+    }, error = function(e) FALSE)
+    if (ok) {
+      return(list(process = process, url = url, port = port))
+    }
+    if (!process$is_alive()) {
+      break
+    }
+    Sys.sleep(poll)
+  }
+
+  pr$kill()
+  stop("Failed to start server")
+}
+
+response_to_json <- function(x) {
+  jsonlite::fromJSON(httr::content(r, "text", encoding = "UTF-8"), FALSE)
+}

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -41,11 +41,11 @@ get_free_port <- free_port(9000)
 # up. So the default is to use an incrementing port number. This has
 # proven more reliable in practice anyway. The approach above is the
 # same used in vaultr.
-hintr_server <- function(port = NULL, n_tries = 10, poll = 0.1) {
+hintr_server <- function(n_tries = 10, poll = 0.1) {
   skip_if_not_installed("callr")
   skip_if_not_installed("httr")
 
-  port <- port %||% get_free_port()
+  port <- get_free_port()
 
   process <- callr::r_bg(function(port) hintr:::api(port),
                          args = list(port = port))

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -52,7 +52,7 @@ hintr_server <- function(port = NULL, n_tries = 10, poll = 0.1) {
   url <- sprintf("http://localhost:%d", port)
 
   for (i in seq_len(n_tries)) {
-    ok <-  tryCatch({
+    ok <- tryCatch({
       httr::stop_for_status(httr::GET(url))
       TRUE
     }, error = function(e) FALSE)

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -34,6 +34,13 @@ check_port <- function(port) {
 
 get_free_port <- free_port(9000)
 
+# The callr package will create a supervised process with a finaliser
+# that will clean up on garbage collection, so we don't need to
+# explicitly clean up. However, it means that consecutive tests should
+# not use the same port because a process might still be being cleaned
+# up. So the default is to use an incrementing port number. This has
+# proven more reliable in practice anyway. The approach above is the
+# same used in vaultr.
 hintr_server <- function(port = NULL, n_tries = 10, poll = 0.1) {
   skip_if_not_installed("callr")
   skip_if_not_installed("httr")

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -63,5 +63,5 @@ hintr_server <- function(port = NULL, n_tries = 10, poll = 0.1) {
 }
 
 response_to_json <- function(x) {
-  jsonlite::fromJSON(httr::content(r, "text", encoding = "UTF-8"), FALSE)
+  jsonlite::fromJSON(httr::content(x, "text", encoding = "UTF-8"), FALSE)
 }

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -36,6 +36,7 @@ get_free_port <- free_port(9000)
 
 hintr_server <- function(port = NULL, n_tries = 10, poll = 0.1) {
   skip_if_not_installed("processx")
+  skip_if_not_installed("httr")
 
   port <- port %||% get_free_port()
 

--- a/tests/testthat/helper-server.R
+++ b/tests/testthat/helper-server.R
@@ -35,11 +35,10 @@ check_port <- function(port) {
 get_free_port <- free_port(9000)
 
 hintr_server <- function(port = NULL, n_tries = 10, poll = 0.1) {
-  skip_if_not_installed("processx")
+  skip_if_not_installed("callr")
   skip_if_not_installed("httr")
 
   port <- port %||% get_free_port()
-
 
   process <- callr::r_bg(function(port) hintr:::api(port),
                          args = list(port = port))

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -1,0 +1,26 @@
+context("server")
+
+test_that("Root", {
+  server <- hintr_server()
+
+  r <- httr::GET(server$url)
+  expect_equal(httr::status_code(r), 200)
+  expect_equal(response_to_json(r), "Welcome to hintr")
+})
+
+test_that("validate pjnz", {
+  server <- hintr_server()
+
+  pjnz <- system.file("testdata", "Botswana2018.PJNZ", package = "hintr")
+  body <- list(type = scalar("pjnz"), path = scalar(pjnz))
+
+  r <- httr::POST(paste0(server$url, "/validate"), body = body,
+                  encode = "json")
+  expect_equal(httr::status_code(r), 200)
+  expect_equal(response_to_json(r),
+               list(status = "success",
+                    errors = structure(list(), names = character(0)),
+                    data = list(filename = "Botswana2018.PJNZ",
+                                type = "pjnz",
+                                data = list(country = "Botswana"))))
+})


### PR DESCRIPTION
This PR fixes an error in the serialiser that breaks the `/validate` endpoint, but that change is contained in 6bfbcab

The bulk of this PR sets up tests for the whole server, running it in a background server, and bringing up a new server for each test