### PR TITLE
check file exists before validating it

### DIFF
--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -34,8 +34,12 @@ endpoint_validate_input <- function(req, res, type, path) {
     programme = do_validate_programme,
     anc = do_validate_anc,
     survey = do_validate_survey)
+  validate_if_exists <- function(path) {
+    if (!file.exists(path)) stop("File does not exist. Create it, or fix the path.", call. = FALSE)
+    validate_func(path)
+  }
   response <- with_success(
-    validate_func(path))
+    validate_if_exists(path))
   if (response$success) {
     response$value <- input_response(response$value, path, type)
   } else {

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -25,6 +25,20 @@ test_that("endpoint_validate_input correctly validates data", {
   })
 })
 
+test_that("endpoint_validate_input returns nice error if file does not exist", {
+
+  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file"}')
+  res <- MockPlumberResponse$new()
+  response <- endpoint_validate_input(req, res, "pjnz", "path/to/file")
+  response <- jsonlite::parse_json(response)
+  expect_equal(response$status, "failure")
+  expect_length(response$errors, 1)
+  expect_equal(response$errors[[1]]$error, "INVALID_FILE")
+  expect_equal(response$errors[[1]]$detail, "File does not exist. Create it, or fix the path.")
+  expect_equal(res$status, 400)
+
+})
+
 test_that("endpoint_validate_input validates the input and response", {
   pjnz <- file.path("testdata", "Botswana2018.PJNZ")
   mock_validate_json_schema <- mockery::mock(TRUE, cycle = TRUE)


### PR DESCRIPTION
Current behaviour: depending on the endpoint, passing a path to a non-existent file throws a different error (whatever is thrown by the package reading the file, utils, jsonlite, specio, etc). To standardise these, this PR adds a check that the file exists before passing it off to the relevant validation method.