### PR TITLE
mrc-512: Tag images with package version

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -6,5 +6,6 @@ HERE=$(dirname $0)
 docker build --pull \
        -t $TAG_SHA \
        -t $TAG_BRANCH \
+       -t $TAG_VERSION \
        -f docker/Dockerfile \
        .

--- a/docker/common
+++ b/docker/common
@@ -4,6 +4,7 @@ PACKAGE_NAME=hintr
 PACKAGE_ORG=mrcide
 
 GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
+PKG_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION | grep '^Version:' | sed 's/^.*: *//')
 
 if [ "$TRAVIS" = "true" ]; then
     GIT_BRANCH=$TRAVIS_BRANCH
@@ -13,3 +14,4 @@ fi
 
 TAG_SHA="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_SHA}"
 TAG_BRANCH="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_BRANCH}"
+TAG_VERSION="${PACKAGE_ORG}/${PACKAGE_NAME}:v${PKG_VERSION}"

--- a/docker/push
+++ b/docker/push
@@ -4,6 +4,7 @@ HERE=$(dirname $0)
 . $HERE/common
 docker push $TAG_SHA
 docker push $TAG_BRANCH
+docker push $TAG_VERSION
 
 if [ $GIT_BRANCH == "master" ]; then
    TAG_LATEST="${PACKAGE_ORG}/${PACKAGE_NAME}:latest"


### PR DESCRIPTION
This PR will add an additional docker tag that can be used to reference a semantic version of hintr.  This might be useful for reducing unexpected behaviour as hintr changes.