### PR TITLE
expect original filename and return it

### DIFF
--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -147,7 +147,7 @@ endpoint_validate_survey_programme <- function(req, res, type, path, shape, orig
 
 
 input_response <- function(value, path, type, filename) {
-  ret <- list(filename = scalar(basename(path)),
+  ret <- list(hash = scalar(basename(path)),
               type = scalar(type),
               data = value$data,
               originalFilename = filename,

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -92,7 +92,7 @@ is_error <- function(x) {
 #'
 #' @return Validated JSON response with data and incidcation of success.
 #' @keywords internal
-endpoint_validate_baseline <- function(req, res, type, path) {
+endpoint_validate_baseline <- function(req, res, type, path, originalFilename) {
   validate_json_schema(req$postBody, "ValidateInputRequest")
   validate_func <- switch(type,
                           pjnz = do_validate_pjnz,
@@ -103,7 +103,7 @@ endpoint_validate_baseline <- function(req, res, type, path) {
     validate_func(path)
   })
   if (response$success) {
-    response$value <- input_response(response$value, path, type)
+    response$value <- input_response(response$value, path, type, originalFilename)
   } else {
     response$errors <- hintr_errors(list("INVALID_FILE" = response$message))
     res$status <- 400
@@ -124,7 +124,7 @@ endpoint_validate_baseline <- function(req, res, type, path) {
 #'
 #' @return Validated JSON response with data and incidcation of success.
 #' @keywords internal
-endpoint_validate_survey_programme <- function(req, res, type, path, shape) {
+endpoint_validate_survey_programme <- function(req, res, type, path, shape, originalFilename) {
   validate_json_schema(req$postBody, "ValidateSurveyAndProgrammeRequest")
   validate_func <- switch(type,
                           programme = do_validate_programme,
@@ -136,7 +136,7 @@ endpoint_validate_survey_programme <- function(req, res, type, path, shape) {
     validate_func(path, shape)
   })
   if (response$success) {
-    response$value <- input_response(response$value, path, type)
+    response$value <- input_response(response$value, path, type, originalFilename)
   } else {
     response$errors <- hintr_errors(list("INVALID_FILE" = response$message))
     res$status <- 400
@@ -146,10 +146,11 @@ endpoint_validate_survey_programme <- function(req, res, type, path, shape) {
 }
 
 
-input_response <- function(value, path, type) {
+input_response <- function(value, path, type, filename) {
   ret <- list(filename = scalar(basename(path)),
               type = scalar(type),
               data = value$data,
+              originalFilename = filename,
               filters = value$filters)
   validate_json_schema(to_json(ret), get_input_response_schema(type), "data")
   ret

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -89,6 +89,7 @@ is_error <- function(x) {
 #' @param type The type of file to validate: pjnz, shape, population, ANC,
 #' survey or programme.
 #' @param path Path to the file to validate.
+#' @param originalFilename Original file name to be returned in the serialised data.
 #'
 #' @return Validated JSON response with data and incidcation of success.
 #' @keywords internal
@@ -121,6 +122,7 @@ endpoint_validate_baseline <- function(req, res, type, path, originalFilename) {
 #' @param type The type of file to validate: ANC, survey or programme.
 #' @param path Path to the file to validate.
 #' @param shape Path to shape file for comparison.
+#' @param originalFilename Original file name to be returned in the serialised data.
 #'
 #' @return Validated JSON response with data and incidcation of success.
 #' @keywords internal
@@ -146,11 +148,11 @@ endpoint_validate_survey_programme <- function(req, res, type, path, shape, orig
 }
 
 
-input_response <- function(value, path, type, filename) {
+input_response <- function(value, path, type, originalFilename) {
   ret <- list(hash = scalar(basename(path)),
               type = scalar(type),
               data = value$data,
-              originalFilename = filename,
+              originalFilename = scalar(originalFilename),
               filters = value$filters)
   validate_json_schema(to_json(ret), get_input_response_schema(type), "data")
   ret

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -88,9 +88,7 @@ is_error <- function(x) {
 #' @param res The response as a PlumberResponse object.
 #' @param type The type of file to validate: pjnz, shape, population, ANC,
 #' survey or programme.
-#' @param path Path to the file to validate.
-#' @param hash md5 hash of the file to validate.
-#' @param filename Original file name to be returned in the serialised data.
+#' @param file File object containing path, filename and md5 hash.
 #'
 #' @return Validated JSON response with data and incidcation of success.
 #' @keywords internal
@@ -122,9 +120,8 @@ endpoint_validate_baseline <- function(req, res, type, file) {
 #' @param res The response as a PlumberResponse object.
 #' @param type The type of file to validate: ANC, survey or programme.
 #' @param path Path to the file to validate.
+#' @param file File object containing path, filename and md5 hash.
 #' @param shape Path to shape file for comparison.
-#' @param hash md5 hash of the file to validate.
-#' @param filename Original file name to be returned in the serialised data.
 #'
 #' @return Validated JSON response with data and incidcation of success.
 #' @keywords internal

--- a/README.md
+++ b/README.md
@@ -116,8 +116,13 @@ To run tests locally:
 1. Install all dependencies with `devtools::install_deps(".")`. You may be prompted to install some operating system 
     packages; these should be available via your package manager but for `protoc` you may need the following instructions:
    https://askubuntu.com/questions/1072683/how-can-i-install-protoc-on-ubuntu-16-04
-1. Install the latest version of `jsonvalidate` from GitHub with
-     `devtools::install_github("ropensci/jsonvalidate")`
+1. Some packages need to be installed from GitHub:
+    * `devtools::install_github("ropensci/jsonvalidate")`
+    * `devtools::install_github("mrc-ide/eppasm")`
+    * `devtools::install_github("mrc-ide/naomi")`
+    * `devtools::install_github("mrc-ide/queuer")`
+    * `devtools::install_github("mrc-ide/context")`    
+    * `devtools::install_github("mrc-ide/rrq")`
 1. Install the hintr package:
    ```
    R CMD INSTALL .

--- a/inst/schema/SessionFile.schema.json
+++ b/inst/schema/SessionFile.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "path" : { "$ref": "FilePath.schema.json" },
+  "hash" : { "type": "string" },
+  "filename" : { "type": "string" },
+  "additionalProperties": false,
+  "required": ["filename", "hash", "path"]
+}

--- a/inst/schema/SessionFile.schema.json
+++ b/inst/schema/SessionFile.schema.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "path" : { "$ref": "FilePath.schema.json" },
-  "hash" : { "type": "string" },
-  "filename" : { "type": "string" },
+  "properties": {
+    "path" : { "$ref": "FilePath.schema.json" },
+    "hash" : { "type": "string" },
+    "filename" : { "type": "string" }
+  },
   "additionalProperties": false,
   "required": ["filename", "hash", "path"]
 }

--- a/inst/schema/ValidateInputRequest.schema.json
+++ b/inst/schema/ValidateInputRequest.schema.json
@@ -4,12 +4,14 @@
   "properties": {
     "type" : { "$ref": "InputType.schema.json" },
     "path" : { "$ref": "FilePath.schema.json" },
-    "originalFilename" : { "$ref": "FilePath.schema.json" }
+    "hash" : { "type": "string" },
+    "filename" : { "type": "string" }
   },
   "additionalProperties": false,
   "required": [
     "type",
     "path",
-    "originalFilename"
+    "hash",
+    "filename"
   ]
 }

--- a/inst/schema/ValidateInputRequest.schema.json
+++ b/inst/schema/ValidateInputRequest.schema.json
@@ -3,15 +3,11 @@
   "type": "object",
   "properties": {
     "type" : { "$ref": "InputType.schema.json" },
-    "path" : { "$ref": "FilePath.schema.json" },
-    "hash" : { "type": "string" },
-    "filename" : { "type": "string" }
+    "file" : { "$ref": "SessionFile.schema.json" }
   },
   "additionalProperties": false,
   "required": [
-    "type",
-    "path",
-    "hash",
-    "filename"
+    "file",
+    "type"
   ]
 }

--- a/inst/schema/ValidateInputRequest.schema.json
+++ b/inst/schema/ValidateInputRequest.schema.json
@@ -3,11 +3,13 @@
   "type": "object",
   "properties": {
     "type" : { "$ref": "InputType.schema.json" },
-    "path" : { "$ref": "FilePath.schema.json" }
+    "path" : { "$ref": "FilePath.schema.json" },
+    "originalFilename" : { "$ref": "FilePath.schema.json" }
   },
   "additionalProperties": false,
   "required": [
     "type",
-    "path"
+    "path",
+    "originalFilename"
   ]
 }

--- a/inst/schema/ValidateInputResponse.schema.json
+++ b/inst/schema/ValidateInputResponse.schema.json
@@ -3,7 +3,7 @@
   "definitions": {
     "pjnz_response": {
       "properties": {
-        "path": { "$ref": "FileName.schema.json" },
+        "hash": { "$ref": "FileName.schema.json" },
         "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
@@ -13,12 +13,12 @@
         "filters": { "type": "null" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "path", "type", "data"]
+      "required": ["originalFilename", "hash", "type", "data"]
     },
 
     "shape_response": {
       "properties": {
-        "path": { "$ref": "FileName.schema.json" },
+        "hash": { "$ref": "FileName.schema.json" },
         "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
@@ -40,12 +40,12 @@
         }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "path", "type", "data", "filters"]
+      "required": ["originalFilename", "hash", "type", "data", "filters"]
     },
 
     "population_response": {
       "properties": {
-        "path": { "$ref": "FileName.schema.json" },
+        "hash": { "$ref": "FileName.schema.json" },
         "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
@@ -55,12 +55,12 @@
         "filters": { "type": "null" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "path", "type", "data"]
+      "required": ["originalFilename", "hash", "type", "data"]
     },
 
     "programme_response": {
       "properties": {
-        "path": { "$ref": "FileName.schema.json" },
+        "hash": { "$ref": "FileName.schema.json" },
         "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
@@ -70,12 +70,12 @@
         "filters": { "$ref": "AgeFilters.schema.json" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "path", "data", "filters"]
+      "required": ["originalFilename", "hash", "data", "filters"]
     },
 
     "anc_response": {
       "properties": {
-        "path": { "$ref": "FileName.schema.json" },
+        "hash": { "$ref": "FileName.schema.json" },
         "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
@@ -85,12 +85,12 @@
         "filters": { "$ref": "AgeFilters.schema.json" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "path", "type", "data", "filters"]
+      "required": ["originalFilename", "hash", "type", "data", "filters"]
     },
 
     "survey_response": {
       "properties": {
-        "path": { "$ref": "FileName.schema.json" },
+        "hash": { "$ref": "FileName.schema.json" },
         "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
@@ -100,7 +100,7 @@
         "filters": { "$ref": "SurveyFilters.schema.json" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "path", "type", "data", "filters"]
+      "required": ["originalFilename", "hash", "type", "data", "filters"]
     }
   },
 

--- a/inst/schema/ValidateInputResponse.schema.json
+++ b/inst/schema/ValidateInputResponse.schema.json
@@ -4,7 +4,7 @@
     "pjnz_response": {
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
-        "originalFilename" : { "$ref": "FilePath.schema.json" },
+        "filename" : { "type": "string" },
         "type": {
           "type": "string",
           "enum": [ "pjnz" ]
@@ -13,13 +13,13 @@
         "filters": { "type": "null" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "hash", "type", "data"]
+      "required": ["filename", "hash", "type", "data"]
     },
 
     "shape_response": {
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
-        "originalFilename" : { "$ref": "FilePath.schema.json" },
+        "filename" : { "type": "string" },
         "type": {
           "type": "string",
           "enum": [ "shape" ]
@@ -40,13 +40,13 @@
         }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "hash", "type", "data", "filters"]
+      "required": ["filename", "hash", "type", "data", "filters"]
     },
 
     "population_response": {
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
-        "originalFilename" : { "$ref": "FilePath.schema.json" },
+        "filename" : { "type": "string" },
         "type": {
           "type": "string",
           "enum": [ "population" ]
@@ -55,13 +55,13 @@
         "filters": { "type": "null" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "hash", "type", "data"]
+      "required": ["filename", "hash", "type", "data"]
     },
 
     "programme_response": {
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
-        "originalFilename" : { "$ref": "FilePath.schema.json" },
+        "filename" : { "type": "string" },
         "type": {
           "type": "string",
           "enum": [ "programme" ]
@@ -70,13 +70,13 @@
         "filters": { "$ref": "AgeFilters.schema.json" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "hash", "type", "data", "filters"]
+      "required": ["filename", "hash", "type", "data", "filters"]
     },
 
     "anc_response": {
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
-        "originalFilename" : { "$ref": "FilePath.schema.json" },
+        "filename" : { "type": "string" },
         "type": {
           "type": "string",
           "enum": [ "anc" ]
@@ -85,13 +85,13 @@
         "filters": { "$ref": "AgeFilters.schema.json" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "hash", "type", "data", "filters"]
+      "required": ["filename", "hash", "type", "data", "filters"]
     },
 
     "survey_response": {
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
-        "originalFilename" : { "$ref": "FilePath.schema.json" },
+        "filename" : { "type": "string" },
         "type": {
           "type": "string",
           "enum": [ "survey" ]
@@ -100,7 +100,7 @@
         "filters": { "$ref": "SurveyFilters.schema.json" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "hash", "type", "data", "filters"]
+      "required": ["filename", "hash", "type", "data", "filters"]
     }
   },
 

--- a/inst/schema/ValidateInputResponse.schema.json
+++ b/inst/schema/ValidateInputResponse.schema.json
@@ -70,7 +70,7 @@
         "filters": { "$ref": "AgeFilters.schema.json" }
       },
       "additionalProperties": false,
-      "required": ["originalFilename", "hash", "data", "filters"]
+      "required": ["originalFilename", "hash", "type", "data", "filters"]
     },
 
     "anc_response": {

--- a/inst/schema/ValidateInputResponse.schema.json
+++ b/inst/schema/ValidateInputResponse.schema.json
@@ -3,7 +3,8 @@
   "definitions": {
     "pjnz_response": {
       "properties": {
-        "filename": { "$ref": "FileName.schema.json" },
+        "path": { "$ref": "FileName.schema.json" },
+        "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
           "enum": [ "pjnz" ]
@@ -12,12 +13,13 @@
         "filters": { "type": "null" }
       },
       "additionalProperties": false,
-      "required": ["filename", "type", "data"]
+      "required": ["originalFilename", "path", "type", "data"]
     },
 
     "shape_response": {
       "properties": {
-        "filename": { "$ref": "FileName.schema.json" },
+        "path": { "$ref": "FileName.schema.json" },
+        "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
           "enum": [ "shape" ]
@@ -38,12 +40,13 @@
         }
       },
       "additionalProperties": false,
-      "required": ["filename", "type", "data", "filters"]
+      "required": ["originalFilename", "path", "type", "data", "filters"]
     },
 
     "population_response": {
       "properties": {
-        "filename": { "$ref": "FileName.schema.json" },
+        "path": { "$ref": "FileName.schema.json" },
+        "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
           "enum": [ "population" ]
@@ -52,12 +55,13 @@
         "filters": { "type": "null" }
       },
       "additionalProperties": false,
-      "required": ["filename", "type", "data"]
+      "required": ["originalFilename", "path", "type", "data"]
     },
 
     "programme_response": {
       "properties": {
-        "filename": { "$ref": "FileName.schema.json" },
+        "path": { "$ref": "FileName.schema.json" },
+        "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
           "enum": [ "programme" ]
@@ -66,12 +70,13 @@
         "filters": { "$ref": "AgeFilters.schema.json" }
       },
       "additionalProperties": false,
-      "required": ["filename", "type", "data", "filters"]
+      "required": ["originalFilename", "path", "data", "filters"]
     },
 
     "anc_response": {
       "properties": {
-        "filename": { "$ref": "FileName.schema.json" },
+        "path": { "$ref": "FileName.schema.json" },
+        "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
           "enum": [ "anc" ]
@@ -80,12 +85,13 @@
         "filters": { "$ref": "AgeFilters.schema.json" }
       },
       "additionalProperties": false,
-      "required": ["filename", "type", "data", "filters"]
+      "required": ["originalFilename", "path", "type", "data", "filters"]
     },
 
     "survey_response": {
       "properties": {
-        "filename": { "$ref": "FileName.schema.json" },
+        "path": { "$ref": "FileName.schema.json" },
+        "originalFilename" : { "$ref": "FilePath.schema.json" },
         "type": {
           "type": "string",
           "enum": [ "survey" ]
@@ -94,7 +100,7 @@
         "filters": { "$ref": "SurveyFilters.schema.json" }
       },
       "additionalProperties": false,
-      "required": ["filename", "type", "data", "filters"]
+      "required": ["originalFilename", "path", "type", "data", "filters"]
     }
   },
 

--- a/inst/schema/ValidateSurveyAndProgrammeRequest.schema.json
+++ b/inst/schema/ValidateSurveyAndProgrammeRequest.schema.json
@@ -3,17 +3,13 @@
   "type": "object",
   "properties": {
     "type" : { "$ref": "InputType.schema.json" },
-    "path" : { "$ref": "FilePath.schema.json" },
-    "shape": { "$ref": "FilePath.schema.json" },
-    "hash" : { "type": "string" },
-    "filename" : { "$ref": "FilePath.schema.json" }
+    "file" : { "$ref": "SessionFile.schema.json" },
+    "shape": { "$ref": "FilePath.schema.json" }
   },
   "additionalProperties": false,
   "required": [
     "type",
-    "path",
-    "shape",
-    "hash",
-    "filename"
+    "file",
+    "shape"
   ]
 }

--- a/inst/schema/ValidateSurveyAndProgrammeRequest.schema.json
+++ b/inst/schema/ValidateSurveyAndProgrammeRequest.schema.json
@@ -5,13 +5,15 @@
     "type" : { "$ref": "InputType.schema.json" },
     "path" : { "$ref": "FilePath.schema.json" },
     "shape": { "$ref": "FilePath.schema.json" },
-    "originalFilename" : { "$ref": "FilePath.schema.json" }
+    "hash" : { "type": "string" },
+    "filename" : { "$ref": "FilePath.schema.json" }
   },
   "additionalProperties": false,
   "required": [
     "type",
     "path",
     "shape",
-    "originalFilename"
+    "hash",
+    "filename"
   ]
 }

--- a/inst/schema/ValidateSurveyAndProgrammeRequest.schema.json
+++ b/inst/schema/ValidateSurveyAndProgrammeRequest.schema.json
@@ -4,12 +4,14 @@
   "properties": {
     "type" : { "$ref": "InputType.schema.json" },
     "path" : { "$ref": "FilePath.schema.json" },
-    "shape": { "$ref": "FilePath.schema.json" }
+    "shape": { "$ref": "FilePath.schema.json" },
+    "originalFilename" : { "$ref": "FilePath.schema.json" }
   },
   "additionalProperties": false,
   "required": [
     "type",
     "path",
-    "shape"
+    "shape",
+    "originalFilename"
   ]
 }

--- a/man/endpoint_validate_baseline.Rd
+++ b/man/endpoint_validate_baseline.Rd
@@ -5,7 +5,7 @@
 \title{Validate an baseline input file and return an indication of success and
 if successful return the data required by UI.}
 \usage{
-endpoint_validate_baseline(req, res, type, path, hash, filename)
+endpoint_validate_baseline(req, res, type, file)
 }
 \arguments{
 \item{req}{The request as PlumberRequest object.}
@@ -15,11 +15,7 @@ endpoint_validate_baseline(req, res, type, path, hash, filename)
 \item{type}{The type of file to validate: pjnz, shape, population, ANC,
 survey or programme.}
 
-\item{path}{Path to the file to validate.}
-
-\item{hash}{md5 hash of the file to validate.}
-
-\item{filename}{Original file name to be returned in the serialised data.}
+\item{file}{File object containing path, filename and md5 hash.}
 }
 \value{
 Validated JSON response with data and incidcation of success.

--- a/man/endpoint_validate_baseline.Rd
+++ b/man/endpoint_validate_baseline.Rd
@@ -5,7 +5,7 @@
 \title{Validate an baseline input file and return an indication of success and
 if successful return the data required by UI.}
 \usage{
-endpoint_validate_baseline(req, res, type, path)
+endpoint_validate_baseline(req, res, type, path, hash, filename)
 }
 \arguments{
 \item{req}{The request as PlumberRequest object.}
@@ -16,6 +16,10 @@ endpoint_validate_baseline(req, res, type, path)
 survey or programme.}
 
 \item{path}{Path to the file to validate.}
+
+\item{hash}{md5 hash of the file to validate.}
+
+\item{filename}{Original file name to be returned in the serialised data.}
 }
 \value{
 Validated JSON response with data and incidcation of success.

--- a/man/endpoint_validate_survey_programme.Rd
+++ b/man/endpoint_validate_survey_programme.Rd
@@ -6,8 +6,7 @@
 returning an indication of success and if successful return the data
 required by UI.}
 \usage{
-endpoint_validate_survey_programme(req, res, type, path, shape, hash,
-  filename)
+endpoint_validate_survey_programme(req, res, type, file, shape)
 }
 \arguments{
 \item{req}{The request as PlumberRequest object.}
@@ -16,13 +15,11 @@ endpoint_validate_survey_programme(req, res, type, path, shape, hash,
 
 \item{type}{The type of file to validate: ANC, survey or programme.}
 
-\item{path}{Path to the file to validate.}
+\item{file}{File object containing path, filename and md5 hash.}
 
 \item{shape}{Path to shape file for comparison.}
 
-\item{hash}{md5 hash of the file to validate.}
-
-\item{filename}{Original file name to be returned in the serialised data.}
+\item{path}{Path to the file to validate.}
 }
 \value{
 Validated JSON response with data and incidcation of success.

--- a/man/endpoint_validate_survey_programme.Rd
+++ b/man/endpoint_validate_survey_programme.Rd
@@ -6,7 +6,8 @@
 returning an indication of success and if successful return the data
 required by UI.}
 \usage{
-endpoint_validate_survey_programme(req, res, type, path, shape)
+endpoint_validate_survey_programme(req, res, type, path, shape, hash,
+  filename)
 }
 \arguments{
 \item{req}{The request as PlumberRequest object.}
@@ -18,6 +19,10 @@ endpoint_validate_survey_programme(req, res, type, path, shape)
 \item{path}{Path to the file to validate.}
 
 \item{shape}{Path to shape file for comparison.}
+
+\item{hash}{md5 hash of the file to validate.}
+
+\item{filename}{Original file name to be returned in the serialised data.}
 }
 \value{
 Validated JSON response with data and incidcation of success.

--- a/tests/testthat/payload/validate_anc_payload.json
+++ b/tests/testthat/payload/validate_anc_payload.json
@@ -1,5 +1,6 @@
 {
   "type": "anc",
   "path": "testdata/anc.csv",
-  "shape": "testdata/malawi.geojson"
+  "shape": "testdata/malawi.geojson",
+  "originalFilename": "original.geojson"
 }

--- a/tests/testthat/payload/validate_anc_payload.json
+++ b/tests/testthat/payload/validate_anc_payload.json
@@ -1,7 +1,9 @@
 {
   "type": "anc",
-  "path": "testdata/anc.csv",
-  "shape": "testdata/malawi.geojson",
-  "hash": "12345",
-  "filename": "original.csv"
+  "file": {
+    "path": "testdata/anc.csv",
+    "hash": "12345",
+    "filename": "original.csv"
+  },
+  "shape": "testdata/malawi.geojson"
 }

--- a/tests/testthat/payload/validate_anc_payload.json
+++ b/tests/testthat/payload/validate_anc_payload.json
@@ -2,5 +2,5 @@
   "type": "anc",
   "path": "testdata/anc.csv",
   "shape": "testdata/malawi.geojson",
-  "originalFilename": "original.geojson"
+  "originalFilename": "original.csv"
 }

--- a/tests/testthat/payload/validate_anc_payload.json
+++ b/tests/testthat/payload/validate_anc_payload.json
@@ -2,5 +2,6 @@
   "type": "anc",
   "path": "testdata/anc.csv",
   "shape": "testdata/malawi.geojson",
-  "originalFilename": "original.csv"
+  "hash": "12345",
+  "filename": "original.csv"
 }

--- a/tests/testthat/payload/validate_pjnz_payload.json
+++ b/tests/testthat/payload/validate_pjnz_payload.json
@@ -1,4 +1,5 @@
 {
 	"type": "pjnz",
-	"path": "testdata/Botswana2018.PJNZ"
+	"path": "testdata/Botswana2018.PJNZ",
+	"originalFilename": "original.PJNZ"
 }

--- a/tests/testthat/payload/validate_pjnz_payload.json
+++ b/tests/testthat/payload/validate_pjnz_payload.json
@@ -1,5 +1,6 @@
 {
 	"type": "pjnz",
 	"path": "testdata/Botswana2018.PJNZ",
-	"originalFilename": "original.PJNZ"
+	"filename": "original.PJNZ",
+	"hash": "12345"
 }

--- a/tests/testthat/payload/validate_pjnz_payload.json
+++ b/tests/testthat/payload/validate_pjnz_payload.json
@@ -1,6 +1,8 @@
 {
-	"type": "pjnz",
-	"path": "testdata/Botswana2018.PJNZ",
-	"filename": "original.PJNZ",
-	"hash": "12345"
+  "type": "pjnz",
+  "file": {
+    "path": "testdata/Botswana2018.PJNZ",
+    "filename": "original.PJNZ",
+    "hash": "12345"
+  }
 }

--- a/tests/testthat/payload/validate_population_payload.json
+++ b/tests/testthat/payload/validate_population_payload.json
@@ -1,5 +1,6 @@
 {
   "type": "population",
   "path": "testdata/population.csv",
-  "originalFilename": "original.csv"
+  "filename": "original.csv",
+  "hash": "12345"
 }

--- a/tests/testthat/payload/validate_population_payload.json
+++ b/tests/testthat/payload/validate_population_payload.json
@@ -1,4 +1,5 @@
 {
   "type": "population",
-  "path": "testdata/population.csv"
+  "path": "testdata/population.csv",
+  "originalFilename": "original.csv"
 }

--- a/tests/testthat/payload/validate_population_payload.json
+++ b/tests/testthat/payload/validate_population_payload.json
@@ -1,6 +1,8 @@
 {
   "type": "population",
-  "path": "testdata/population.csv",
-  "filename": "original.csv",
-  "hash": "12345"
+  "file": {
+    "path": "testdata/population.csv",
+    "filename": "original.csv",
+    "hash": "12345"
+  }
 }

--- a/tests/testthat/payload/validate_programme_payload.json
+++ b/tests/testthat/payload/validate_programme_payload.json
@@ -1,5 +1,6 @@
 {
   "type": "programme",
   "path": "testdata/programme.csv",
-  "shape": "testdata/malawi.geojson"
+  "shape": "testdata/malawi.geojson",
+  "originalFilename": "original.csv"
 }

--- a/tests/testthat/payload/validate_programme_payload.json
+++ b/tests/testthat/payload/validate_programme_payload.json
@@ -1,7 +1,9 @@
 {
   "type": "programme",
-  "path": "testdata/programme.csv",
-  "shape": "testdata/malawi.geojson",
-  "filename": "original.csv",
-  "hash": "12345"
+  "file": {
+    "path": "testdata/programme.csv",
+    "filename": "original.csv",
+    "hash": "12345"
+  },
+  "shape": "testdata/malawi.geojson"
 }

--- a/tests/testthat/payload/validate_programme_payload.json
+++ b/tests/testthat/payload/validate_programme_payload.json
@@ -2,5 +2,6 @@
   "type": "programme",
   "path": "testdata/programme.csv",
   "shape": "testdata/malawi.geojson",
-  "originalFilename": "original.csv"
+  "filename": "original.csv",
+  "hash": "12345"
 }

--- a/tests/testthat/payload/validate_shape_payload.json
+++ b/tests/testthat/payload/validate_shape_payload.json
@@ -1,5 +1,6 @@
 {
   "type": "shape",
   "path": "testdata/malawi.geojson",
-  "originalFilename": "original.geojson"
+  "filename": "original.geojson",
+  "hash": "12345"
 }

--- a/tests/testthat/payload/validate_shape_payload.json
+++ b/tests/testthat/payload/validate_shape_payload.json
@@ -1,6 +1,8 @@
 {
   "type": "shape",
-  "path": "testdata/malawi.geojson",
-  "filename": "original.geojson",
-  "hash": "12345"
+  "file": {
+    "path": "testdata/malawi.geojson",
+    "filename": "original.geojson",
+    "hash": "12345"
+  }
 }

--- a/tests/testthat/payload/validate_shape_payload.json
+++ b/tests/testthat/payload/validate_shape_payload.json
@@ -1,5 +1,5 @@
 {
   "type": "shape",
   "path": "testdata/malawi.geojson",
-  "originalFilename": "original.csv"
+  "originalFilename": "original.geojson"
 }

--- a/tests/testthat/payload/validate_shape_payload.json
+++ b/tests/testthat/payload/validate_shape_payload.json
@@ -1,4 +1,5 @@
 {
   "type": "shape",
-  "path": "testdata/malawi.geojson"
+  "path": "testdata/malawi.geojson",
+  "originalFilename": "original.csv"
 }

--- a/tests/testthat/payload/validate_survey_payload.json
+++ b/tests/testthat/payload/validate_survey_payload.json
@@ -1,5 +1,6 @@
 {
   "type": "survey",
   "path": "testdata/survey.csv",
-  "shape": "testdata/malawi.geojson"
+  "shape": "testdata/malawi.geojson",
+  "originalFilename": "original.csv"
 }

--- a/tests/testthat/payload/validate_survey_payload.json
+++ b/tests/testthat/payload/validate_survey_payload.json
@@ -2,5 +2,6 @@
   "type": "survey",
   "path": "testdata/survey.csv",
   "shape": "testdata/malawi.geojson",
-  "originalFilename": "original.csv"
+  "filename": "original.csv",
+  "hash": "12345"
 }

--- a/tests/testthat/payload/validate_survey_payload.json
+++ b/tests/testthat/payload/validate_survey_payload.json
@@ -1,7 +1,9 @@
 {
   "type": "survey",
-  "path": "testdata/survey.csv",
-  "shape": "testdata/malawi.geojson",
-  "filename": "original.csv",
-  "hash": "12345"
+  "file": {
+    "path": "testdata/survey.csv",
+    "filename": "original.csv",
+    "hash": "12345"
+  },
+  "shape": "testdata/malawi.geojson"
 }

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -2,9 +2,10 @@ context("endpoints-validate")
 
 test_that("endpoint_validate_baseline correctly validates data", {
   pjnz <- file.path("testdata", "Botswana2018.PJNZ")
-  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","hash": "12345","filename":"original"}')
+  req <- list(postBody = '{"type": "pjnz", "file": {"path": "path/to/file", "hash": "12345", "filename": "original"}}')
   res <- MockPlumberResponse$new()
-  response <- endpoint_validate_baseline(req, res, "pjnz", pjnz, "12345", "original")
+  file <- list(path = pjnz, hash = "12345", filename = "original")
+  response <- endpoint_validate_baseline(req, res, "pjnz", file)
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "success")
   expect_equal(response$data$hash, "12345")
@@ -15,11 +16,12 @@ test_that("endpoint_validate_baseline correctly validates data", {
 
 test_that("endpoint_validate_baseline returns error on invalid data", {
   pjnz <- file.path("testdata", "Botswana2018.PJNZ")
-  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","hash": "12345","filename":"original"}')
+  req <- list(postBody = '{"type": "pjnz", "file": {"path": "path/to/file", "hash": "12345", "filename": "original"}}')
+  file <- list(path = pjnz, hash = "12345", filename = "original")
   mock_read_country <- mockery::mock("GBR")
   with_mock("hintr:::read_country" = mock_read_country, {
     res <- MockPlumberResponse$new()
-    response <- endpoint_validate_baseline(req, res, "pjnz", pjnz, "12345", "original")
+    response <- endpoint_validate_baseline(req, res, "pjnz", file)
     response <- jsonlite::parse_json(response)
     expect_equal(response$status, "failure")
     expect_length(response$errors, 1)
@@ -30,9 +32,10 @@ test_that("endpoint_validate_baseline returns error on invalid data", {
 })
 
 test_that("endpoint_validate_baseline returns nice error if file does not exist", {
-  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","hash": "12345","filename":"original"}')
+  req <- list(postBody = '{"type": "pjnz", "file": {"path": "path/to/file", "hash": "12345", "filename": "original"}}')
   res <- MockPlumberResponse$new()
-  response <- endpoint_validate_baseline(req, res, "pjnz", "path/to/file", "12345", "filename")
+  file <- list(path = "path/to/file", hash = "12345", filename = "original")
+  response <- endpoint_validate_baseline(req, res, "pjnz", file)
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "failure")
   expect_length(response$errors, 1)
@@ -46,9 +49,10 @@ test_that("endpoint_validate_baseline returns nice error if file does not exist"
 test_that("endpoint_validate_baseline validates the input and response", {
   pjnz <- file.path("testdata", "Botswana2018.PJNZ")
   mock_validate_json_schema <- mockery::mock(TRUE, cycle = TRUE)
+  file <- list(path = pjnz, hash = "12345", filename = "original")
   with_mock("hintr:::validate_json_schema" = mock_validate_json_schema, {
     ret <- endpoint_validate_baseline(list(postBody = "request"),
-                                   MockPlumberResponse$new(), "pjnz", pjnz, "12345", "original")
+                                   MockPlumberResponse$new(), "pjnz", file)
   })
 
   mockery::expect_called(mock_validate_json_schema, 4)
@@ -63,13 +67,12 @@ test_that("endpoint_validate_baseline validates the input and response", {
 test_that("endpoint_validate_baseline support shape file", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
+  file <- list(path = shape, hash = "12345", filename = "original")
   response <- endpoint_validate_baseline(
-    list(postBody = '{"type":"shape","path":"path/to/file","hash": "12345","filename":"original"}'),
+    list(postBody = '{"type":"shape", "file": {"path": "path/to/file", "hash": "12345", "filename": "original"}}'),
     res,
     "shape",
-    shape,
-    "12345",
-    "original")
+    file)
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
@@ -84,13 +87,12 @@ test_that("endpoint_validate_baseline support shape file", {
 test_that("endpoint_validate_baseline supports population file", {
   population <- file.path("testdata", "population.csv")
   res <- MockPlumberResponse$new()
+  file <- list(path = population, hash = "12345", filename = "original")
   response <- endpoint_validate_baseline(
-    list(postBody = '{"type":"population","path":"path/to/file","hash": "12345","filename":"original"}'),
+    list(postBody = '{"type":"population","file": {"path": "path/to/file", "hash": "12345", "filename": "original"}}'),
     res,
     "population",
-    population,
-    "12345",
-    "original")
+    file)
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -2,19 +2,20 @@ context("endpoints-validate")
 
 test_that("endpoint_validate_baseline correctly validates data", {
   pjnz <- file.path("testdata", "Botswana2018.PJNZ")
-  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file"}')
+  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","originalFilename":"original"}')
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_baseline(req, res, "pjnz", pjnz)
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "success")
-  expect_equal(response$data$filename, "Botswana2018.PJNZ")
+  expect_equal(response$data$path, "path/to/file")
   expect_equal(response$data$data$country, "Botswana")
+  expect_equal(response$data$data$originalFilename, "original")
   expect_equal(res$status, 200)
 })
 
 test_that("endpoint_validate_baseline returns error on invalid data", {
   pjnz <- file.path("testdata", "Botswana2018.PJNZ")
-  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file"}')
+  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","originalFilename":"original"}')
   mock_read_country <- mockery::mock("GBR")
   with_mock("hintr:::read_country" = mock_read_country, {
     res <- MockPlumberResponse$new()
@@ -29,7 +30,7 @@ test_that("endpoint_validate_baseline returns error on invalid data", {
 })
 
 test_that("endpoint_validate_baseline returns nice error if file does not exist", {
-  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file"}')
+  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","originalFilename":"original"}')
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_baseline(req, res, "pjnz", "path/to/file")
   response <- jsonlite::parse_json(response)
@@ -63,14 +64,15 @@ test_that("endpoint_validate_baseline support shape file", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_baseline(
-    list(postBody = '{"type":"shape","path":"path/to/file"}'),
+    list(postBody = '{"type":"shape","path":"path/to/file","originalFilename":"original"}'),
     res,
     "shape",
     shape)
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
-  expect_equal(response$data$filename, "malawi.geojson")
+  expect_equal(response$data$originalFilename, "original")
+  expect_equal(response$data$path, "path/to/file")
   expect_true(all(c("type", "features") %in% names(response$data$data)))
   expect_equal(length(response$data$data$features), 69)
   expect_equal(res$status, 200)
@@ -81,14 +83,15 @@ test_that("endpoint_validate_baseline supports population file", {
   population <- file.path("testdata", "population.csv")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_baseline(
-    list(postBody = '{"type":"population","path":"path/to/file"}'),
+    list(postBody = '{"type":"population","path":"path/to/file","originalFilename":"original"}'),
     res,
     "population",
     population)
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
-  expect_equal(response$data$filename, "population.csv")
+  expect_equal(response$data$originalFilename, "original")
+  expect_equal(response$data$path, "path/to/file")
   expect_length(response$data$data, 0)
   expect_equal(res$status, 200)
 })

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -4,7 +4,7 @@ test_that("endpoint_validate_baseline correctly validates data", {
   pjnz <- file.path("testdata", "Botswana2018.PJNZ")
   req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","originalFilename":"original"}')
   res <- MockPlumberResponse$new()
-  response <- endpoint_validate_baseline(req, res, "pjnz", pjnz)
+  response <- endpoint_validate_baseline(req, res, "pjnz", pjnz, "original")
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "success")
   expect_equal(response$data$hash, "file")
@@ -19,7 +19,7 @@ test_that("endpoint_validate_baseline returns error on invalid data", {
   mock_read_country <- mockery::mock("GBR")
   with_mock("hintr:::read_country" = mock_read_country, {
     res <- MockPlumberResponse$new()
-    response <- endpoint_validate_baseline(req, res, "pjnz", pjnz)
+    response <- endpoint_validate_baseline(req, res, "pjnz", pjnz, "original")
     response <- jsonlite::parse_json(response)
     expect_equal(response$status, "failure")
     expect_length(response$errors, 1)
@@ -67,7 +67,8 @@ test_that("endpoint_validate_baseline support shape file", {
     list(postBody = '{"type":"shape","path":"path/to/file","originalFilename":"original"}'),
     res,
     "shape",
-    shape)
+    shape,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
@@ -86,7 +87,8 @@ test_that("endpoint_validate_baseline supports population file", {
     list(postBody = '{"type":"population","path":"path/to/file","originalFilename":"original"}'),
     res,
     "population",
-    population)
+    population,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -7,9 +7,9 @@ test_that("endpoint_validate_baseline correctly validates data", {
   response <- endpoint_validate_baseline(req, res, "pjnz", pjnz, "original")
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "success")
-  expect_equal(response$data$hash, "file")
+  expect_equal(response$data$hash, "Botswana2018.PJNZ")
   expect_equal(response$data$data$country, "Botswana")
-  expect_equal(response$data$data$originalFilename, "original")
+  expect_equal(response$data$originalFilename, "original")
   expect_equal(res$status, 200)
 })
 
@@ -48,7 +48,7 @@ test_that("endpoint_validate_baseline validates the input and response", {
   mock_validate_json_schema <- mockery::mock(TRUE, cycle = TRUE)
   with_mock("hintr:::validate_json_schema" = mock_validate_json_schema, {
     ret <- endpoint_validate_baseline(list(postBody = "request"),
-                                   MockPlumberResponse$new(), "pjnz", pjnz)
+                                   MockPlumberResponse$new(), "pjnz", pjnz, "original")
   })
 
   mockery::expect_called(mock_validate_json_schema, 4)
@@ -73,7 +73,7 @@ test_that("endpoint_validate_baseline support shape file", {
 
   expect_equal(response$status, "success")
   expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$hash, "file")
+  expect_equal(response$data$hash, "malawi.geojson")
   expect_true(all(c("type", "features") %in% names(response$data$data)))
   expect_equal(length(response$data$data$features), 69)
   expect_equal(res$status, 200)
@@ -93,7 +93,7 @@ test_that("endpoint_validate_baseline supports population file", {
 
   expect_equal(response$status, "success")
   expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$hash, "file")
+  expect_equal(response$data$hash, "population.csv")
   expect_length(response$data$data, 0)
   expect_equal(res$status, 200)
 })

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -7,7 +7,7 @@ test_that("endpoint_validate_baseline correctly validates data", {
   response <- endpoint_validate_baseline(req, res, "pjnz", pjnz)
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "success")
-  expect_equal(response$data$path, "path/to/file")
+  expect_equal(response$data$hash, "file")
   expect_equal(response$data$data$country, "Botswana")
   expect_equal(response$data$data$originalFilename, "original")
   expect_equal(res$status, 200)
@@ -72,7 +72,7 @@ test_that("endpoint_validate_baseline support shape file", {
 
   expect_equal(response$status, "success")
   expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$path, "path/to/file")
+  expect_equal(response$data$hash, "file")
   expect_true(all(c("type", "features") %in% names(response$data$data)))
   expect_equal(length(response$data$data$features), 69)
   expect_equal(res$status, 200)
@@ -91,7 +91,7 @@ test_that("endpoint_validate_baseline supports population file", {
 
   expect_equal(response$status, "success")
   expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$path, "path/to/file")
+  expect_equal(response$data$hash, "file")
   expect_length(response$data$data, 0)
   expect_equal(res$status, 200)
 })

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -2,24 +2,24 @@ context("endpoints-validate")
 
 test_that("endpoint_validate_baseline correctly validates data", {
   pjnz <- file.path("testdata", "Botswana2018.PJNZ")
-  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","originalFilename":"original"}')
+  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","hash": "12345","filename":"original"}')
   res <- MockPlumberResponse$new()
-  response <- endpoint_validate_baseline(req, res, "pjnz", pjnz, "original")
+  response <- endpoint_validate_baseline(req, res, "pjnz", pjnz, "12345", "original")
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "success")
-  expect_equal(response$data$hash, "Botswana2018.PJNZ")
+  expect_equal(response$data$hash, "12345")
   expect_equal(response$data$data$country, "Botswana")
-  expect_equal(response$data$originalFilename, "original")
+  expect_equal(response$data$filename, "original")
   expect_equal(res$status, 200)
 })
 
 test_that("endpoint_validate_baseline returns error on invalid data", {
   pjnz <- file.path("testdata", "Botswana2018.PJNZ")
-  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","originalFilename":"original"}')
+  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","hash": "12345","filename":"original"}')
   mock_read_country <- mockery::mock("GBR")
   with_mock("hintr:::read_country" = mock_read_country, {
     res <- MockPlumberResponse$new()
-    response <- endpoint_validate_baseline(req, res, "pjnz", pjnz, "original")
+    response <- endpoint_validate_baseline(req, res, "pjnz", pjnz, "12345", "original")
     response <- jsonlite::parse_json(response)
     expect_equal(response$status, "failure")
     expect_length(response$errors, 1)
@@ -30,9 +30,9 @@ test_that("endpoint_validate_baseline returns error on invalid data", {
 })
 
 test_that("endpoint_validate_baseline returns nice error if file does not exist", {
-  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","originalFilename":"original"}')
+  req <- list(postBody = '{"type": "pjnz", "path": "path/to/file","hash": "12345","filename":"original"}')
   res <- MockPlumberResponse$new()
-  response <- endpoint_validate_baseline(req, res, "pjnz", "path/to/file")
+  response <- endpoint_validate_baseline(req, res, "pjnz", "path/to/file", "12345", "filename")
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "failure")
   expect_length(response$errors, 1)
@@ -48,7 +48,7 @@ test_that("endpoint_validate_baseline validates the input and response", {
   mock_validate_json_schema <- mockery::mock(TRUE, cycle = TRUE)
   with_mock("hintr:::validate_json_schema" = mock_validate_json_schema, {
     ret <- endpoint_validate_baseline(list(postBody = "request"),
-                                   MockPlumberResponse$new(), "pjnz", pjnz, "original")
+                                   MockPlumberResponse$new(), "pjnz", pjnz, "12345", "original")
   })
 
   mockery::expect_called(mock_validate_json_schema, 4)
@@ -64,16 +64,17 @@ test_that("endpoint_validate_baseline support shape file", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_baseline(
-    list(postBody = '{"type":"shape","path":"path/to/file","originalFilename":"original"}'),
+    list(postBody = '{"type":"shape","path":"path/to/file","hash": "12345","filename":"original"}'),
     res,
     "shape",
     shape,
+    "12345",
     "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
-  expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$hash, "malawi.geojson")
+  expect_equal(response$data$filename, "original")
+  expect_equal(response$data$hash, "12345")
   expect_true(all(c("type", "features") %in% names(response$data$data)))
   expect_equal(length(response$data$data$features), 69)
   expect_equal(res$status, 200)
@@ -84,16 +85,17 @@ test_that("endpoint_validate_baseline supports population file", {
   population <- file.path("testdata", "population.csv")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_baseline(
-    list(postBody = '{"type":"population","path":"path/to/file","originalFilename":"original"}'),
+    list(postBody = '{"type":"population","path":"path/to/file","hash": "12345","filename":"original"}'),
     res,
     "population",
     population,
+    "12345",
     "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
-  expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$hash, "population.csv")
+  expect_equal(response$data$filename, "original")
+  expect_equal(response$data$hash, "12345")
   expect_length(response$data$data, 0)
   expect_equal(res$status, 200)
 })

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -15,7 +15,7 @@ test_that("endpoint_validate_survey_programme supports programme file", {
 
   expect_equal(response$status, "success")
   expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$hash, "file")
+  expect_equal(response$data$hash, "programme.csv")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 1400)
@@ -58,7 +58,7 @@ test_that("endpoint_validate_survey_programme supports ANC file", {
 
   expect_equal(response$status, "success")
   expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$hash, "file")
+  expect_equal(response$data$hash, "anc.csv")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 800)
@@ -105,7 +105,7 @@ test_that("endpoint_validate_survey_programme supports survey file", {
 
   expect_equal(response$status, "success")
   expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$hash, "file")
+  expect_equal(response$data$hash, "survey.csv")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 20000)

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -3,15 +3,14 @@ context("survey-and-programme")
 test_that("endpoint_validate_survey_programme supports programme file", {
   programme <- file.path("testdata", "programme.csv")
   shape <- file.path("testdata", "malawi.geojson")
+  file <- list(path = programme, hash = "12345", filename = "original")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
+    list(postBody = '{"type":"programme", "file": {"path":"path/to/file","hash": "12345","filename":"original"}, "shape":"path"}'),
     res,
     "programme",
-    programme,
-    shape,
-    "12345",
-    "original")
+    file,
+    shape)
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
@@ -26,15 +25,14 @@ test_that("endpoint_validate_survey_programme supports programme file", {
 test_that("endpoint_validate_survey_programme returns error on invalid programme data", {
   programme <- file.path("testdata", "malformed_programme.csv")
   shape <- file.path("testdata", "malawi.geojson")
+  file <- list(path = programme, hash = "12345", filename = "original")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
+    list(postBody = '{"type":"programme", "file": {"path":"path/to/file","hash": "12345","filename":"original"}, "shape":"path"}'),
     res,
     "programme",
-    programme,
-    shape,
-    "12345",
-    "original")
+    file,
+    shape)
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "failure")
@@ -48,15 +46,14 @@ test_that("endpoint_validate_survey_programme returns error on invalid programme
 test_that("endpoint_validate_survey_programme supports ANC file", {
   anc <- file.path("testdata", "anc.csv")
   shape <- file.path("testdata", "malawi.geojson")
+  file <- list(path = anc, hash = "12345", filename = "original")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
+    list(postBody = '{"type":"anc", "file": {"path":"path/to/file","hash": "12345","filename":"original"}, "shape":"path"}'),
     res,
     "anc",
-    anc,
-    shape,
-    "12345",
-    "original")
+    file,
+    shape)
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
@@ -74,14 +71,14 @@ test_that("endpoint_validate_survey_programme supports ANC file", {
 test_that("endpoint_validate_survey_programme returns error on invalid ANC data", {
   anc <- file.path("testdata", "malformed_anc.csv")
   shape <- file.path("testdata", "malawi.geojson")
+  file <- list(path = anc, hash = "12345", filename = "original")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
+    list(postBody = '{"type":"anc", "file": {"path":"path/to/file","hash": "12345","filename":"original"}, "shape":"path"}'),
     res,
     "anc",
-    anc,
-    shape,
-    "original")
+    file,
+    shape)
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "failure")
@@ -96,15 +93,14 @@ test_that("endpoint_validate_survey_programme returns error on invalid ANC data"
 test_that("endpoint_validate_survey_programme supports survey file", {
   survey <- file.path("testdata", "survey.csv")
   shape <- file.path("testdata", "malawi.geojson")
+  file <- list(path = survey, hash = "12345", filename = "original")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
+    list(postBody = '{"type":"survey", "file": {"path":"path/to/file","hash": "12345","filename":"original"}, "shape":"path"}'),
     res,
     "survey",
-    survey,
-    shape,
-    "12345",
-    "original")
+    file,
+    shape)
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
@@ -119,15 +115,14 @@ test_that("endpoint_validate_survey_programme supports survey file", {
 test_that("endpoint_validate_survey_programme returns error on invalid survey data", {
   survey <- file.path("testdata", "malformed_survey.csv")
   shape <- file.path("testdata", "malawi.geojson")
+  file <- list(path = survey, hash = "12345", filename = "original")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
+    list(postBody = '{"type":"survey", "file": {"path":"path/to/file","hash": "12345","filename":"original"}, "shape":"path"}'),
     res,
     "survey",
-    survey,
-    shape,
-    "12345",
-    "original")
+    file,
+    shape)
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "failure")

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -5,7 +5,7 @@ test_that("endpoint_validate_survey_programme supports programme file", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path"}'),
+    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","originalFilename":"original"}'),
     res,
     "programme",
     programme,
@@ -13,7 +13,8 @@ test_that("endpoint_validate_survey_programme supports programme file", {
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
-  expect_equal(response$data$filename, "programme.csv")
+  expect_equal(response$data$originalFilename, "original")
+  expect_equal(response$data$path, "path/to/file")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 1400)
@@ -25,7 +26,7 @@ test_that("endpoint_validate_survey_programme returns error on invalid programme
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path"}'),
+    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","originalFilename":"original"}'),
     res,
     "programme",
     programme,
@@ -45,7 +46,7 @@ test_that("endpoint_validate_survey_programme supports ANC file", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path"}'),
+    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","originalFilename":"original"}'),
     res,
     "anc",
     anc,
@@ -53,7 +54,8 @@ test_that("endpoint_validate_survey_programme supports ANC file", {
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
-  expect_equal(response$data$filename, "anc.csv")
+  expect_equal(response$data$originalFilename, "original")
+  expect_equal(response$data$path, "path/to/file")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 800)
@@ -68,7 +70,7 @@ test_that("endpoint_validate_survey_programme returns error on invalid ANC data"
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path"}'),
+    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","originalFilename":"original"}'),
     res,
     "anc",
     anc,
@@ -89,7 +91,7 @@ test_that("endpoint_validate_survey_programme supports survey file", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path"}'),
+    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","originalFilename":"original"}'),
     res,
     "survey",
     survey,
@@ -97,7 +99,8 @@ test_that("endpoint_validate_survey_programme supports survey file", {
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
-  expect_equal(response$data$filename, "survey.csv")
+  expect_equal(response$data$originalFilename, "original")
+  expect_equal(response$data$path, "path/to/file")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 20000)
@@ -109,7 +112,7 @@ test_that("endpoint_validate_survey_programme returns error on invalid survey da
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path"}'),
+    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","originalFilename":"original"}'),
     res,
     "survey",
     survey,

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -5,17 +5,18 @@ test_that("endpoint_validate_survey_programme supports programme file", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","originalFilename":"original"}'),
+    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
     res,
     "programme",
     programme,
     shape,
+    "12345",
     "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
-  expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$hash, "programme.csv")
+  expect_equal(response$data$filename, "original")
+  expect_equal(response$data$hash, "12345")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 1400)
@@ -27,11 +28,12 @@ test_that("endpoint_validate_survey_programme returns error on invalid programme
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","originalFilename":"original"}'),
+    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
     res,
     "programme",
     programme,
     shape,
+    "12345",
     "original")
   response <- jsonlite::parse_json(response)
 
@@ -48,17 +50,18 @@ test_that("endpoint_validate_survey_programme supports ANC file", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","originalFilename":"original"}'),
+    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
     res,
     "anc",
     anc,
     shape,
+    "12345",
     "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
-  expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$hash, "anc.csv")
+  expect_equal(response$data$filename, "original")
+  expect_equal(response$data$hash, "12345")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 800)
@@ -73,7 +76,7 @@ test_that("endpoint_validate_survey_programme returns error on invalid ANC data"
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","originalFilename":"original"}'),
+    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
     res,
     "anc",
     anc,
@@ -95,17 +98,18 @@ test_that("endpoint_validate_survey_programme supports survey file", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","originalFilename":"original"}'),
+    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
     res,
     "survey",
     survey,
     shape,
+    "12345",
     "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
-  expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$hash, "survey.csv")
+  expect_equal(response$data$filename, "original")
+  expect_equal(response$data$hash, "12345")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 20000)
@@ -117,11 +121,12 @@ test_that("endpoint_validate_survey_programme returns error on invalid survey da
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","originalFilename":"original"}'),
+    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","hash": "12345","filename":"original"}'),
     res,
     "survey",
     survey,
     shape,
+    "12345",
     "original")
   response <- jsonlite::parse_json(response)
 

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -9,7 +9,8 @@ test_that("endpoint_validate_survey_programme supports programme file", {
     res,
     "programme",
     programme,
-    shape)
+    shape,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
@@ -30,7 +31,8 @@ test_that("endpoint_validate_survey_programme returns error on invalid programme
     res,
     "programme",
     programme,
-    shape)
+    shape,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "failure")
@@ -50,7 +52,8 @@ test_that("endpoint_validate_survey_programme supports ANC file", {
     res,
     "anc",
     anc,
-    shape)
+    shape,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
@@ -74,7 +77,8 @@ test_that("endpoint_validate_survey_programme returns error on invalid ANC data"
     res,
     "anc",
     anc,
-    shape)
+    shape,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "failure")
@@ -95,7 +99,8 @@ test_that("endpoint_validate_survey_programme supports survey file", {
     res,
     "survey",
     survey,
-    shape)
+    shape,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "success")
@@ -116,7 +121,8 @@ test_that("endpoint_validate_survey_programme returns error on invalid survey da
     res,
     "survey",
     survey,
-    shape)
+    shape,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(response$status, "failure")

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -14,7 +14,7 @@ test_that("endpoint_validate_survey_programme supports programme file", {
 
   expect_equal(response$status, "success")
   expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$path, "path/to/file")
+  expect_equal(response$data$hash, "file")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 1400)
@@ -55,7 +55,7 @@ test_that("endpoint_validate_survey_programme supports ANC file", {
 
   expect_equal(response$status, "success")
   expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$path, "path/to/file")
+  expect_equal(response$data$hash, "file")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 800)
@@ -100,7 +100,7 @@ test_that("endpoint_validate_survey_programme supports survey file", {
 
   expect_equal(response$status, "success")
   expect_equal(response$data$originalFilename, "original")
-  expect_equal(response$data$path, "path/to/file")
+  expect_equal(response$data$hash, "file")
   expect_equal(res$status, 200)
   ## Sanity check that data has been returned
   expect_true(length(response$data$data) >= 20000)

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -219,15 +219,14 @@ test_that("possible filters are returned for data", {
   ))
 
   anc <- file.path("testdata", "anc.csv")
+  file <- list(path = anc, hash = "12345", filename = "original")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
     list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","hash":"12345","filename":"original"}'),
     res,
     "anc",
-    anc,
-    shape,
-    "12345",
-    "original")
+    file,
+    shape)
   response <- jsonlite::parse_json(response)
 
   expect_equal(names(response$data$filters), "age")
@@ -241,14 +240,13 @@ test_that("possible filters are returned for data", {
 
   survey <- file.path("testdata", "survey.csv")
   res <- MockPlumberResponse$new()
+  file <- list(path = survey, hash = "12345", filename = "original")
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","hash":"12345","filename":"original"}'),
+    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","filename":"original"}'),
     res,
     "survey",
-    survey,
-    shape,
-    "12345",
-    "original")
+    file,
+    shape)
   response <- jsonlite::parse_json(response)
 
   expect_equal(names(response$data$filters), c("age", "surveys"))

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -109,14 +109,16 @@ test_that("format_response_data correctly formats data and validates it", {
     response <- input_response(list(data = list(country = scalar("Botswana")),
                                     filters = scalar(NA)),
                                "/path/to/file.pjnz",
-                               "pjnz")
+                               "pjnz",
+                               "original.pjnz")
   })
   expect_equal(response$data$country, scalar("Botswana"))
   expect_equal(response$filename, scalar("file.pjnz"))
   mockery::expect_called(mock_validate, 1)
   args <- mockery::mock_args(mock_validate)[[1]]
   expected_data <- list(
-    filename = "file.pjnz",
+    path = "/path/to/file.pjnz",
+    originalFilename = "original.pjnz",
     type = "pjnz",
     data = list(
       country = "Botswana"
@@ -191,7 +193,7 @@ test_that("possible filters are returned for data", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path"}'),
+    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","originalFilename":"original"}'),
     res,
     "programme",
     programme,
@@ -214,7 +216,7 @@ test_that("possible filters are returned for data", {
   anc <- file.path("testdata", "anc.csv")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path"}'),
+    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","originalFilename":"original"}'),
     res,
     "anc",
     anc,
@@ -233,7 +235,7 @@ test_that("possible filters are returned for data", {
   survey <- file.path("testdata", "survey.csv")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path"}'),
+    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","originalFilename":"original"}'),
     res,
     "survey",
     survey,

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -4,8 +4,8 @@ test_that("hintr_response correctly prepares response", {
   value <- list(
     success = TRUE,
     value = list(
-      originalFilename = scalar("original.pjnz"),
-      hash = scalar("file.pjnz"),
+      filename = scalar("original.pjnz"),
+      hash = scalar("12345"),
       type = scalar("pjnz"),
       data = list(country = scalar("Botswana"))
     )
@@ -17,8 +17,8 @@ test_that("hintr_response correctly prepares response", {
 
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "success")
-  expect_equal(response$data$hash, "file.pjnz")
-  expect_equal(response$data$originalFilename, "original.pjnz")
+  expect_equal(response$data$hash, "12345")
+  expect_equal(response$data$filename, "original.pjnz")
   expect_equal(response$data$data$country, "Botswana")
   expect_equal(response$errors, list())
 
@@ -48,9 +48,9 @@ test_that("hintr_response distinguishes incorrect data schema", {
   value <- list(
     success = TRUE,
     value = list(
-      originalFilename = scalar("test.pjnz"),
+      filename = scalar("test.pjnz"),
       type = scalar("pjnz"),
-      hash = scalar("file"),
+      hash = scalar("12345"),
       data = list(
         country = scalar("Botswana"))
     )
@@ -111,21 +111,21 @@ test_that("format_response_data correctly formats data and validates it", {
   with_mock("hintr:::validate_json_schema" = mock_validate, {
     response <- input_response(list(data = list(country = scalar("Botswana")),
                                     filters = scalar(NA)),
-                               "/path/to/file.pjnz",
                                "pjnz",
+                               "12345",
                                "original.pjnz")
   })
   expect_equal(response$data$country, scalar("Botswana"))
-  expect_equal(response$hash, scalar("file.pjnz"))
+  expect_equal(response$hash, scalar("12345"))
   mockery::expect_called(mock_validate, 1)
   args <- mockery::mock_args(mock_validate)[[1]]
   expected_data <- list(
-    hash = "file.pjnz",
+    hash = "12345",
     type = "pjnz",
     data = list(
       country = "Botswana"
     ),
-    originalFilename = "original.pjnz",
+    filename = "original.pjnz",
     filters = NULL
   )
   expect_equal(jsonlite::fromJSON(args[[1]]), expected_data)
@@ -196,11 +196,12 @@ test_that("possible filters are returned for data", {
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","originalFilename":"original"}'),
+    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","hash":"12345","filename":"original"}'),
     res,
     "programme",
     programme,
     shape,
+    "12345",
     "original")
   response <- jsonlite::parse_json(response)
 
@@ -220,11 +221,12 @@ test_that("possible filters are returned for data", {
   anc <- file.path("testdata", "anc.csv")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","originalFilename":"original"}'),
+    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","hash":"12345","filename":"original"}'),
     res,
     "anc",
     anc,
     shape,
+    "12345",
     "original")
   response <- jsonlite::parse_json(response)
 
@@ -240,11 +242,12 @@ test_that("possible filters are returned for data", {
   survey <- file.path("testdata", "survey.csv")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","originalFilename":"original"}'),
+    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","hash":"12345","filename":"original"}'),
     res,
     "survey",
     survey,
     shape,
+    "12345",
     "original")
   response <- jsonlite::parse_json(response)
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -108,12 +108,12 @@ test_that("plumber api can be built", {
 
 test_that("format_response_data correctly formats data and validates it", {
   mock_validate <- mockery::mock(TRUE)
+  file <- list(path = "path", hash = "12345", filename = "original.pjnz")
   with_mock("hintr:::validate_json_schema" = mock_validate, {
     response <- input_response(list(data = list(country = scalar("Botswana")),
                                     filters = scalar(NA)),
                                "pjnz",
-                               "12345",
-                               "original.pjnz")
+                                file)
   })
   expect_equal(response$data$country, scalar("Botswana"))
   expect_equal(response$hash, scalar("12345"))
@@ -195,14 +195,13 @@ test_that("possible filters are returned for data", {
   programme <- file.path("testdata", "programme.csv")
   shape <- file.path("testdata", "malawi.geojson")
   res <- MockPlumberResponse$new()
+  file <- list(path = programme, hash = "12345", filename = "original.pjnz")
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"programme","path":"path/to/file","shape":"path","hash":"12345","filename":"original"}'),
+    list(postBody = '{"type":"programme","shape":"path","file": {"path":"path/to/file","hash":"12345","filename":"original"}}'),
     res,
     "programme",
-    programme,
-    shape,
-    "12345",
-    "original")
+    file,
+    shape)
   response <- jsonlite::parse_json(response)
 
   expect_equal(names(response$data$filters), "age")
@@ -222,7 +221,7 @@ test_that("possible filters are returned for data", {
   file <- list(path = anc, hash = "12345", filename = "original")
   res <- MockPlumberResponse$new()
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"anc","path":"path/to/file","shape":"path","hash":"12345","filename":"original"}'),
+    list(postBody = '{"type":"anc","shape":"path","file": {"path":"path/to/file","hash":"12345","filename":"original"}}'),
     res,
     "anc",
     file,
@@ -242,7 +241,7 @@ test_that("possible filters are returned for data", {
   res <- MockPlumberResponse$new()
   file <- list(path = survey, hash = "12345", filename = "original")
   response <- endpoint_validate_survey_programme(
-    list(postBody = '{"type":"survey","path":"path/to/file","shape":"path","filename":"original"}'),
+    list(postBody = '{"type":"survey", "shape":"path", "file": {"path":"path/to/file","hash":"12345", "filename":"original"}}'),
     res,
     "survey",
     file,

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -4,7 +4,8 @@ test_that("hintr_response correctly prepares response", {
   value <- list(
     success = TRUE,
     value = list(
-      filename = scalar("file.pjnz"),
+      originalFilename = scalar("original.pjnz"),
+      path = scalar("path/to/file")
       type = scalar("pjnz"),
       data = list(country = scalar("Botswana"))
     )
@@ -16,7 +17,8 @@ test_that("hintr_response correctly prepares response", {
 
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "success")
-  expect_equal(response$data$filename, "file.pjnz")
+  expect_equal(response$data$hash, "file")
+  expect_equal(response$data$originalFilename, "original.pjnz")
   expect_equal(response$data$data$country, "Botswana")
   expect_equal(response$errors, list())
 
@@ -46,8 +48,9 @@ test_that("hintr_response distinguishes incorrect data schema", {
   value <- list(
     success = TRUE,
     value = list(
-      filename = scalar("test.pjnz"),
+      originalFilename = scalar("test.pjnz"),
       type = scalar("pjnz"),
+      hash = "file",
       data = list(
         country = scalar("Botswana"))
     )
@@ -117,7 +120,7 @@ test_that("format_response_data correctly formats data and validates it", {
   mockery::expect_called(mock_validate, 1)
   args <- mockery::mock_args(mock_validate)[[1]]
   expected_data <- list(
-    path = "/path/to/file.pjnz",
+    hash = "file.pjnz",
     originalFilename = "original.pjnz",
     type = "pjnz",
     data = list(
@@ -197,7 +200,8 @@ test_that("possible filters are returned for data", {
     res,
     "programme",
     programme,
-    shape)
+    shape,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(names(response$data$filters), "age")
@@ -220,7 +224,8 @@ test_that("possible filters are returned for data", {
     res,
     "anc",
     anc,
-    shape)
+    shape,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(names(response$data$filters), "age")
@@ -239,7 +244,8 @@ test_that("possible filters are returned for data", {
     res,
     "survey",
     survey,
-    shape)
+    shape,
+    "original")
   response <- jsonlite::parse_json(response)
 
   expect_equal(names(response$data$filters), c("age", "surveys"))

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -5,7 +5,7 @@ test_that("hintr_response correctly prepares response", {
     success = TRUE,
     value = list(
       originalFilename = scalar("original.pjnz"),
-      path = scalar("path/to/file")
+      path = scalar("path/to/file"),
       type = scalar("pjnz"),
       data = list(country = scalar("Botswana"))
     )

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -5,7 +5,7 @@ test_that("hintr_response correctly prepares response", {
     success = TRUE,
     value = list(
       originalFilename = scalar("original.pjnz"),
-      path = scalar("path/to/file"),
+      hash = scalar("file.pjnz"),
       type = scalar("pjnz"),
       data = list(country = scalar("Botswana"))
     )
@@ -17,7 +17,7 @@ test_that("hintr_response correctly prepares response", {
 
   response <- jsonlite::parse_json(response)
   expect_equal(response$status, "success")
-  expect_equal(response$data$hash, "file")
+  expect_equal(response$data$hash, "file.pjnz")
   expect_equal(response$data$originalFilename, "original.pjnz")
   expect_equal(response$data$data$country, "Botswana")
   expect_equal(response$errors, list())
@@ -50,7 +50,7 @@ test_that("hintr_response distinguishes incorrect data schema", {
     value = list(
       originalFilename = scalar("test.pjnz"),
       type = scalar("pjnz"),
-      hash = "file",
+      hash = scalar("file"),
       data = list(
         country = scalar("Botswana"))
     )
@@ -116,16 +116,16 @@ test_that("format_response_data correctly formats data and validates it", {
                                "original.pjnz")
   })
   expect_equal(response$data$country, scalar("Botswana"))
-  expect_equal(response$filename, scalar("file.pjnz"))
+  expect_equal(response$hash, scalar("file.pjnz"))
   mockery::expect_called(mock_validate, 1)
   args <- mockery::mock_args(mock_validate)[[1]]
   expected_data <- list(
     hash = "file.pjnz",
-    originalFilename = "original.pjnz",
     type = "pjnz",
     data = list(
       country = "Botswana"
     ),
+    originalFilename = "original.pjnz",
     filters = NULL
   )
   expect_equal(jsonlite::fromJSON(args[[1]]), expected_data)

--- a/tests/testthat/test-json.R
+++ b/tests/testthat/test-json.R
@@ -13,10 +13,10 @@ test_that("schema validation can be turned off", {
 })
 
 test_that("validate locates schema and does validation with referenced files", {
-  test_json <- '{"type": "pjnz", "path": "path/to/file"}'
+  test_json <- '{"type": "pjnz", "path": "path/to/file", "originalFilename": "original"}'
   expect_true(validate(test_json, "ValidateInputRequest"))
 
-  test_json <- '{"type": "notvalid", "path": "path/to/file"}'
+  test_json <- '{"type": "notvalid", "path": "path/to/file", "originalFilename": "original"}'
   expect_error(validate(test_json, "ValidateInputRequest"))
 
   test_json <- '{"type": "pjnz"}'

--- a/tests/testthat/test-json.R
+++ b/tests/testthat/test-json.R
@@ -13,7 +13,7 @@ test_that("schema validation can be turned off", {
 })
 
 test_that("validate locates schema and does validation with referenced files", {
-  test_json <- '{"type": "pjnz", "path": "path/to/file", "hash": "12345", "filename": "original"}'
+  test_json <- '{"type": "pjnz", "file": {"path": "path/to/file", "hash": "12345", "filename": "original"}}'
   expect_true(validate(test_json, "ValidateInputRequest"))
 
   test_json <- '{"type": "notvalid", "path": "path/to/file", "hash": "12345", "filename": "original"}'

--- a/tests/testthat/test-json.R
+++ b/tests/testthat/test-json.R
@@ -13,10 +13,10 @@ test_that("schema validation can be turned off", {
 })
 
 test_that("validate locates schema and does validation with referenced files", {
-  test_json <- '{"type": "pjnz", "path": "path/to/file", "originalFilename": "original"}'
+  test_json <- '{"type": "pjnz", "path": "path/to/file", "hash": "12345", "filename": "original"}'
   expect_true(validate(test_json, "ValidateInputRequest"))
 
-  test_json <- '{"type": "notvalid", "path": "path/to/file", "originalFilename": "original"}'
+  test_json <- '{"type": "notvalid", "path": "path/to/file", "hash": "12345", "filename": "original"}'
   expect_error(validate(test_json, "ValidateInputRequest"))
 
   test_json <- '{"type": "pjnz"}'

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -20,8 +20,9 @@ test_that("validate pjnz", {
     response_from_json(r),
     list(status = "success",
          errors = list(),
-         data = list(filename = "Botswana2018.PJNZ",
+         data = list(hash = "Botswana2018.PJNZ",
                      type = "pjnz",
+                     originalFilename = "original.PJNZ",
                      data = list(country = "Botswana"),
                      filters = NULL)))
 })
@@ -38,7 +39,8 @@ test_that("validate shape", {
 
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
-  expect_equal(response$data$filename, "malawi.geojson")
+  expect_equal(response$data$hash, "malawi.geojson")
+  expect_equal(response$data$originalFilename, "original.geojson")
   expect_equal(response$data$type, "shape")
   expect_true(all(c("type", "features") %in% names(response$data$data)))
   expect_equal(response$data$data$type, "FeatureCollection")
@@ -56,7 +58,8 @@ test_that("validate population", {
   expect_equal(response_from_json(r),
                list(status = "success",
                     errors = list(),
-                    data = list(filename = "population.csv",
+                    data = list(originalFilename = "origianl.csv",
+                                hash = "population.csv",
                                 type = "population",
                                 data = NULL,
                                 filters = NULL)))
@@ -74,7 +77,8 @@ test_that("validate programme", {
   response <- response_from_json(r)
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
-  expect_equal(response$data$filename, "programme.csv")
+  expect_equal(response$data$hash, "programme.csv")
+  expect_equal(response$data$originalFilename, "original.csv")
   expect_equal(response$data$type, "programme")
   expect_true(length(response$data$data) >= 1400)
   expect_equal(typeof(response$data$data[[1]]$current_art), "double")
@@ -94,7 +98,8 @@ test_that("validate ANC", {
   response <- response_from_json(r)
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
-  expect_equal(response$data$filename, "anc.csv")
+  expect_equal(response$data$hash, "anc.csv")
+  expect_equal(response$data$originalFilename, "original.csv")
   expect_equal(response$data$type, "anc")
   expect_true(length(response$data$data) >= 800)
   expect_equal(typeof(response$data$data[[1]]$ancrt_hiv_status), "integer")
@@ -114,7 +119,8 @@ test_that("validate survey", {
   response <- response_from_json(r)
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
-  expect_equal(response$data$filename, "survey.csv")
+  expect_equal(response$data$hash, "survey.csv")
+  expect_equal(response$data$originalFilename, "original.csv")
   expect_equal(response$data$type, "survey")
   expect_true(length(response$data$data) >= 20000)
   expect_equal(typeof(response$data$data[[1]]$est), "double")

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -20,7 +20,7 @@ test_that("validate pjnz", {
     response_from_json(r),
     list(status = "success",
          errors = list(),
-         data = list(hash = "Botswana2018.PJNZ",
+         data = list(hash = "12345",
                      type = "pjnz",
                      data = list(country = "Botswana"),
                      filename = "original.PJNZ",
@@ -39,7 +39,7 @@ test_that("validate shape", {
 
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
-  expect_equal(response$data$hash, "malawi.geojson")
+  expect_equal(response$data$hash, "12345")
   expect_equal(response$data$filename, "original.geojson")
   expect_equal(response$data$type, "shape")
   expect_true(all(c("type", "features") %in% names(response$data$data)))
@@ -77,7 +77,7 @@ test_that("validate programme", {
   response <- response_from_json(r)
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
-  expect_equal(response$data$hash, "programme.csv")
+  expect_equal(response$data$hash, "12345")
   expect_equal(response$data$filename, "original.csv")
   expect_equal(response$data$type, "programme")
   expect_true(length(response$data$data) >= 1400)
@@ -119,7 +119,7 @@ test_that("validate survey", {
   response <- response_from_json(r)
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
-  expect_equal(response$data$hash, "survey.csv")
+  expect_equal(response$data$hash, "12345")
   expect_equal(response$data$filename, "original.csv")
   expect_equal(response$data$type, "survey")
   expect_true(length(response$data$data) >= 20000)

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -22,8 +22,8 @@ test_that("validate pjnz", {
          errors = list(),
          data = list(hash = "Botswana2018.PJNZ",
                      type = "pjnz",
-                     originalFilename = "original.PJNZ",
                      data = list(country = "Botswana"),
+                     originalFilename = "original.PJNZ",
                      filters = NULL)))
 })
 
@@ -58,10 +58,10 @@ test_that("validate population", {
   expect_equal(response_from_json(r),
                list(status = "success",
                     errors = list(),
-                    data = list(originalFilename = "origianl.csv",
-                                hash = "population.csv",
+                    data = list(hash = "population.csv",
                                 type = "population",
                                 data = NULL,
+                                originalFilename = "original.csv",
                                 filters = NULL)))
 })
 

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -58,7 +58,7 @@ test_that("validate population", {
   expect_equal(response_from_json(r),
                list(status = "success",
                     errors = list(),
-                    data = list(hash = "population.csv",
+                    data = list(hash = "12345",
                                 type = "population",
                                 data = NULL,
                                 filename = "original.csv",

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -23,7 +23,7 @@ test_that("validate pjnz", {
          data = list(hash = "Botswana2018.PJNZ",
                      type = "pjnz",
                      data = list(country = "Botswana"),
-                     originalFilename = "original.PJNZ",
+                     filename = "original.PJNZ",
                      filters = NULL)))
 })
 
@@ -40,7 +40,7 @@ test_that("validate shape", {
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
   expect_equal(response$data$hash, "malawi.geojson")
-  expect_equal(response$data$originalFilename, "original.geojson")
+  expect_equal(response$data$filename, "original.geojson")
   expect_equal(response$data$type, "shape")
   expect_true(all(c("type", "features") %in% names(response$data$data)))
   expect_equal(response$data$data$type, "FeatureCollection")
@@ -61,7 +61,7 @@ test_that("validate population", {
                     data = list(hash = "population.csv",
                                 type = "population",
                                 data = NULL,
-                                originalFilename = "original.csv",
+                                filename = "original.csv",
                                 filters = NULL)))
 })
 
@@ -78,7 +78,7 @@ test_that("validate programme", {
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
   expect_equal(response$data$hash, "programme.csv")
-  expect_equal(response$data$originalFilename, "original.csv")
+  expect_equal(response$data$filename, "original.csv")
   expect_equal(response$data$type, "programme")
   expect_true(length(response$data$data) >= 1400)
   expect_equal(typeof(response$data$data[[1]]$current_art), "double")
@@ -98,8 +98,8 @@ test_that("validate ANC", {
   response <- response_from_json(r)
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
-  expect_equal(response$data$hash, "anc.csv")
-  expect_equal(response$data$originalFilename, "original.csv")
+  expect_equal(response$data$hash, "12345")
+  expect_equal(response$data$filename, "original.csv")
   expect_equal(response$data$type, "anc")
   expect_true(length(response$data$data) >= 800)
   expect_equal(typeof(response$data$data[[1]]$ancrt_hiv_status), "integer")
@@ -120,7 +120,7 @@ test_that("validate survey", {
   expect_equal(response$status, "success")
   expect_equal(response$errors, list())
   expect_equal(response$data$hash, "survey.csv")
-  expect_equal(response$data$originalFilename, "original.csv")
+  expect_equal(response$data$filename, "original.csv")
   expect_equal(response$data$type, "survey")
   expect_true(length(response$data$data) >= 20000)
   expect_equal(typeof(response$data$data[[1]]$est), "double")


### PR DESCRIPTION
Files are now saved by their hash, but we want to display the original filename to the user in the front-end, so we need it back in the serialised data. This PR changes the schema so the original filename gets sent with the validation request and returned with the validation response. Feels a bit annoying to just send it back and forth like this but can't think of another way, since it's `HINT` that knows the filename but `hintr` that does the serialisation.