### PR TITLE
MRC- 543: Pin dependencies temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ r_packages:
 r_github_packages:
   - ropensci/jsonvalidate@i25
   - mrc-ide/eppasm
-  - mrc-ide/naomi
+  - mrc-ide/naomi@demo-201910
+  - mrc-ide/rrq@v0.1.2
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,5 +32,3 @@ Suggests:
     mockery,
     testthat (>= 2.1.0),
     withr
-Remotes:
-    mrc-ide/naomi

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ To run tests locally:
 1. Some packages need to be installed from GitHub:
     * `devtools::install_github("ropensci/jsonvalidate")`
     * `devtools::install_github("mrc-ide/eppasm")`
-    * `devtools::install_github("mrc-ide/naomi")`
+    * `devtools::install_github("mrc-ide/naomi@demo-201910")`
     * `devtools::install_github("mrc-ide/queuer")`
     * `devtools::install_github("mrc-ide/context")`    
-    * `devtools::install_github("mrc-ide/rrq")`
+    * `devtools::install_github("mrc-ide/rrq@v0.1.2")`
 1. Install the hintr package:
    ```
    R CMD INSTALL .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,6 @@ RUN install_packages --repo=https://mrc-ide.github.io/drat \
         plumber \
         ps \
         remotes \
-        rrq \
         specio \
         testthat
 
@@ -30,7 +29,8 @@ RUN install_packages --repo=https://inla.r-inla-download.org/R/stable \
 
 RUN install_remote \
         mrc-ide/eppasm \
-        mrc-ide/naomi
+        mrc-ide/naomi@demo-201910 \
+        mrc-ide/rrq@v0.1.2
 
 COPY . /src
 RUN R CMD INSTALL /src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,8 @@ RUN install_packages --repo=https://inla.r-inla-download.org/R/stable \
 RUN install_remote \
         mrc-ide/eppasm \
         mrc-ide/naomi@demo-201910 \
+        mrc-ide/context \
+        mrc-ide/queuer \
         mrc-ide/rrq@v0.1.2
 
 COPY . /src


### PR DESCRIPTION
This PR will pin the dependencies so that we have a stable build ahead of the demo.  Both the travis and the docker build are affected