### PR TITLE
mrc-576: restructure the docker endpoints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
 Additional_repositories: https://mrc-ide.github.io/drat
 Imports:
+    docopt,
     geojsonio,
     ids,
     jsonlite (>= 1.2.2),

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -22,8 +22,8 @@ api_run <- function(pr, port = 8888) {
   pr$run(host = "0.0.0.0", port = port) # nocov
 }
 
-api <- function(port = 8888) {
-  queue <- Queue$new() # nocov
+api <- function(port = 8888, queue_id = NULL, workers = 2) {
+  queue <- Queue$new(queue_id, workers) # nocov
   api_run(api_build(queue), port) # nocov
 }
 

--- a/R/main.R
+++ b/R/main.R
@@ -25,6 +25,6 @@ hintr_worker [<queue_id>]"
   list(queue_id = dat$queue_id)
 }
 
-main_worker <- function(args = commanbdArgs(TRUE)) {
+main_worker <- function(args = commandArgs(TRUE)) {
   rrq::rrq_worker(hintr_queue_id(main_worker_args(args)$queue_id, TRUE)) # nocov
 }

--- a/R/main.R
+++ b/R/main.R
@@ -1,0 +1,30 @@
+main_api_args <- function(args = commandArgs(TRUE)) {
+  usage <- "Usage:
+  hintr_api [options] [<queue_id>]
+
+Options:
+--workers=N   Number of workers to spawn [default: 2]
+--port=PORT   Port to use [default: 8888]"
+
+  dat <- docopt::docopt(usage, args)
+  list(port = as.integer(dat$port),
+       queue_id = dat$queue_id,
+       workers = as.integer(dat$workers))
+}
+
+main_api <- function(args = commandArgs(TRUE)) {
+  dat <- main_api_args(args) # nocov
+  api(dat$port, dat$queue_id, dat$workers) # nocov
+}
+
+main_worker_args <- function(args = commandArgs(TRUE)) {
+  usage <- "Usage:
+hintr_worker [<queue_id>]"
+
+  dat <- docopt::docopt(usage, args)
+  list(queue_id = dat$queue_id)
+}
+
+main_worker <- function(args = commanbdArgs(TRUE)) {
+  rrq::rrq_worker(hintr_queue_id(main_worker_args(args)$queue_id, TRUE)) # nocov
+}

--- a/R/queue.R
+++ b/R/queue.R
@@ -6,14 +6,15 @@ Queue <- R6::R6Class(
     cleanup_on_exit = NULL,
     queue = NULL,
 
-    initialize = function(workers = 2, cleanup_on_exit = workers > 0) {
+    initialize = function(queue_id = NULL, workers = 2,
+                          cleanup_on_exit = workers > 0) {
       self$cleanup_on_exit <- cleanup_on_exit
 
       message("connecting to redis at ", redux::redis_config()$url)
       con <- redux::hiredis()
 
       message("Starting queue")
-      self$queue <- rrq::rrq_controller(hintr_queue_id(), con)
+      self$queue <- rrq::rrq_controller(hintr_queue_id(queue_id), con)
 
       self$start(workers)
     },
@@ -73,7 +74,11 @@ Queue <- R6::R6Class(
   )
 )
 
-hintr_queue_id <- function(worker = FALSE) {
+hintr_queue_id <- function(queue_id, worker = FALSE) {
+  if (!is.null(queue_id)) {
+    assert_scalar_character(queue_id)
+    return(queue_id)
+  }
   id <- Sys.getenv("HINTR_QUEUE_ID", "")
   if (!nzchar(id)) {
     if (worker) {

--- a/R/queue.R
+++ b/R/queue.R
@@ -76,7 +76,6 @@ Queue <- R6::R6Class(
 
 hintr_queue_id <- function(queue_id, worker = FALSE) {
   if (!is.null(queue_id)) {
-    assert_scalar_character(queue_id)
     return(queue_id)
   }
   id <- Sys.getenv("HINTR_QUEUE_ID", "")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get -y install \
 COPY docker/bin /usr/local/bin/
 
 RUN install_packages --repo=https://mrc-ide.github.io/drat \
+        docopt \
         geojsonio \
         jsonlite \
         plumber \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,4 +39,4 @@ RUN R CMD INSTALL /src
 EXPOSE 8888
 ENV HINTR_QUEUE_ID=hintr
 
-ENTRYPOINT ["/src/inst/entrypoint.R"]
+ENTRYPOINT ["/usr/local/bin/hintr_api"]

--- a/docker/bin/hintr_api
+++ b/docker/bin/hintr_api
@@ -1,0 +1,2 @@
+#!/usr/bin/env Rscript
+hintr:::main_api()

--- a/docker/bin/hintr_worker
+++ b/docker/bin/hintr_worker
@@ -1,0 +1,2 @@
+#!/usr/bin/env Rscript
+hintr:::main_worker()

--- a/docker/build
+++ b/docker/build
@@ -5,7 +5,7 @@ HERE=$(dirname $0)
 
 cat << EOF > $HERE/Dockerfile.worker
 FROM $TAG_SHA
-ENTRYPOINT ["/src/inst/worker.R"]
+ENTRYPOINT ["/usr/local/bin/hintr_worker"]
 EOF
 
 docker build --pull \
@@ -21,3 +21,5 @@ docker build \
        -t $TAG_WORKER_VERSION \
        -f docker/Dockerfile.worker \
        .
+
+rm -f docker/Dockerfile.worker

--- a/inst/entrypoint.R
+++ b/inst/entrypoint.R
@@ -1,2 +1,0 @@
-#!/usr/bin/env Rscript
-hintr:::api()

--- a/inst/worker.R
+++ b/inst/worker.R
@@ -1,2 +1,0 @@
-#!/usr/bin/env Rscript
-rrq::rrq_worker(hintr_queue_id(TRUE))

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -1,0 +1,14 @@
+context("main")
+
+test_that("main_api_args", {
+  expect_equal(main_api_args(c()),
+               list(port = 8888, queue_id = NULL, workers = 2))
+  expect_equal(
+    main_api_args(c("--workers=0", "--port", "80", "hintr")),
+    list(port = 80, queue_id = "hintr", workers = 0))
+})
+
+test_that("main_worker_args", {
+  expect_equal(main_worker_args(c()), list(queue_id = NULL))
+  expect_equal(main_worker_args("hintr"), list(queue_id = "hintr"))
+})

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -61,16 +61,22 @@ test_that("queue works as intended", {
 test_that("queue_id is generated if not supplied", {
   withr::with_envvar(
     c("HINTR_QUEUE_ID" = NA),
-    expect_match(hintr_queue_id(), "^hintr:[[:xdigit:]]+$"))
+    expect_match(hintr_queue_id(NULL), "^hintr:[[:xdigit:]]+$"))
   withr::with_envvar(
     c("HINTR_QUEUE_ID" = "myqueue"),
-    expect_equal(hintr_queue_id(), "myqueue"))
+    expect_equal(hintr_queue_id(NULL), "myqueue"))
 })
 
 
 test_that("queue_id is required for workers", {
   withr::with_envvar(
     c("HINTR_QUEUE_ID" = NA),
-    expect_error(hintr_queue_id(TRUE),
+    expect_error(hintr_queue_id(NULL, TRUE),
                  "Environment variable 'HINTR_QUEUE_ID' is not set"))
+})
+
+test_that("queue_id is returned if supplied", {
+  withr::with_envvar(
+    c("HINTR_QUEUE_ID" = NA),
+    expect_equal(hintr_queue_id("myqueue", TRUE), "myqueue"))
 })


### PR DESCRIPTION
This PR will restructure the docker endpoints in order to make the number of workers configurable from the command line.  This is needed for the deployment work.  Default behaviour will not change (2 workers within the primary container) as this is convenient for testing, at least for now