### PR TITLE
mrc-544: add informational endpoints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 0.0.7
+
+* New `GET /hintr/version` and `GET /hintr/worker/status` endpoints, the first in a series of hintr informational endpoints
+
 # hintr 0.0.6
 
 * Fix plotting metadata for output dataset

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -14,8 +14,10 @@ api_build <- function(queue) {
             serializer = serializer_json_hintr())
   pr$handle("GET", "/meta/plotting/<country>", endpoint_plotting_metadata,
             serializer = serializer_json_hintr())
-  pr$handle("GET", "/hintr/version", endpoint_hintr_version)
-  pr$handle("GET", "/hintr/worker/status", endpoint_hintr_worker_status(queue))
+  pr$handle("GET", "/hintr/version", endpoint_hintr_version,
+            serializer = serializer_json_hintr())
+  pr$handle("GET", "/hintr/worker/status", endpoint_hintr_worker_status(queue),
+            serializer = serializer_json_hintr())
   pr$handle("GET", "/", api_root)
   pr
 }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -15,6 +15,7 @@ api_build <- function(queue) {
   pr$handle("GET", "/meta/plotting/<country>", endpoint_plotting_metadata,
             serializer = serializer_json_hintr())
   pr$handle("GET", "/hintr/version", endpoint_hintr_version)
+  pr$handle("GET", "/hintr/workers", endpoint_hintr_workers(queue))
   pr$handle("GET", "/", api_root)
   pr
 }
@@ -243,10 +244,10 @@ with_success <- function(expr) {
   )
 }
 
-endpoint_hintr_version <- function() {
+endpoint_hintr_version <- function(req, res) {
   packages <- c("hintr", "naomi", "rrq")
   value <- lapply(packages, function(p)
-    scalar(as.character(packageVersion(p))))
+    scalar(as.character(utils::packageVersion(p))))
   names(value) <- packages
   hintr_response(list(success = TRUE, value = value), "HintrVersionResponse")
 }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -15,7 +15,6 @@ api_build <- function(queue) {
   pr$handle("GET", "/meta/plotting/<country>", endpoint_plotting_metadata,
             serializer = serializer_json_hintr())
   pr$handle("GET", "/hintr/version", endpoint_hintr_version)
-  pr$handle("GET", "/hintr/workers", endpoint_hintr_workers(queue))
   pr$handle("GET", "/", api_root)
   pr
 }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -15,6 +15,7 @@ api_build <- function(queue) {
   pr$handle("GET", "/meta/plotting/<country>", endpoint_plotting_metadata,
             serializer = serializer_json_hintr())
   pr$handle("GET", "/hintr/version", endpoint_hintr_version)
+  pr$handle("GET", "/hintr/worker/status", endpoint_hintr_worker_status(queue))
   pr$handle("GET", "/", api_root)
   pr
 }
@@ -249,6 +250,13 @@ endpoint_hintr_version <- function(req, res) {
     scalar(as.character(utils::packageVersion(p))))
   names(value) <- packages
   hintr_response(list(success = TRUE, value = value), "HintrVersionResponse")
+}
+
+endpoint_hintr_worker_status <- function(queue) {
+  function(req, res) {
+    response <- with_success(lapply(queue$queue$worker_status(), scalar))
+    hintr_response(response, "HintrWorkerStatus")
+  }
 }
 
 api_root <- function() {

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -14,6 +14,7 @@ api_build <- function(queue) {
             serializer = serializer_json_hintr())
   pr$handle("GET", "/meta/plotting/<country>", endpoint_plotting_metadata,
             serializer = serializer_json_hintr())
+  pr$handle("GET", "/hintr/version", endpoint_hintr_version)
   pr$handle("GET", "/", api_root)
   pr
 }
@@ -242,9 +243,18 @@ with_success <- function(expr) {
   )
 }
 
+endpoint_hintr_version <- function() {
+  packages <- c("hintr", "naomi", "rrq")
+  value <- lapply(packages, function(p)
+    scalar(as.character(packageVersion(p))))
+  names(value) <- packages
+  hintr_response(list(success = TRUE, value = value), "HintrVersionResponse")
+}
+
 api_root <- function() {
   scalar("Welcome to hintr")
 }
+
 
 # This serialiser allows us to splice in objects with a class "json"
 # into list structures, without converting these structures into

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Get plotting metadata for Malawi:
 curl http://localhost:8888/meta/plotting/Malawi
 ```
 
+Get information about hintr versions
+```
+curl http://localhost:8888/hintr/version
+#> {"status":"success","errors":[],"data":{"hintr":"0.0.7","naomi":"0.0.6","rrq":"0.2.0"}}
+```
+
+Get information about hintr's workers
+```
+curl http://localhost:8888/hintr/worker/status
+#> {"status":"success","errors":[],"data":{"acoustic_bufflehead_1":"IDLE","acoustic_bufflehead_2":"IDLE"}}
+```
+
 Docker container can be cleaned up using
 ```
 docker rm -f hintr

--- a/inst/schema/HintrVersionResponse.schema.json
+++ b/inst/schema/HintrVersionResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties" : {
+    "type" : "string",
+    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+  }
+}

--- a/inst/schema/HintrWorkerStatus.schema.json
+++ b/inst/schema/HintrWorkerStatus.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties" : {
+    "type" : "string",
+    "enum": ["BUSY", "IDLE", "PAUSED", "EXITED", "LOST"]
+  }
+}

--- a/tests/testthat/test-endpoints-hintr.R
+++ b/tests/testthat/test-endpoints-hintr.R
@@ -1,0 +1,10 @@
+context("endpoints-hintr")
+
+test_that("endpoint hintr works", {
+  response <- endpoint_hintr_version()
+  response <- jsonlite::parse_json(response)
+
+  expect_is(response$data, "list")
+  expect_setequal(names(response$data), c("hintr", "naomi", "rrq"))
+  expect_equal(response$data$rrq, as.character(packageVersion("rrq")))
+})

--- a/tests/testthat/test-endpoints-hintr.R
+++ b/tests/testthat/test-endpoints-hintr.R
@@ -8,3 +8,19 @@ test_that("endpoint hintr works", {
   expect_setequal(names(response$data), c("hintr", "naomi", "rrq"))
   expect_equal(response$data$rrq, as.character(packageVersion("rrq")))
 })
+
+test_that("endpoint worker status works", {
+  queue <- Queue$new()
+  endpoint <- endpoint_hintr_worker_status(queue)
+
+  response <- jsonlite::parse_json(endpoint())
+  expect_equal(unlist(response$data, FALSE, FALSE), rep("IDLE", 2))
+
+  queue$queue$worker_stop(timeout = 5)
+  response <- jsonlite::parse_json(endpoint())
+  expect_equal(unlist(response$data, FALSE, FALSE), rep("EXITED", 2))
+
+  queue$queue$worker_delete_exited()
+  response <- jsonlite::parse_json(endpoint())
+  expect_equal(response$data, setNames(list(), character()))
+})

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -98,9 +98,9 @@ test_that("hintr API can be tested", {
 test_that("plumber api can be built", {
   api <- api_build()
   expect_s3_class(api, "plumber")
-  expect_length(api$routes, 4)
+  expect_length(api$routes, 5)
   expect_equal(names(api$routes),
-               c("validate", "model", "meta", ""))
+               c("validate", "model", "meta", "hintr", ""))
   expect_equal(names(api$routes$validate),
                c("baseline-individual", "baseline-combined", "survey-and-programme"))
   expect_equal(names(api$routes$model), c("submit", "status", "result"))

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -217,3 +217,23 @@ test_that("plotting metadata is exposed", {
   expect_equal(response$data$anc$choropleth$indicators[[2]]$name,
                "Prevalence")
 })
+
+test_that("version information is returned", {
+  server <- hintr_server()
+  r <- httr::GET(paste0(server$url, "/hintr/version"))
+  expect_equal(httr::status_code(r), 200)
+  response <- response_from_json(r)
+  expect_equal(response$status, "success")
+  expect_setequal(names(response$data),
+                  c("hintr", "naomi", "rrq"))
+})
+
+test_that("worker information is returned", {
+  server <- hintr_server()
+  r <- httr::GET(paste0(server$url, "/hintr/worker/status"))
+  expect_equal(httr::status_code(r), 200)
+  response <- response_from_json(r)
+  expect_equal(response$status, "success")
+  expect_match(names(response$data), "^[a-z]+_[a-z]+_[12]$")
+  expect_equivalent(response$data, list("IDLE", "IDLE"))
+})


### PR DESCRIPTION
This PR will add informational endpoints to query software versions and the state of workers (and by extension their state). This will be useful in deployment work, especially after #48/mrc-576 is merged as the number of workers will be variable