### PR TITLE
mrc-604: Push sha-tagged images even on failure

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -23,3 +23,8 @@ docker build \
        .
 
 rm -f docker/Dockerfile.worker
+
+# We always push the SHA tagged versions, for debugging if the tests
+# after this step fail
+docker push $TAG_SHA
+docker push $TAG_WORKER_SHA

--- a/docker/push
+++ b/docker/push
@@ -2,11 +2,12 @@
 set -e
 HERE=$(dirname $0)
 . $HERE/common
-docker push $TAG_SHA
+
+# Push the human-readable tagged versions here (the SHA versions were
+# pushed during build)
 docker push $TAG_BRANCH
 docker push $TAG_VERSION
 
-docker push $TAG_WORKER_SHA
 docker push $TAG_WORKER_BRANCH
 docker push $TAG_WORKER_VERSION
 


### PR DESCRIPTION
This PR will push the sha-tagged images even on test failure, allowing local debugging