### PR TITLE
Fix json validation bugs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     glue,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 0.0.8),
+    naomi (>= 0.0.11),
     plumber,
     R6,
     redux,

--- a/R/model_options.R
+++ b/R/model_options.R
@@ -51,7 +51,7 @@ do_endpoint_model_options <- function(shape, survey, programme, anc) {
 
 
   params <- list(
-    area_scope_options = regions,
+    area_scope_options = list(regions),
     area_scope_default = parent_region,
     area_level_options = area_level_options,
     t1_options = time_options,

--- a/R/model_options.R
+++ b/R/model_options.R
@@ -19,8 +19,7 @@ do_endpoint_model_options <- function(shape, survey, programme, anc) {
   ## General options
   json <- hintr_geojson_read(shape)
   regions <- get_region_filters(json)
-  parent_region <- list(id = regions$id,
-                        label = regions$label)
+  parent_region_id <- regions$id
   area_level_options <- get_level_options(json)
   time_options <- get_time_options()
 
@@ -52,7 +51,7 @@ do_endpoint_model_options <- function(shape, survey, programme, anc) {
 
   params <- list(
     area_scope_options = list(regions),
-    area_scope_default = parent_region,
+    area_scope_default = parent_region_id,
     area_level_options = area_level_options,
     t1_options = time_options,
     t2_options = time_options,

--- a/R/model_options.R
+++ b/R/model_options.R
@@ -108,7 +108,7 @@ get_level_options <- function(json) {
     level <- NULL
     if (as.logical(feature$properties$display)) {
       level <- list(
-        id = scalar(feature$properties$area_level),
+        id = scalar(as.character(feature$properties$area_level)),
         label = scalar(feature$properties$area_level_label)
       )
     }

--- a/inst/schema/ModelRunOptions.schema.json
+++ b/inst/schema/ModelRunOptions.schema.json
@@ -7,7 +7,7 @@
         "label": { "type": "string" },
         "type": { "enum": [ "select", "multiselect" ] },
         "required": { "type": "boolean" },
-        "default": { "type": "string" },
+        "value": { "type": "string" },
         "helpText": { "type": "string" },
         "options": { "type":  "array", "items": { "type": "string" }}
       },
@@ -20,7 +20,7 @@
         "label": { "type": "string" },
         "type": { "enum": [ "number" ] },
         "required": { "type": "boolean" },
-        "default": { "type": "number" },
+        "value": { "type": "number" },
         "helpText": { "type": "string" },
         "min": { "type": "number" },
         "max": { "type": "number" }

--- a/inst/schema/ModelRunOptions.schema.json
+++ b/inst/schema/ModelRunOptions.schema.json
@@ -2,12 +2,13 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "selectControl": {
+      "type": "object",
       "properties": {
         "name": { "type": "string" },
         "label": { "type": "string" },
         "type": { "enum": [ "select", "multiselect" ] },
         "required": { "type": "boolean" },
-        "value": { "type": "string" },
+        "default": { "type": "string" },
         "helpText": { "type": "string" },
         "options": { "type":  "array", "items": { "type": "string" }}
       },
@@ -15,12 +16,13 @@
       "required": [ "name", "type", "required" ]
     },
     "numberControl": {
+      "type": "object",
       "properties": {
         "name": { "type": "string" },
         "label": { "type": "string" },
         "type": { "enum": [ "number" ] },
         "required": { "type": "boolean" },
-        "value": { "type": "number" },
+        "default": { "type": "number" },
         "helpText": { "type": "string" },
         "min": { "type": "number" },
         "max": { "type": "number" }
@@ -29,6 +31,7 @@
       "required": [ "name", "type", "required" ]
     },
     "controlGroup": {
+      "type": "object",
       "properties": {
         "label": { "type": "string" },
         "controls": { "oneOf": [ { "ref": "#/definitions/selectControl" }, { "ref": "#/definitions/numberControl" }] }
@@ -37,10 +40,14 @@
       "required": [ "controls" ]
     },
     "controlSection": {
+      "type": "object",
       "properties": {
         "label": { "type": "string" },
         "description": { "type": "string" },
-        "controlGroups": { "$ref": "#/definitions/controlGroup" }
+        "controlGroups": { 
+          "type": "array", 
+          "items": { "$ref": "#/definitions/controlGroup" }
+        }
       },
       "additionalProperties": false,
       "required": [ "label", "controlGroups" ]

--- a/inst/schema/ModelRunOptions.schema.json
+++ b/inst/schema/ModelRunOptions.schema.json
@@ -8,9 +8,30 @@
         "label": { "type": "string" },
         "type": { "enum": [ "select", "multiselect" ] },
         "required": { "type": "boolean" },
-        "default": { "type": "string" },
+        "value": { 
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "label": { "type": "string" }
+          }
+        },
         "helpText": { "type": "string" },
-        "options": { "type":  "array", "items": { "type": "string" }}
+        "options": { 
+          "type":  "array", 
+          "items": { 
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "label": { "type": "string" },
+              "children": { 
+                "type": "array",
+                "items": { "type": "object" }
+              }
+            },
+            "additionalProperties": false,
+            "required": [ "id", "label" ] 
+          }
+        }
       },
       "additionalProperties": false,
       "required": [ "name", "type", "required" ]
@@ -22,7 +43,7 @@
         "label": { "type": "string" },
         "type": { "enum": [ "number" ] },
         "required": { "type": "boolean" },
-        "default": { "type": "number" },
+        "value": { "type": "number" },
         "helpText": { "type": "string" },
         "min": { "type": "number" },
         "max": { "type": "number" }
@@ -34,7 +55,15 @@
       "type": "object",
       "properties": {
         "label": { "type": "string" },
-        "controls": { "oneOf": [ { "ref": "#/definitions/selectControl" }, { "ref": "#/definitions/numberControl" }] }
+        "controls": { 
+          "type": "array", 
+          "items": { "oneOf": 
+            [ 
+              { "$ref": "#/definitions/selectControl" },
+              { "$ref": "#/definitions/numberControl" }
+            ]
+          }
+        }
       },
       "additionalProperties": false,
       "required": [ "controls" ]

--- a/inst/schema/ModelRunOptions.schema.json
+++ b/inst/schema/ModelRunOptions.schema.json
@@ -8,13 +8,7 @@
         "label": { "type": "string" },
         "type": { "enum": [ "select", "multiselect" ] },
         "required": { "type": "boolean" },
-        "value": { 
-          "type": "object",
-          "properties": {
-            "id": { "type": "string" },
-            "label": { "type": "string" }
-          }
-        },
+        "value": { "type": "string" },
         "helpText": { "type": "string" },
         "options": { 
           "type":  "array", 

--- a/inst/schema/Response.schema.json
+++ b/inst/schema/Response.schema.json
@@ -5,7 +5,9 @@
     "status": {
       "enum": [ "success", "failure" ]
     },
-    "data": {},
+    "data": {
+      "type": "object"
+    },
     "errors": {
       "type": "array",
       "items": { "$ref": "Error.schema.json" }

--- a/inst/schema/SessionFile.schema.json
+++ b/inst/schema/SessionFile.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
   "properties": {
     "path" : { "$ref": "FilePath.schema.json" },
     "hash" : { "type": "string" },

--- a/inst/schema/ShapeResponseData.schema.json
+++ b/inst/schema/ShapeResponseData.schema.json
@@ -9,7 +9,7 @@
       "type": "string",
       "enum": [ "FeatureCollection" ] },
     "crs": { "type": "object" },
-    "name": { "tyep": "string" },
+    "name": { "type": "string" },
     "features": {
       "type": "array",
       "items": { "type": "object" }

--- a/inst/schema/ValidateInputResponse.schema.json
+++ b/inst/schema/ValidateInputResponse.schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "pjnz_response": {
+      "type": "object",
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
         "filename" : { "type": "string" },
@@ -17,6 +18,7 @@
     },
 
     "shape_response": {
+      "type": "object",
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
         "filename" : { "type": "string" },
@@ -41,6 +43,7 @@
     },
 
     "population_response": {
+      "type": "object",
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
         "filename" : { "type": "string" },
@@ -56,6 +59,7 @@
     },
 
     "programme_response": {
+      "type": "object",
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
         "filename" : { "type": "string" },
@@ -71,6 +75,7 @@
     },
 
     "anc_response": {
+      "type": "object",
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
         "filename" : { "type": "string" },
@@ -86,6 +91,7 @@
     },
 
     "survey_response": {
+      "type": "object",
       "properties": {
         "hash": { "$ref": "FileName.schema.json" },
         "filename" : { "type": "string" },

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -382,81 +382,81 @@ test_that("endpoint_model_options returns model options", {
     "Malawi"
   )
   expect_equal(
-    names(general_section$controlGroups[[1]]$controls[[1]]$default),
+    names(general_section$controlGroups[[1]]$controls[[1]]$value),
     c("id", "label"))
   expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$default$id,
+    general_section$controlGroups[[1]]$controls[[1]]$value$id,
     "MWI")
   expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$default$label,
+    general_section$controlGroups[[1]]$controls[[1]]$value$label,
     "Malawi")
   expect_length(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]],
+    general_section$controlGroups[[2]]$controls[[1]]$options,
     5
   )
   expect_equal(
-    names(general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]),
+    names(general_section$controlGroups[[2]]$controls[[1]]$options[[1]]),
     c("id", "label")
   )
   expect_equal(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]$id,
+    general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$id,
     0)
   expect_equal(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]$label,
+    general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$label,
     "Country")
 
   survey_section <- json$data$controlSections[[2]]
   expect_length(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]],
+    survey_section$controlGroups[[1]]$controls[[1]]$options,
     4
   )
   expect_equal(
-    names(survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]),
+    names(survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$id,
+    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
     "MWI2016PHIA")
   expect_equal(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$label,
+    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
     "MWI2016PHIA")
 
   art_section <- json$data$controlSections[[3]]
   expect_length(
-    art_section$controlGroups[[1]]$controls[[1]]$options[[1]],
+    art_section$controlGroups[[1]]$controls[[1]]$options,
     32
   )
   expect_equal(
-    names(art_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]),
+    names(art_section$controlGroups[[1]]$controls[[1]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$id,
+    art_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
     "445")
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$label,
+    art_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
     "Jan-Mar 2011")
   expect_equal(
-    names(art_section$controlGroups[[1]]$controls[[2]]$options[[1]][[1]]),
+    names(art_section$controlGroups[[1]]$controls[[2]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[2]]$options[[1]][[1]]$id,
+    art_section$controlGroups[[1]]$controls[[2]]$options[[1]]$id,
     "445")
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[2]]$options[[1]][[1]]$label,
+    art_section$controlGroups[[1]]$controls[[2]]$options[[1]]$label,
     "Jan-Mar 2011")
 
   anc_section <- json$data$controlSections[[4]]
   expect_length(
-    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]],
+    anc_section$controlGroups[[1]]$controls[[1]]$options,
     29
   )
   expect_equal(
-    names(anc_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]),
+    names(anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$id,
+    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
     "447")
   expect_equal(
-    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$label,
+    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
     "Jul-Sep 2011")
 })
 
@@ -491,42 +491,42 @@ test_that("endpoint_model_options can be run without programme data", {
     "Malawi"
   )
   expect_equal(
-    names(general_section$controlGroups[[1]]$controls[[1]]$default),
+    names(general_section$controlGroups[[1]]$controls[[1]]$value),
     c("id", "label"))
   expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$default$id,
+    general_section$controlGroups[[1]]$controls[[1]]$value$id,
     "MWI")
   expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$default$label,
+    general_section$controlGroups[[1]]$controls[[1]]$value$label,
     "Malawi")
   expect_length(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]],
+    general_section$controlGroups[[2]]$controls[[1]]$options,
     5
   )
   expect_equal(
-    names(general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]),
+    names(general_section$controlGroups[[2]]$controls[[1]]$options[[1]]),
     c("id", "label")
   )
   expect_equal(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]$id,
+    general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$id,
     0)
   expect_equal(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]$label,
+    general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$label,
     "Country")
 
   survey_section <- json$data$controlSections[[2]]
   expect_length(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]],
+    survey_section$controlGroups[[1]]$controls[[1]]$options,
     4
   )
   expect_equal(
-    names(survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]),
+    names(survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$id,
+    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
     "MWI2016PHIA")
   expect_equal(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$label,
+    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
     "MWI2016PHIA")
 })
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -447,7 +447,7 @@ test_that("endpoint_model_options returns model options", {
   )
   expect_equal(
     general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$id,
-    0)
+    "0")
   expect_equal(
     general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$label,
     "Country")
@@ -556,7 +556,7 @@ test_that("endpoint_model_options can be run without programme data", {
   )
   expect_equal(
     general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$id,
-    0)
+    "0")
   expect_equal(
     general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$label,
     "Country")

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -429,14 +429,8 @@ test_that("endpoint_model_options returns model options", {
     "Malawi"
   )
   expect_equal(
-    names(general_section$controlGroups[[1]]$controls[[1]]$value),
-    c("id", "label"))
-  expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$value$id,
+    general_section$controlGroups[[1]]$controls[[1]]$value,
     "MWI")
-  expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$value$label,
-    "Malawi")
   expect_length(
     general_section$controlGroups[[2]]$controls[[1]]$options,
     5
@@ -538,14 +532,8 @@ test_that("endpoint_model_options can be run without programme data", {
     "Malawi"
   )
   expect_equal(
-    names(general_section$controlGroups[[1]]$controls[[1]]$value),
-    c("id", "label"))
-  expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$value$id,
+    general_section$controlGroups[[1]]$controls[[1]]$value,
     "MWI")
-  expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$value$label,
-    "Malawi")
   expect_length(
     general_section$controlGroups[[2]]$controls[[1]]$options,
     5

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -50,87 +50,86 @@ test_that("do_endpoint_model_options correctly builds params list", {
   with_mock("hintr:::build_json" = mock_build_json,  {
     json <- do_endpoint_model_options(shape, survey, art, anc)
     args <- mockery::mock_args(mock_build_json)
-    expect_length(args[[1]], 2)
-    expect_true(grepl('"label": "ART"', args[[1]][[1]]))
-    expect_true(grepl('"label": "ANC"', args[[1]][[1]]))
-    params <- args[[1]][[2]]
-    expect_equal(names(params),
-      c("area_scope_options", "area_scope_default", "area_level_options",
-        "t1_options", "t2_options", "survey_prevalence_options",
-        "survey_art_coverage_options", "survey_vls_options",
-        "survey_recently_infected_options", "survey_art_or_vls_options",
-        "art_t1_options", "art_t2_options", "anc_prevalence_t1_options",
-        "anc_prevalence_t2_options", "anc_art_coverage_t1_options",
-        "anc_art_coverage_t2_options"))
-
-    expect_length(params$area_scope_options, 1)
-    expect_equal(names(params$area_scope_options[[1]]),
-                 c("id", "label", "children"))
-    expect_equal(params$area_scope_options[[1]]$id, scalar("MWI"))
-    expect_equal(params$area_scope_options[[1]]$label, scalar("Malawi"))
-    expect_length(params$area_scope_options[[1]]$children, 3)
-    expect_equal(params$area_scope_default$id, scalar("MWI"))
-    expect_equal(params$area_scope_default$label, scalar("Malawi"))
-    expect_equal(params$area_level_options, list(
-      list(
-        id = scalar("0"),
-        label = scalar("Country")
-      ),
-      list(
-        id = scalar("1"),
-        label = scalar("Region")
-      ),
-      list(
-        id = scalar("2"),
-        label = scalar("Zone")
-      ),
-      list(
-        id = scalar("3"),
-        label = scalar("District")
-      ),
-      list(
-        id = scalar("4"),
-        label = scalar("District + Metro")
-      )))
-    expect_equal(params$t1_options[[length(params$t1_options)]]$id,
-                 scalar("449"))
-    expect_equal(params$t1_options[[length(params$t1_options)]]$label,
-                 scalar("Jan-Mar 2012"))
-    expect_true(length(params$t1_options) >= 32)
-    expect_equal(params$t1_options[[length(params$t2_options)]]$id,
-                 scalar("449"))
-    expect_equal(params$t1_options[[length(params$t2_options)]]$label,
-                 scalar("Jan-Mar 2012"))
-    expect_true(length(params$t2_options) >= 32)
-    expect_length(params$survey_prevalence_options, 4)
-    expect_equal(params$survey_prevalence_options[[1]]$id,
-                 scalar("MWI2016PHIA"))
-    expect_equal(params$survey_prevalence_options[[1]]$label,
-                 scalar("MWI2016PHIA"))
-    expect_equal(params$survey_prevalence_options,
-                 params$survey_art_coverage_options)
-    expect_equal(params$survey_prevalence_options,
-                 params$survey_vls_options)
-    expect_equal(params$survey_prevalence_options,
-                 params$survey_recently_infected_options)
-    expect_equal(params$survey_art_or_vls_options[[1]]$id,
-                 scalar("art_coverage"))
-    expect_equal(params$survey_art_or_vls_options[[2]]$id, scalar("vls"))
-    expect_length(params$art_t1_options, 32)
-    expect_equal(params$art_t1_options[[1]]$id, scalar("445"))
-    expect_equal(params$art_t1_options[[1]]$label, scalar("Jan-Mar 2011"))
-    expect_equal(params$art_t2_options, params$art_t1_options)
-    expect_length(params$anc_prevalence_t1_options, 29)
-    expect_equal(params$anc_prevalence_t1_options[[1]]$id, scalar("447"))
-    expect_equal(params$anc_prevalence_t1_options[[1]]$label,
-                 scalar("Jul-Sep 2011"))
-    expect_equal(params$anc_prevalence_t1_options,
-                 params$anc_prevalence_t2_options)
-    expect_equal(params$anc_prevalence_t1_options,
-                 params$anc_art_coverage_t1_options)
-    expect_equal(params$anc_prevalence_t1_options,
-                 params$anc_art_coverage_t2_options)
   })
+  expect_length(args[[1]], 2)
+  expect_true(grepl('"label": "ART"', args[[1]][[1]]))
+  expect_true(grepl('"label": "ANC"', args[[1]][[1]]))
+  params <- args[[1]][[2]]
+  expect_equal(names(params),
+               c("area_scope_options", "area_scope_default", "area_level_options",
+                 "t1_options", "t2_options", "survey_prevalence_options",
+                 "survey_art_coverage_options", "survey_vls_options",
+                 "survey_recently_infected_options", "survey_art_or_vls_options",
+                 "art_t1_options", "art_t2_options", "anc_prevalence_t1_options",
+                 "anc_prevalence_t2_options", "anc_art_coverage_t1_options",
+                 "anc_art_coverage_t2_options"))
+
+  expect_length(params$area_scope_options, 1)
+  expect_equal(names(params$area_scope_options[[1]]),
+               c("id", "label", "children"))
+  expect_equal(params$area_scope_options[[1]]$id, scalar("MWI"))
+  expect_equal(params$area_scope_options[[1]]$label, scalar("Malawi"))
+  expect_length(params$area_scope_options[[1]]$children, 3)
+  expect_equal(params$area_scope_default, scalar("MWI"))
+  expect_equal(params$area_level_options, list(
+    list(
+      id = scalar("0"),
+      label = scalar("Country")
+    ),
+    list(
+      id = scalar("1"),
+      label = scalar("Region")
+    ),
+    list(
+      id = scalar("2"),
+      label = scalar("Zone")
+    ),
+    list(
+      id = scalar("3"),
+      label = scalar("District")
+    ),
+    list(
+      id = scalar("4"),
+      label = scalar("District + Metro")
+    )))
+  expect_equal(params$t1_options[[length(params$t1_options)]]$id,
+               scalar("449"))
+  expect_equal(params$t1_options[[length(params$t1_options)]]$label,
+               scalar("Jan-Mar 2012"))
+  expect_true(length(params$t1_options) >= 32)
+  expect_equal(params$t1_options[[length(params$t2_options)]]$id,
+               scalar("449"))
+  expect_equal(params$t1_options[[length(params$t2_options)]]$label,
+               scalar("Jan-Mar 2012"))
+  expect_true(length(params$t2_options) >= 32)
+  expect_length(params$survey_prevalence_options, 4)
+  expect_equal(params$survey_prevalence_options[[1]]$id,
+               scalar("MWI2016PHIA"))
+  expect_equal(params$survey_prevalence_options[[1]]$label,
+               scalar("MWI2016PHIA"))
+  expect_equal(params$survey_prevalence_options,
+               params$survey_art_coverage_options)
+  expect_equal(params$survey_prevalence_options,
+               params$survey_vls_options)
+  expect_equal(params$survey_prevalence_options,
+               params$survey_recently_infected_options)
+  expect_equal(params$survey_art_or_vls_options[[1]]$id,
+               scalar("art_coverage"))
+  expect_equal(params$survey_art_or_vls_options[[2]]$id, scalar("vls"))
+  expect_length(params$art_t1_options, 32)
+  expect_equal(params$art_t1_options[[1]]$id, scalar("445"))
+  expect_equal(params$art_t1_options[[1]]$label, scalar("Jan-Mar 2011"))
+  expect_equal(params$art_t2_options, params$art_t1_options)
+  expect_length(params$anc_prevalence_t1_options, 29)
+  expect_equal(params$anc_prevalence_t1_options[[1]]$id, scalar("447"))
+  expect_equal(params$anc_prevalence_t1_options[[1]]$label,
+               scalar("Jul-Sep 2011"))
+  expect_equal(params$anc_prevalence_t1_options,
+               params$anc_prevalence_t2_options)
+  expect_equal(params$anc_prevalence_t1_options,
+               params$anc_art_coverage_t1_options)
+  expect_equal(params$anc_prevalence_t1_options,
+               params$anc_art_coverage_t2_options)
 })
 
 test_that("do_endpoint_model_options without programme data", {
@@ -141,79 +140,78 @@ test_that("do_endpoint_model_options without programme data", {
   with_mock("hintr:::build_json" = mock_build_json,  {
     json <- do_endpoint_model_options(shape, survey, NULL, NULL)
     args <- mockery::mock_args(mock_build_json)
-    expect_length(args[[1]], 2)
-    expect_false(grepl('"label": "ART"', args[[1]][[1]]))
-    expect_false(grepl('"label": "ANC"', args[[1]][[1]]))
-    params <- args[[1]][[2]]
-    expect_equal(names(params),
-      c("area_scope_options", "area_scope_default", "area_level_options",
-        "t1_options", "t2_options", "survey_prevalence_options",
-        "survey_art_coverage_options", "survey_vls_options",
-        "survey_recently_infected_options", "survey_art_or_vls_options",
-        "art_t1_options", "art_t2_options", "anc_prevalence_t1_options",
-        "anc_prevalence_t2_options", "anc_art_coverage_t1_options",
-        "anc_art_coverage_t2_options"))
-
-    expect_length(params$area_scope_options, 1)
-    expect_equal(names(params$area_scope_options[[1]]),
-                 c("id", "label", "children"))
-    expect_equal(params$area_scope_options[[1]]$id, scalar("MWI"))
-    expect_equal(params$area_scope_options[[1]]$label, scalar("Malawi"))
-    expect_length(params$area_scope_options[[1]]$children, 3)
-    expect_equal(params$area_scope_default$id, scalar("MWI"))
-    expect_equal(params$area_scope_default$label, scalar("Malawi"))
-    expect_equal(params$area_level_options, list(
-      list(
-        id = scalar("0"),
-        label = scalar("Country")
-      ),
-      list(
-        id = scalar("1"),
-        label = scalar("Region")
-      ),
-      list(
-        id = scalar("2"),
-        label = scalar("Zone")
-      ),
-      list(
-        id = scalar("3"),
-        label = scalar("District")
-      ),
-      list(
-        id = scalar("4"),
-        label = scalar("District + Metro")
-      )))
-    expect_equal(params$t1_options[[length(params$t1_options)]]$id,
-                 scalar("449"))
-    expect_equal(params$t1_options[[length(params$t1_options)]]$label,
-                 scalar("Jan-Mar 2012"))
-    expect_true(length(params$t1_options) >= 32)
-    expect_equal(params$t1_options[[length(params$t1_options)]]$id,
-                 scalar("449"))
-    expect_equal(params$t1_options[[length(params$t2_options)]]$label,
-                 scalar("Jan-Mar 2012"))
-    expect_true(length(params$t2_options) >= 32)
-    expect_length(params$survey_prevalence_options, 4)
-    expect_equal(params$survey_prevalence_options[[1]]$id,
-                 scalar("MWI2016PHIA"))
-    expect_equal(params$survey_prevalence_options[[1]]$label,
-                 scalar("MWI2016PHIA"))
-    expect_equal(params$survey_prevalence_options,
-                 params$survey_art_coverage_options)
-    expect_equal(params$survey_prevalence_options,
-                 params$survey_vls_options)
-    expect_equal(params$survey_prevalence_options,
-                 params$survey_recently_infected_options)
-    expect_equal(params$survey_art_or_vls_options[[1]]$id,
-                 scalar("art_coverage"))
-    expect_equal(params$survey_art_or_vls_options[[2]]$id, scalar("vls"))
-    expect_null(params$art_t1_options)
-    expect_null(params$art_t2_options)
-    expect_null(params$anc_prevalence_t1_options)
-    expect_null(params$anc_prevalence_t2_options)
-    expect_null(params$anc_art_coverage_t1_options)
-    expect_null(params$anc_art_coverage_t2_options)
   })
+  expect_length(args[[1]], 2)
+  expect_false(grepl('"label": "ART"', args[[1]][[1]]))
+  expect_false(grepl('"label": "ANC"', args[[1]][[1]]))
+  params <- args[[1]][[2]]
+  expect_equal(names(params),
+               c("area_scope_options", "area_scope_default", "area_level_options",
+                 "t1_options", "t2_options", "survey_prevalence_options",
+                 "survey_art_coverage_options", "survey_vls_options",
+                 "survey_recently_infected_options", "survey_art_or_vls_options",
+                 "art_t1_options", "art_t2_options", "anc_prevalence_t1_options",
+                 "anc_prevalence_t2_options", "anc_art_coverage_t1_options",
+                 "anc_art_coverage_t2_options"))
+
+  expect_length(params$area_scope_options, 1)
+  expect_equal(names(params$area_scope_options[[1]]),
+               c("id", "label", "children"))
+  expect_equal(params$area_scope_options[[1]]$id, scalar("MWI"))
+  expect_equal(params$area_scope_options[[1]]$label, scalar("Malawi"))
+  expect_length(params$area_scope_options[[1]]$children, 3)
+  expect_equal(params$area_scope_default, scalar("MWI"))
+  expect_equal(params$area_level_options, list(
+    list(
+      id = scalar("0"),
+      label = scalar("Country")
+    ),
+    list(
+      id = scalar("1"),
+      label = scalar("Region")
+    ),
+    list(
+      id = scalar("2"),
+      label = scalar("Zone")
+    ),
+    list(
+      id = scalar("3"),
+      label = scalar("District")
+    ),
+    list(
+      id = scalar("4"),
+      label = scalar("District + Metro")
+    )))
+  expect_equal(params$t1_options[[length(params$t1_options)]]$id,
+               scalar("449"))
+  expect_equal(params$t1_options[[length(params$t1_options)]]$label,
+               scalar("Jan-Mar 2012"))
+  expect_true(length(params$t1_options) >= 32)
+  expect_equal(params$t1_options[[length(params$t1_options)]]$id,
+               scalar("449"))
+  expect_equal(params$t1_options[[length(params$t2_options)]]$label,
+               scalar("Jan-Mar 2012"))
+  expect_true(length(params$t2_options) >= 32)
+  expect_length(params$survey_prevalence_options, 4)
+  expect_equal(params$survey_prevalence_options[[1]]$id,
+               scalar("MWI2016PHIA"))
+  expect_equal(params$survey_prevalence_options[[1]]$label,
+               scalar("MWI2016PHIA"))
+  expect_equal(params$survey_prevalence_options,
+               params$survey_art_coverage_options)
+  expect_equal(params$survey_prevalence_options,
+               params$survey_vls_options)
+  expect_equal(params$survey_prevalence_options,
+               params$survey_recently_infected_options)
+  expect_equal(params$survey_art_or_vls_options[[1]]$id,
+               scalar("art_coverage"))
+  expect_equal(params$survey_art_or_vls_options[[2]]$id, scalar("vls"))
+  expect_null(params$art_t1_options)
+  expect_null(params$art_t2_options)
+  expect_null(params$anc_prevalence_t1_options)
+  expect_null(params$anc_prevalence_t2_options)
+  expect_null(params$anc_art_coverage_t1_options)
+  expect_null(params$anc_art_coverage_t2_options)
 })
 
 test_that("can retrieve validated model options", {
@@ -243,14 +241,8 @@ test_that("can retrieve validated model options", {
     "Malawi"
   )
   expect_equal(
-    names(general_section$controlGroups[[1]]$controls[[1]]$value),
-    c("id", "label"))
-  expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$value$id,
+    general_section$controlGroups[[1]]$controls[[1]]$value,
     "MWI")
-  expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$value$label,
-    "Malawi")
   expect_length(
     general_section$controlGroups[[2]]$controls[[1]]$options,
     5

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -73,23 +73,23 @@ test_that("do_endpoint_model_options correctly builds params list", {
     expect_equal(params$area_scope_default$label, scalar("Malawi"))
     expect_equal(params$area_level_options, list(
       list(
-        id = scalar(0),
+        id = scalar("0"),
         label = scalar("Country")
       ),
       list(
-        id = scalar(1),
+        id = scalar("1"),
         label = scalar("Region")
       ),
       list(
-        id = scalar(2),
+        id = scalar("2"),
         label = scalar("Zone")
       ),
       list(
-        id = scalar(3),
+        id = scalar("3"),
         label = scalar("District")
       ),
       list(
-        id = scalar(4),
+        id = scalar("4"),
         label = scalar("District + Metro")
       )))
     expect_equal(params$t1_options[[length(params$t1_options)]]$id,
@@ -164,23 +164,23 @@ test_that("do_endpoint_model_options without programme data", {
     expect_equal(params$area_scope_default$label, scalar("Malawi"))
     expect_equal(params$area_level_options, list(
       list(
-        id = scalar(0),
+        id = scalar("0"),
         label = scalar("Country")
       ),
       list(
-        id = scalar(1),
+        id = scalar("1"),
         label = scalar("Region")
       ),
       list(
-        id = scalar(2),
+        id = scalar("2"),
         label = scalar("Zone")
       ),
       list(
-        id = scalar(3),
+        id = scalar("3"),
         label = scalar("District")
       ),
       list(
-        id = scalar(4),
+        id = scalar("4"),
         label = scalar("District + Metro")
       )))
     expect_equal(params$t1_options[[length(params$t1_options)]]$id,
@@ -261,7 +261,7 @@ test_that("can retrieve validated model options", {
   )
   expect_equal(
     general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$id,
-    0)
+    "0")
   expect_equal(
     general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$label,
     "Country")
@@ -329,23 +329,23 @@ test_that("can read geojson level labels", {
   expect_length(levels, 5)
   expect_equal(levels, list(
     list(
-      id = scalar(0),
+      id = scalar("0"),
       label = scalar("Country")
     ),
     list(
-      id = scalar(1),
+      id = scalar("1"),
       label = scalar("Region")
     ),
     list(
-      id = scalar(2),
+      id = scalar("2"),
       label = scalar("Zone")
     ),
     list(
-      id = scalar(3),
+      id = scalar("3"),
       label = scalar("District")
     ),
     list(
-      id = scalar(4),
+      id = scalar("4"),
       label = scalar("District + Metro")
     )))
 })

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -63,10 +63,12 @@ test_that("do_endpoint_model_options correctly builds params list", {
         "anc_prevalence_t2_options", "anc_art_coverage_t1_options",
         "anc_art_coverage_t2_options"))
 
-    expect_equal(names(params$area_scope_options), c("id", "label", "children"))
-    expect_equal(params$area_scope_options$id, scalar("MWI"))
-    expect_equal(params$area_scope_options$label, scalar("Malawi"))
-    expect_length(params$area_scope_options$children, 3)
+    expect_length(params$area_scope_options, 1)
+    expect_equal(names(params$area_scope_options[[1]]),
+                 c("id", "label", "children"))
+    expect_equal(params$area_scope_options[[1]]$id, scalar("MWI"))
+    expect_equal(params$area_scope_options[[1]]$label, scalar("Malawi"))
+    expect_length(params$area_scope_options[[1]]$children, 3)
     expect_equal(params$area_scope_default$id, scalar("MWI"))
     expect_equal(params$area_scope_default$label, scalar("Malawi"))
     expect_equal(params$area_level_options, list(
@@ -152,10 +154,12 @@ test_that("do_endpoint_model_options without programme data", {
         "anc_prevalence_t2_options", "anc_art_coverage_t1_options",
         "anc_art_coverage_t2_options"))
 
-    expect_equal(names(params$area_scope_options), c("id", "label", "children"))
-    expect_equal(params$area_scope_options$id, scalar("MWI"))
-    expect_equal(params$area_scope_options$label, scalar("Malawi"))
-    expect_length(params$area_scope_options$children, 3)
+    expect_length(params$area_scope_options, 1)
+    expect_equal(names(params$area_scope_options[[1]]),
+                 c("id", "label", "children"))
+    expect_equal(params$area_scope_options[[1]]$id, scalar("MWI"))
+    expect_equal(params$area_scope_options[[1]]$label, scalar("Malawi"))
+    expect_length(params$area_scope_options[[1]]$children, 3)
     expect_equal(params$area_scope_default$id, scalar("MWI"))
     expect_equal(params$area_scope_default$label, scalar("Malawi"))
     expect_equal(params$area_level_options, list(
@@ -239,81 +243,81 @@ test_that("can retrieve validated model options", {
     "Malawi"
   )
   expect_equal(
-    names(general_section$controlGroups[[1]]$controls[[1]]$default),
+    names(general_section$controlGroups[[1]]$controls[[1]]$value),
     c("id", "label"))
   expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$default$id,
+    general_section$controlGroups[[1]]$controls[[1]]$value$id,
     "MWI")
   expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$default$label,
+    general_section$controlGroups[[1]]$controls[[1]]$value$label,
     "Malawi")
   expect_length(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]],
+    general_section$controlGroups[[2]]$controls[[1]]$options,
     5
   )
   expect_equal(
-    names(general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]),
+    names(general_section$controlGroups[[2]]$controls[[1]]$options[[1]]),
     c("id", "label")
   )
   expect_equal(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]$id,
+    general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$id,
     0)
   expect_equal(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]$label,
+    general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$label,
     "Country")
 
   survey_section <- json$controlSections[[2]]
   expect_length(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]],
+    survey_section$controlGroups[[1]]$controls[[1]]$options,
     4
   )
   expect_equal(
-    names(survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]),
+    names(survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$id,
+    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
     "MWI2016PHIA")
   expect_equal(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$label,
+    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
     "MWI2016PHIA")
 
   art_section <- json$controlSections[[3]]
   expect_length(
-    art_section$controlGroups[[1]]$controls[[1]]$options[[1]],
+    art_section$controlGroups[[1]]$controls[[1]]$options,
     32
   )
   expect_equal(
-    names(art_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]),
+    names(art_section$controlGroups[[1]]$controls[[1]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$id,
+    art_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
     "445")
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$label,
+    art_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
     "Jan-Mar 2011")
   expect_equal(
-    names(art_section$controlGroups[[1]]$controls[[2]]$options[[1]][[1]]),
+    names(art_section$controlGroups[[1]]$controls[[2]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[2]]$options[[1]][[1]]$id,
+    art_section$controlGroups[[1]]$controls[[2]]$options[[1]]$id,
     "445")
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[2]]$options[[1]][[1]]$label,
+    art_section$controlGroups[[1]]$controls[[2]]$options[[1]]$label,
     "Jan-Mar 2011")
 
   anc_section <- json$controlSections[[4]]
   expect_length(
-    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]],
+    anc_section$controlGroups[[1]]$controls[[1]]$options,
     29
   )
   expect_equal(
-    names(anc_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]),
+    names(anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$id,
+    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
     "447")
   expect_equal(
-    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$label,
+    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
     "Jul-Sep 2011")
 })
 

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -266,7 +266,7 @@ test_that("model run options are exposed", {
   )
   expect_equal(
     general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$id,
-    0)
+    "0")
   expect_equal(
     general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$label,
     "Country")

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -248,14 +248,8 @@ test_that("model run options are exposed", {
     "Malawi"
   )
   expect_equal(
-    names(general_section$controlGroups[[1]]$controls[[1]]$value),
-    c("id", "label"))
-  expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$value$id,
+    general_section$controlGroups[[1]]$controls[[1]]$value,
     "MWI")
-  expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$value$label,
-    "Malawi")
   expect_length(
     general_section$controlGroups[[2]]$controls[[1]]$options,
     5

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -248,81 +248,81 @@ test_that("model run options are exposed", {
     "Malawi"
   )
   expect_equal(
-    names(general_section$controlGroups[[1]]$controls[[1]]$default),
+    names(general_section$controlGroups[[1]]$controls[[1]]$value),
     c("id", "label"))
   expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$default$id,
+    general_section$controlGroups[[1]]$controls[[1]]$value$id,
     "MWI")
   expect_equal(
-    general_section$controlGroups[[1]]$controls[[1]]$default$label,
+    general_section$controlGroups[[1]]$controls[[1]]$value$label,
     "Malawi")
   expect_length(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]],
+    general_section$controlGroups[[2]]$controls[[1]]$options,
     5
   )
   expect_equal(
-    names(general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]),
+    names(general_section$controlGroups[[2]]$controls[[1]]$options[[1]]),
     c("id", "label")
   )
   expect_equal(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]$id,
+    general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$id,
     0)
   expect_equal(
-    general_section$controlGroups[[2]]$controls[[1]]$options[[1]][[1]]$label,
+    general_section$controlGroups[[2]]$controls[[1]]$options[[1]]$label,
     "Country")
 
   survey_section <- response$data$controlSections[[2]]
   expect_length(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]],
+    survey_section$controlGroups[[1]]$controls[[1]]$options,
     4
   )
   expect_equal(
-    names(survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]),
+    names(survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$id,
+    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
     "MWI2016PHIA")
   expect_equal(
-    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$label,
+    survey_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
     "MWI2016PHIA")
 
   art_section <- response$data$controlSections[[3]]
   expect_length(
-    art_section$controlGroups[[1]]$controls[[1]]$options[[1]],
+    art_section$controlGroups[[1]]$controls[[1]]$options,
     32
   )
   expect_equal(
-    names(art_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]),
+    names(art_section$controlGroups[[1]]$controls[[1]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$id,
+    art_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
     "445")
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$label,
+    art_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
     "Jan-Mar 2011")
   expect_equal(
-    names(art_section$controlGroups[[1]]$controls[[2]]$options[[1]][[1]]),
+    names(art_section$controlGroups[[1]]$controls[[2]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[2]]$options[[1]][[1]]$id,
+    art_section$controlGroups[[1]]$controls[[2]]$options[[1]]$id,
     "445")
   expect_equal(
-    art_section$controlGroups[[1]]$controls[[2]]$options[[1]][[1]]$label,
+    art_section$controlGroups[[1]]$controls[[2]]$options[[1]]$label,
     "Jan-Mar 2011")
 
   anc_section <- response$data$controlSections[[4]]
   expect_length(
-    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]],
+    anc_section$controlGroups[[1]]$controls[[1]]$options,
     29
   )
   expect_equal(
-    names(anc_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]),
+    names(anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]),
     c("id", "label"))
   expect_equal(
-    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$id,
+    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
     "447")
   expect_equal(
-    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]][[1]]$label,
+    anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
     "Jul-Sep 2011")
 })
 


### PR DESCRIPTION
This PR will
* Add a test to ensure that all json schema sections have a type declared
* Update model run options schema and code to make it valid now that the schema is actually being checked
* Fix some other discovered typos in schema

This also includes the changes in #57 which were what showed this bug in the first place

@hillalex Do you want to confirm the changes to ModelRunOptions schema work for you?

Note: This requires https://github.com/mrc-ide/naomi/pull/20 to be merged before it will work