### PR TITLE
make programme and anc default to null

### DIFF
--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -50,7 +50,7 @@ api <- function(port = 8888, queue_id = NULL, workers = 2) {
 #'
 #' @return Function to generate model options from input data.
 #' @keywords internal
-endpoint_model_options <- function(req, res, shape, survey, programme, anc) {
+endpoint_model_options <- function(req, res, shape, survey, programme =  NULL, anc = NULL) {
   response <- with_success({
     ## Shape and survey must exist
     assert_file_exists(shape$path)

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -467,8 +467,7 @@ test_that("endpoint_model_options can be run without programme data", {
   shape_file <- list(path = shape, hash = "12345", filename = "original")
   survey_file <- list(path = survey, hash = "12345", filename = "original")
 
-  response <- endpoint_model_options(NULL, res, shape_file, survey_file, NULL,
-                                     NULL)
+  response <- endpoint_model_options(NULL, res, shape_file, survey_file)
   json <- jsonlite::parse_json(response)
 
   expect_equal(res$status, 200)


### PR DESCRIPTION
Fixes bug where an absence of programme or anc data causes an error like
`argument "programme" is missing, with no default`