### PR TITLE
Return model run status to front end

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     plumber,
     R6,
     redux,
-    rrq (>= 0.2.0),
+    rrq (>= 0.2.1),
     specio
 Suggests:
     callr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,11 +16,11 @@ RoxygenNote: 6.1.1
 Additional_repositories: https://mrc-ide.github.io/drat
 Imports:
     docopt,
-    geojsonio,
+    geojsonio (>=0.8.0),
     glue,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 0.0.12),
+    naomi (>= 0.0.14),
     plumber,
     R6,
     redux,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ RoxygenNote: 6.1.1
 Additional_repositories: https://mrc-ide.github.io/drat
 Imports:
     docopt,
-    geojsonio (>=0.8.0),
+    geojsonio (>= 0.8.0),
     glue,
     ids,
     jsonlite (>= 1.2.2),

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -87,6 +87,7 @@ endpoint_model_status <- function(queue) {
     response <- with_success(
       queue$status(id))
     if (response$success) {
+      response$value <- progress()
       response$value <- lapply(response$value, scalar)
       response$value$id <- scalar(id)
     } else {

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -370,7 +370,7 @@ prepare_status_response <- function(value, id) {
     }
   }
 
-  response_value <- lapply(value[-which(names(value) == "progress")], scalar)
+  response_value <- lapply(value[names(value) != "progress"], scalar)
   response_value$progress <- lapply(value$progress, set_scalar)
   response_value$id <- scalar(id)
   response_value

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -89,8 +89,6 @@ endpoint_model_status <- function(queue) {
     if (response$success) {
       response$value <- lapply(response$value, scalar)
       response$value$id <- scalar(id)
-      response$value$progress <- scalar("50%")
-      response$value$timeRemaining <- scalar("10s")
     } else {
       response$errors <- hintr_errors(
         list("FAILED_TO_RETRIEVE_STATUS" = response$message))

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -87,9 +87,7 @@ endpoint_model_status <- function(queue) {
     response <- with_success(
       queue$status(id))
     if (response$success) {
-      response$value <- progress()
-      response$value <- lapply(response$value, scalar)
-      response$value$id <- scalar(id)
+      response$value <- prepare_status_response(response$value, id)
     } else {
       response$errors <- hintr_errors(
         list("FAILED_TO_RETRIEVE_STATUS" = response$message))
@@ -361,6 +359,21 @@ endpoint_hintr_worker_status <- function(queue) {
 
 api_root <- function() {
   scalar("Welcome to hintr")
+}
+
+prepare_status_response <- function(value, id) {
+  set_scalar <- function(x) {
+    if (length(names(x)) > 1) {
+      lapply(x, set_scalar)
+    } else {
+      scalar(x)
+    }
+  }
+
+  response_value <- lapply(value[-which(names(value) == "progress")], scalar)
+  response_value$progress <- lapply(value$progress, set_scalar)
+  response_value$id <- scalar(id)
+  response_value
 }
 
 

--- a/R/queue.R
+++ b/R/queue.R
@@ -30,7 +30,6 @@ Queue <- R6::R6Class(
     },
 
     status = function(id) {
-      browser()
       status <- unname(self$queue$task_status(id))
       done <- c("ERROR", "COMPLETE")
       incomplete <- c("MISSING")

--- a/R/queue.R
+++ b/R/queue.R
@@ -30,24 +30,29 @@ Queue <- R6::R6Class(
     },
 
     status = function(id) {
+      browser()
       status <- unname(self$queue$task_status(id))
       done <- c("ERROR", "COMPLETE")
       incomplete <- c("MISSING")
+      progress <- self$queue$task_progress(id)
       if (status %in% done) {
         list(done = TRUE,
              status = status,
              success = status == "COMPLETE",
-             queue = 0)
+             queue = 0,
+             progress = progress)
       } else if (status %in% incomplete) {
         list(done = json_verbatim("null"),
              status = status,
              success = json_verbatim("null"),
-             queue = self$queue$task_position(id))
+             queue = self$queue$task_position(id),
+             progress = progress)
       } else {
         list(done = FALSE,
              status = status,
              success = json_verbatim("null"),
-             queue = self$queue$task_position(id))
+             queue = self$queue$task_position(id),
+             progress = progress)
       }
     },
 

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -19,12 +19,12 @@ run_model <- function(data, options) {
     progress_complete <- list(
       list(
         started = TRUE,
-        completed = TRUE,
+        complete = TRUE,
         name = "Started mock model"
       ),
       list(
         started = TRUE,
-        completed = FALSE,
+        complete = FALSE,
         name = "Finished mock model"
       )
     )

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -1,6 +1,35 @@
 run_model <- function(data, options) {
   if (use_mock_model()) {
+    progress_start <- list(
+      list(
+        started = TRUE,
+        complete = FALSE,
+        name = "Started mock model"
+      ),
+      list(
+        started = FALSE,
+        complete = FALSE,
+        name = "Finished mock model"
+      )
+    )
+
+    signalCondition(structure(list(message = progress_start),
+                              class = c("progress", "condition")))
     Sys.sleep(5)
+    progress_complete <- list(
+      list(
+        started = TRUE,
+        completed = TRUE,
+        name = "Started mock model"
+      ),
+      list(
+        started = TRUE,
+        completed = FALSE,
+        name = "Finished mock model"
+      )
+    )
+    signalCondition(structure(list(message = progress_complete),
+                              class = c("progress", "condition")))
     return(list(output_path = system_file("output", "malawi_output.RDS"),
          spectrum_path = system_file("output", "malawi_spectrum_download.zip"),
          summary_path = system_file("output", "malawi_summary_download.zip")))

--- a/inst/schema/ModelStatusResponse.schema.json
+++ b/inst/schema/ModelStatusResponse.schema.json
@@ -7,8 +7,10 @@
     "status": { "type": "string" },
     "success": { "type": [ "boolean", "null" ] },
     "queue": { "type": "integer" },
-    "progress": { "type": "string" },
-    "timeRemaining": { "type": "string" }
+    "progress": { 
+      "type": "array",
+      "items": "ProgressPhase.schema.json" 
+    },
   },
   "additionalProperties": false,
   "required": [
@@ -18,6 +20,5 @@
     "success",
     "queue",
     "progress",
-    "timeRemaining"
   ]
 }

--- a/inst/schema/ModelStatusResponse.schema.json
+++ b/inst/schema/ModelStatusResponse.schema.json
@@ -9,8 +9,8 @@
     "queue": { "type": "integer" },
     "progress": { 
       "type": "array",
-      "items": "ProgressPhase.schema.json" 
-    },
+      "items": { "$ref": "ProgressPhase.schema.json" }
+    }
   },
   "additionalProperties": false,
   "required": [
@@ -19,6 +19,6 @@
     "status",
     "success",
     "queue",
-    "progress",
+    "progress"
   ]
 }

--- a/inst/schema/ProgressPhase.schema.json
+++ b/inst/schema/ProgressPhase.schema.json
@@ -6,6 +6,8 @@
     "complete": "boolean",
     "value": "number",
     "name": "string",
-    "help_text"
-  }
+    "helpText": "string"
+  },
+  "additionalProperties": false,
+  "required": [ "started", "complete", "name" ]
 }

--- a/inst/schema/ProgressPhase.schema.json
+++ b/inst/schema/ProgressPhase.schema.json
@@ -2,11 +2,11 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
-    "started": "boolean",
-    "complete": "boolean",
-    "value": "number",
-    "name": "string",
-    "helpText": "string"
+    "started": { "type": "boolean" },
+    "complete": { "type": "boolean" },
+    "value": { "type": "number" },
+    "name": { "type": "string" },
+    "helpText": { "type": "string" }
   },
   "additionalProperties": false,
   "required": [ "started", "complete", "name" ]

--- a/inst/schema/ProgressPhase.schema.json
+++ b/inst/schema/ProgressPhase.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "started": "boolean",
+    "complete": "boolean",
+    "value": "number",
+    "name": "string",
+    "help_text"
+  }
+}

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -5,9 +5,13 @@ Sys.setenv("USE_MOCK_MODEL" = "true")
 ## up to date INLA build
 INLA:::inla.dynload.workaround()
 
-mock_model <- list(output_path = system_file("output", "malawi_output.RDS"),
-                   spectrum_path = system_file("output", "malawi_spectrum_download.zip"),
-                   summary_path = system_file("output", "malawi_summary_download.zip"))
+## Create mock model if files exist
+mock_model <- list(
+  output_path = system.file("output", "malawi_output.RDS", package = "hintr"),
+  spectrum_path = system.file("output", "malawi_spectrum_download.zip",
+                              package = "hintr"),
+  summary_path = system.file("output", "malawi_summary_download.zip",
+                             package = "hintr"))
 
 test_mock_model_available <- function() {
   lapply(mock_model, function(x) {

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -14,10 +14,10 @@ mock_model <- list(
                              package = "hintr"))
 
 test_mock_model_available <- function() {
-  lapply(mock_model, function(x) {
+  invisible(lapply(mock_model, function(x) {
     if(!file.exists(x)) {
       testthat::skip(sprintf(
         "Test data %s is missing - run ./scripts/build_test_data to create test data.", x))
     }
-  })
+  }))
 }

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -38,7 +38,7 @@ test_that("endpoint model run queues a model run", {
   expect_true("id" %in% names(response$data))
   expect_equal(res$status, 200)
 
-  ## Query for status
+  ## Query for status returns arbitrary R data
   res <- MockPlumberResponse$new()
   model_status <- endpoint_model_status(queue)
   status <- model_status(NULL, res, response$data$id)

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -49,6 +49,11 @@ test_that("endpoint model run queues a model run", {
   expect_equal(status$data$done, FALSE)
   expect_equal(status$data$status, "RUNNING")
   expect_equal(status$data$queue, 0)
+  expect_length(status$data$progress, 2)
+  expect_equal(status$data$progress[[1]]$name, "Started mock model")
+  expect_false(status$data$progress[[1]]$complete)
+  expect_equal(status$data$progress[[2]]$name, "Finished mock model")
+  expect_false(status$data$progress[[2]]$complete)
 
   ## Wait for complete and query for status
   ## Query for status
@@ -63,6 +68,11 @@ test_that("endpoint model run queues a model run", {
   expect_equal(status$data$status, "COMPLETE")
   expect_equal(status$data$queue, 0)
   expect_equal(status$data$success, TRUE)
+  expect_length(status$data$progress, 2)
+  expect_equal(status$data$progress[[1]]$name, "Started mock model")
+  expect_true(status$data$progress[[1]]$complete)
+  expect_equal(status$data$progress[[2]]$name, "Finished mock model")
+  expect_false(status$data$progress[[2]]$complete)
 
   ## Get the result
   res <- MockPlumberResponse$new()

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -581,3 +581,46 @@ test_that("endpoint_model_options fails without shape & survey data", {
   expect_equal(json$errors[[1]]$detail,
                "File at path NULL does not exist. Create it, or fix the path.")
 })
+
+test_that("can convert model status to scalar", {
+  progress <- list(
+    list(
+      started = TRUE,
+      complete = FALSE,
+      name = "Started mock model"
+    ),
+    list(
+      started = FALSE,
+      complete = FALSE,
+      name = "Finished mock model"
+    )
+  )
+  model_status <- list(
+    done = FALSE,
+    status = "RUNNING",
+    success = TRUE,
+    queue = 0,
+    progress = progress
+  )
+  response <- prepare_status_response(model_status, "id")
+  expected_response <- list(
+    done = scalar(FALSE),
+    status = scalar("RUNNING"),
+    success = scalar(TRUE),
+    queue = scalar(0),
+    progress = list(
+      list(
+        started = scalar(TRUE),
+        complete = scalar(FALSE),
+        name = scalar("Started mock model")
+      ),
+      list(
+        started = scalar(FALSE),
+        complete = scalar(FALSE),
+        name = scalar("Finished mock model")
+      )
+    ),
+    id = scalar("id")
+  )
+  expect_equal(response, expected_response)
+})

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -177,6 +177,11 @@ test_that("model interactions", {
     expect_equal(response$data$success, TRUE)
     expect_equal(response$data$queue, 0)
     expect_true("id" %in% names(response$data))
+    expect_length(response$data$progress, 2)
+    expect_equal(response$data$progress[[1]]$name, "Started mock model")
+    expect_true(response$data$progress[[1]]$complete)
+    expect_equal(response$data$progress[[2]]$name, "Finished mock model")
+    expect_false(response$data$progress[[2]]$complete)
   })
 
   ## Get the result


### PR DESCRIPTION
This PR will

* Get the progress from the queue and return it to the front end as part of the `model/status` endpoint
