### PR TITLE
mrc-658: add caching, starting with geojson

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     R6,
     redux,
     rrq (>= 0.2.1),
-    specio
+    specio,
+    storr
 Suggests:
     callr,
     covr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.0.12
+Version: 0.0.13
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 0.0.13
+
+* Caching enabled for geojson reading
+
 # hintr 0.0.12
 
 * Update model download endpoint from indicators to summary

--- a/R/cache.R
+++ b/R/cache.R
@@ -1,4 +1,19 @@
+# The caching layer logic is a bit complicated, in order to make the
+# cache flexible and no too annoying in tests.
+#
+# Each Queue object will create a cache within the package env
+# (hintenv$list), with a name corresponding to the current queue id,
+# and then set the current queue id (hintenv$current_id), and register
+# as a finaliser code to destroy their cache.
+#
+# This means that while a queue is active, the cache will work, but if
+# queue A is cleaned up after queue B is started, the cleanup will not
+# affect queue B, and queue A gets a clean cache.
+hintenv <- new.env(parent = emptyenv())
+hintenv$cache <- list()
+
 with_cache <- function(key, namespace, cache, expr) {
+  cache <- get_cache(cache)
   if (!is.null(cache) && cache$exists(key, namespace)) {
     return(cache$get(key, namespace))
   }
@@ -11,4 +26,21 @@ with_cache <- function(key, namespace, cache, expr) {
 
 new_cache <- function() {
   storr::storr_rds(tempfile(), compress = FALSE, mangle_key = FALSE)
+}
+
+get_cache <- function(cache) {
+  cache %||% if (!is.null(hintenv$current)) hintenv$cache[[hintenv$current]]
+}
+
+set_cache <- function(id) {
+  hintenv$cache[[id]] <- new_cache()
+  hintenv$current <- id
+}
+
+clear_cache <- function(id) {
+  x <- hintenv$cache[[id]]
+  if (!is.null(x)) {
+    x$destroy()
+    hintenv$cache[[id]] <- NULL
+  }
 }

--- a/R/cache.R
+++ b/R/cache.R
@@ -1,0 +1,14 @@
+with_cache <- function(key, namespace, cache, expr) {
+  if (!is.null(cache) && cache$exists(key, namespace)) {
+    return(cache$get(key, namespace))
+  }
+  value <- force(expr)
+  if (!is.null(cache)) {
+    cache$set(key, value, namespace, use_cache = FALSE)
+  }
+  value
+}
+
+new_cache <- function() {
+  storr::storr_rds(tempfile(), compress = FALSE, mangle_key = FALSE)
+}

--- a/R/queue.R
+++ b/R/queue.R
@@ -14,9 +14,13 @@ Queue <- R6::R6Class(
       con <- redux::hiredis()
 
       message("Starting queue")
-      self$queue <- rrq::rrq_controller(hintr_queue_id(queue_id), con)
+      queue_id <- hintr_queue_id(queue_id)
+      self$queue <- rrq::rrq_controller(queue_id, con)
 
       self$start(workers)
+
+      message("Creating cache")
+      set_cache(queue_id)
     },
 
     start = function(workers) {
@@ -69,6 +73,7 @@ Queue <- R6::R6Class(
     },
 
     finalize = function(queue) {
+      clear_cache(self$queue$keys$queue_id)
       if (self$cleanup_on_exit) {
         message("Stopping workers")
         self$queue$worker_stop()

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -1,8 +1,10 @@
 ## Read json and apply a class so we can use method dispatching for json
 hintr_geojson_read <- function(shape) {
-  json <- geojsonio::geojson_read(shape$path)
-  class(json) <- "geojson"
-  json
+  with_cache(shape$hash, "geojson", cache, {
+    json <- geojsonio::geojson_read(shape$path, method = "local")
+    class(json) <- "geojson"
+    json
+  })
 }
 
 read_geojson_regions <- function(shape) {

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -1,7 +1,7 @@
 ## Read json and apply a class so we can use method dispatching for json
 hintr_geojson_read <- function(shape, cache = NULL) {
   with_cache(shape$hash, "geojson", cache, {
-    json <- geojsonio::geojson_read(shape$path, method = "local")
+    json <- geojsonio::geojson_read(shape$path)
     class(json) <- "geojson"
     json
   })

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -1,5 +1,5 @@
 ## Read json and apply a class so we can use method dispatching for json
-hintr_geojson_read <- function(shape) {
+hintr_geojson_read <- function(shape, cache = NULL) {
   with_cache(shape$hash, "geojson", cache, {
     json <- geojsonio::geojson_read(shape$path, method = "local")
     class(json) <- "geojson"

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -1,0 +1,43 @@
+context("cache")
+
+test_that("with_cache does not call target expression on cache hit", {
+  cache <- new_cache()
+  key <- "aaa"
+  namespace <- "ns"
+  fn <- mockery::mock(1, 2, 3)
+  expect_equal(with_cache(key, namespace, cache, fn()), 1)
+  expect_equal(with_cache(key, namespace, cache, fn()), 1)
+
+  expect_equal(cache$get(key, namespace), 1)
+  expect_equal(cache$list(namespace), key)
+
+  mockery::expect_called(fn, 1)
+})
+
+test_that("with_cache calls target expression on cache miss, get on hit", {
+  cache <- new_cache()
+  key1 <- "aaa"
+  key2 <- "bbb"
+  namespace <- "ns"
+  fn <- mockery::mock(1, 2, 3)
+  unlockBinding("get", cache)
+  cache$get <- mockery::mock(-1, -2, -3)
+
+  expect_equal(with_cache(key1, namespace, cache, fn()), 1)
+  expect_equal(with_cache(key2, namespace, cache, fn()), 2)
+
+  expect_equal(with_cache(key1, namespace, cache, fn()), -1)
+  expect_equal(with_cache(key2, namespace, cache, fn()), -2)
+
+  mockery::expect_called(fn, 2)
+  mockery::expect_called(cache$get, 2)
+})
+
+test_that("with_cache calls target expression if cache is missing", {
+  key <- "aaa"
+  namespace <- "ns"
+  fn <- mockery::mock(1, 2, 3)
+  expect_equal(with_cache(key, namespace, NULL, fn()), 1)
+  expect_equal(with_cache(key, namespace, NULL, fn()), 2)
+  mockery::expect_called(fn, 2)
+})

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -41,3 +41,29 @@ test_that("with_cache calls target expression if cache is missing", {
   expect_equal(with_cache(key, namespace, NULL, fn()), 2)
   mockery::expect_called(fn, 2)
 })
+
+test_that("Global cache interaction", {
+  id <- ids::random_id()
+  set_cache(id)
+
+  cache <- hintenv$cache[[id]]
+  fn <- mockery::mock(1, 2, 3)
+  unlockBinding("get", cache)
+  cache$get <- mockery::mock(-1, -2, -3)
+
+  expect_identical(get_cache(NULL), cache)
+  expect_identical(get_cache(TRUE), TRUE)
+
+  expect_equal(with_cache("aaa", "ns", NULL, fn()), 1)
+  expect_equal(with_cache("aaa", "ns", NULL, fn()), -1)
+
+  mockery::expect_called(fn, 1)
+  mockery::expect_called(cache$get, 1)
+
+  clear_cache(id)
+  expect_null(get_cache(NULL))
+  expect_equal(with_cache("aaa", "ns", NULL, fn()), 2)
+
+  mockery::expect_called(fn, 2)
+  mockery::expect_called(cache$get, 1)
+})

--- a/tests/testthat/test-read-data.R
+++ b/tests/testthat/test-read-data.R
@@ -37,3 +37,12 @@ test_that("can read country from PJNZ", {
   pjnz <- file_object(file.path("testdata", "Botswana2018.PJNZ"))
   expect_equal(read_country(pjnz), "Botswana")
 })
+
+test_that("geojson read applies can use cache", {
+  cache <- new_cache()
+  path <- file.path("testdata", "malawi.geojson")
+  value <- hintr_geojson_read(path, cache)
+  h <- unname(tools::md5sum(path))
+  expect_equal(cache$list("geojson"), h)
+  expect_identical(hintr_geojson_read(path, cache), value)
+})

--- a/tests/testthat/test-read-data.R
+++ b/tests/testthat/test-read-data.R
@@ -40,9 +40,8 @@ test_that("can read country from PJNZ", {
 
 test_that("geojson read applies can use cache", {
   cache <- new_cache()
-  path <- file.path("testdata", "malawi.geojson")
+  path <- file_object(file.path("testdata", "malawi.geojson"))
   value <- hintr_geojson_read(path, cache)
-  h <- unname(tools::md5sum(path))
-  expect_equal(cache$list("geojson"), h)
+  expect_equal(cache$list("geojson"), path$hash)
   expect_identical(hintr_geojson_read(path, cache), value)
 })


### PR DESCRIPTION
This PR implements the first of potentially several caching operations to speed up slow queries. It caches the result of the geojson read, which gives a pretty major speed up (~1.4s per validation endpoint for me).

There is no testing that things run faster, as these are prone to failure with gc, and because they're fairly awkward to set up.  But we should think about whether there's enough to ensure that caching is being used to avoid regressions.

If you are testing this locally, be sure to unset `VALIDATE_JSON_SCHEMAS` before measuring any performance gain because that validation costs quite a bit (serialising the json).