### PR TITLE
MRC-691: provide an endpoint for stopping hintr and the workers

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^docker$
 ^README\.md\.in$
 ^README\.yml$
+^scripts$

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -24,6 +24,7 @@ api_build <- function(queue) {
             serializer = serializer_json_hintr())
   pr$handle("GET", "/hintr/worker/status", endpoint_hintr_worker_status(queue),
             serializer = serializer_json_hintr())
+  pr$handle("POST", "/hintr/stop", endpoint_hintr_stop(queue))
   pr$handle("GET", "/", api_root)
   pr
 }
@@ -354,6 +355,16 @@ endpoint_hintr_worker_status <- function(queue) {
   function(req, res) {
     response <- with_success(lapply(queue$queue$worker_status(), scalar))
     hintr_response(response, "HintrWorkerStatus")
+  }
+}
+
+endpoint_hintr_stop <- function(queue) {
+  force(queue)
+  function(req, res) {
+    message("Stopping workers")
+    queue$queue$worker_stop()
+    message("Quitting hintr")
+    quit(save = "no")
   }
 }
 

--- a/docker/bin/hintr_stop
+++ b/docker/bin/hintr_stop
@@ -1,0 +1,7 @@
+#!/usr/bin/env Rscript
+
+## Designed to work from the docker container so we assume hintr on
+## http://localhost:8888 for the conection. Because this will
+## terminate the process and stop the underlying docker exec there's
+## not a lot of point trying to sanitise anything here.
+tryCatch(httr::POST("http://localhost:8888/hintr/stop"), error = identity)

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -99,7 +99,7 @@ test_that("hintr API can be tested", {
 })
 
 test_that("plumber api can be built", {
-  api <- api_build()
+  api <- api_build(NULL)
   expect_s3_class(api, "plumber")
   expect_length(api$routes, 6)
   expect_equal(names(api$routes),

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -463,3 +463,18 @@ test_that("summary file download streams bytes", {
   })
 })
 
+test_that("can quit", {
+  test_mock_model_available()
+  server <- hintr_server()
+
+  expect_true(server$process$is_alive())
+
+  server$process$read_error_lines()
+
+  r <- tryCatch(
+    httr::POST(paste0(server$url, "/hintr/stop")),
+    error = identity)
+  expect_is(r, "error")
+
+  expect_false(server$process$is_alive())
+})


### PR DESCRIPTION
This PR is part of the "upgrade hintr" work. It provides an endpoint `POST /hintr/stop` that will take down the queue after stopping workers. It's not a nice endpoint as it will not actually return http content!  But I don't see obviously an API for doing this in plumber/httpuv nicely (a signal we could throw for example).

The shell script is designed to be called from the docker container via exec.