### PR TITLE
Add content-disposition header to download endpoints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.0.14
+Version: 0.0.15
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.0.15
+Version: 0.0.16
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.0.15
+
+* Add HEAD endpoints for summary and spectrum downloads
+
 # hintr 0.0.14
 
 * Return plotting metadata for barchart with the model result response

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# 0.0.15
+# hintr 0.0.16
+
+* Download endpoints return Content-Disposition headers
+
+# hintr 0.0.15
 
 * Add HEAD endpoints for summary and spectrum downloads
 

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -17,13 +17,13 @@ api_build <- function(queue) {
   pr$handle("GET", "/meta/plotting/<iso3>", endpoint_plotting_metadata,
             serializer = serializer_json_hintr())
   pr$handle("GET", "/download/spectrum/<id>", endpoint_download_spectrum(queue),
-            serializer = serializer_zip("naomi_spectrum_digest.zip"))
+            serializer = serializer_zip("naomi_spectrum_digest"))
   pr$handle("HEAD", "/download/spectrum/<id>", endpoint_download_spectrum(queue),
-            serializer = serializer_zip("naomi_spectrum_digest.zip"))
+            serializer = serializer_zip("naomi_spectrum_digest"))
   pr$handle("GET", "/download/summary/<id>", endpoint_download_summary(queue),
-            serializer = serializer_zip("naomi_summary.zip"))
+            serializer = serializer_zip("naomi_summary"))
   pr$handle("HEAD", "/download/summary/<id>", endpoint_download_summary(queue),
-            serializer = serializer_zip("naomi_summary.zip"))
+            serializer = serializer_zip("naomi_summary"))
   pr$handle("GET", "/hintr/version", endpoint_hintr_version,
             serializer = serializer_json_hintr())
   pr$handle("GET", "/hintr/worker/status", endpoint_hintr_worker_status(queue),
@@ -283,7 +283,11 @@ download <- function(queue, type) {
     path <- switch(type,
                    "spectrum" = response$value$spectrum_path,
                    "summary" = response$value$summary_path)
-    readBin(path, "raw", n = file.size(path))
+    out <- list(
+      bytes = readBin(path, "raw", n = file.size(path)),
+      id = id
+    )
+    out
   }
 }
 
@@ -420,9 +424,11 @@ serializer_zip <- function(filename) {
   function(val, req, res, errorHandler) {
     tryCatch({
       res$setHeader("Content-Type", "application/octet-stream")
+      short_id <- substr(val$id, 1, 5)
       res$setHeader("Content-Disposition",
-                    sprintf('attachment; filename="%s"', filename))
-      res$body <- val
+                    sprintf('attachment; filename="%s_%s.zip"',
+                            filename, short_id))
+      res$body <- val$bytes
       return(res$toResponse())
     }, error = function(e) {
       errorHandler(req, res, e)

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -17,13 +17,13 @@ api_build <- function(queue) {
   pr$handle("GET", "/meta/plotting/<iso3>", endpoint_plotting_metadata,
             serializer = serializer_json_hintr())
   pr$handle("GET", "/download/spectrum/<id>", endpoint_download_spectrum(queue),
-            serializer = serializer_zip())
+            serializer = serializer_zip("naomi_spectrum_digest.zip"))
   pr$handle("HEAD", "/download/spectrum/<id>", endpoint_download_spectrum(queue),
-            serializer = serializer_zip())
+            serializer = serializer_zip("naomi_spectrum_digest.zip"))
   pr$handle("GET", "/download/summary/<id>", endpoint_download_summary(queue),
-            serializer = serializer_zip())
+            serializer = serializer_zip("naomi_summary.zip"))
   pr$handle("HEAD", "/download/summary/<id>", endpoint_download_summary(queue),
-            serializer = serializer_zip())
+            serializer = serializer_zip("naomi_summary.zip"))
   pr$handle("GET", "/hintr/version", endpoint_hintr_version,
             serializer = serializer_json_hintr())
   pr$handle("GET", "/hintr/worker/status", endpoint_hintr_worker_status(queue),
@@ -416,10 +416,12 @@ serializer_json_hintr <- function() {
   }
 }
 
-serializer_zip <- function() {
+serializer_zip <- function(filename) {
   function(val, req, res, errorHandler) {
     tryCatch({
       res$setHeader("Content-Type", "application/octet-stream")
+      res$setHeader("Content-Disposition",
+                    sprintf('attachment; filename="%s"', filename))
       res$body <- val
       return(res$toResponse())
     }, error = function(e) {

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ $ curl -X POST -H 'Content-Type: application/json' \
 
     ],
     "data": {
-        "id": "9e9533716ae1ef229936a5175f9eda91"
+        "id": "fff14fcb70529a45668cddf8fab99bd3"
     }
 }
 ```
@@ -298,7 +298,7 @@ $ curl http://localhost:8888/model/status/{id}
         "progress": [
 
         ],
-        "id": "9e9533716ae1ef229936a5175f9eda91"
+        "id": "fff14fcb70529a45668cddf8fab99bd3"
     }
 }
 ```
@@ -339,11 +339,12 @@ $ curl -I http://localhost:8888/download/summary/{id}
 
 ```json
 HTTP/1.1 200 OK
-Date: Thu, 14 Nov 2019 15:39:06 GMT
+Date: Thu, 14 Nov 2019 16:04:02 GMT
 Content-Type: application/octet-stream
-Date: Thu, 14 Nov 2019 03:39:06 PM GMT
+Content-Disposition: attachment; filename="naomi_summary.zip"
+Date: Thu, 14 Nov 2019 04:04:02 PM GMT
 Connection: close
-Content-Length: 2530557
+Content-Length: 2530508
 
 ```
 Get the summary download
@@ -353,7 +354,7 @@ $ curl http://localhost:8888/download/summary/{id}
 ```
 
 ```json
-Hidden 11666 bytes of output
+Hidden 11632 bytes of output
 ```
 Headers for spectrum digest download
 
@@ -363,11 +364,12 @@ $ curl -I http://localhost:8888/download/spectrum/{id}
 
 ```json
 HTTP/1.1 200 OK
-Date: Thu, 14 Nov 2019 15:39:07 GMT
+Date: Thu, 14 Nov 2019 16:04:02 GMT
 Content-Type: application/octet-stream
-Date: Thu, 14 Nov 2019 03:39:07 PM GMT
+Content-Disposition: attachment; filename="naomi_spectrum_digest.zip"
+Date: Thu, 14 Nov 2019 04:04:02 PM GMT
 Connection: close
-Content-Length: 2530557
+Content-Length: 2530508
 
 ```
 Get the spectrum digest download
@@ -377,7 +379,7 @@ $ curl http://localhost:8888/download/spectrum/{id}
 ```
 
 ```json
-Hidden 11666 bytes of output
+Hidden 11632 bytes of output
 ```
 Get plotting metadata for Malawi
 
@@ -421,7 +423,7 @@ $ curl http://localhost:8888/hintr/version
 
     ],
     "data": {
-        "hintr": "0.0.14",
+        "hintr": "0.0.15",
         "naomi": "0.0.16",
         "rrq": "0.2.1"
     }
@@ -440,8 +442,8 @@ $ curl http://localhost:8888/hintr/worker/status
 
     ],
     "data": {
-        "vaccinated_indianabat_2": "IDLE",
-        "vaccinated_indianabat_1": "IDLE"
+        "unacknowledged_pilchard_2": "IDLE",
+        "unacknowledged_pilchard_1": "IDLE"
     }
 }
 ```

--- a/tests/testthat/helper-endpoint.R
+++ b/tests/testthat/helper-endpoint.R
@@ -27,11 +27,13 @@ build_validate_request <- function(pjnz) {
 MockPlumberResponse <- R6::R6Class("PlumberResponse", list(
   body = NULL,
   status = 200,
-  header = NULL,
-  setHeader = function(...) {
-    self$header <- paste(..., sep = ": ")
+  headers = list(),
+  setHeader = function(name, value) {
+    he <- list()
+    he[[name]] <- value
+    self$headers <- c(self$headers, he)
   },
   toResponse = function() {
-    list(header = self$header, body = self$body)
+    list(headers = self$headers, body = self$body)
   }
 ))

--- a/tests/testthat/test-endpoints-download.R
+++ b/tests/testthat/test-endpoints-download.R
@@ -41,10 +41,11 @@ test_that("indicator download returns bytes", {
   testthat::try_again(4, {
     Sys.sleep(2)
     download_summary <- endpoint_download_summary(queue)
-    bytes <- download_summary(NULL, res, response$data$id)
-    expect_type(bytes, "raw")
-    expect_length(bytes, file.size(system_file("output",
+    download <- download_summary(NULL, res, response$data$id)
+    expect_type(download$data, "raw")
+    expect_length(download$data, file.size(system_file("output",
                                                "malawi_summary_download.zip")))
+    expect_equal(download$id, response$data$id)
   })
 })
 
@@ -89,9 +90,10 @@ test_that("spectrum download returns bytes", {
   testthat::try_again(4, {
     Sys.sleep(2)
     download_spectrum <- endpoint_download_spectrum(queue)
-    bytes <- download_spectrum(NULL, res, response$data$id)
-    expect_type(bytes, "raw")
-    expect_length(bytes, file.size(system_file("output",
+    download <- download_spectrum(NULL, res, response$data$id)
+    expect_type(download$bytes, "raw")
+    expect_length(download$bytes, file.size(system_file("output",
                                                "malawi_spectrum_download.zip")))
+    expect_equal(download$id, response$data$id)
   })
 })

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -148,24 +148,46 @@ test_that("hintr json serializer supports splicing in json objects", {
 
   test <- '{"example_json":123}'
   response <- serializer(test, req, res, errorHandler)
-  expect_equal(response$header, "Content-Type: application/json")
+  expect_equal(names(response$headers), "Content-Type")
+  expect_equal(response$headers$`Content-Type`, "application/json")
   expect_match(response$body, '["{\\"example_json\\":123}"]', fixed = TRUE)
 
   ## Declaring test as a json object
+  res <- MockPlumberResponse$new()
   response <- serializer(json_verbatim(test), req, res, errorHandler)
-  expect_equal(response$header, "Content-Type: application/json")
+  expect_equal(names(response$headers), "Content-Type")
+  expect_equal(response$headers$`Content-Type`, "application/json")
   expect_match(response$body, test, fixed = TRUE)
 
   ## With a list
+  res <- MockPlumberResponse$new()
   test_list <- list(example_json = scalar(123))
   response <- serializer(test_list, req, res, errorHandler)
-  expect_equal(response$header, "Content-Type: application/json")
+  expect_equal(names(response$headers), "Content-Type")
+  expect_equal(response$headers$`Content-Type`, "application/json")
   expect_match(response$body, test, fixed = TRUE)
 
   ## With error handling
   ## When trying to convert a value to JSON which throws an error
   response <- serializer(stop("Throw error"), req, res, errorHandler)
   expect_equal(response, "Throw error")
+})
+
+test_that("serializer_zip sets headers and streams bytes", {
+  req <- '{"test":"example request"}'
+  res <- MockPlumberResponse$new()
+  errorHandler <- function(req, res, e) {
+    e$message
+  }
+
+  serializer <- serializer_zip("test_filename.zip")
+
+  output <- serializer("value", req, res, errorHandler)
+  expect_equal(output$body, "value")
+  expect_equal(names(output$headers), c("Content-Type", "Content-Disposition"))
+  expect_equal(output$headers$`Content-Type`, "application/octet-stream")
+  expect_equal(output$headers$`Content-Disposition`,
+               'attachment; filename="test_filename.zip"')
 })
 
 test_that("Schemas are draft-04", {

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -180,14 +180,15 @@ test_that("serializer_zip sets headers and streams bytes", {
     e$message
   }
 
-  serializer <- serializer_zip("test_filename.zip")
+  serializer <- serializer_zip("test")
 
-  output <- serializer("value", req, res, errorHandler)
+  output <- serializer(list(bytes = "value", id = "1234567"), req, res,
+                       errorHandler)
   expect_equal(output$body, "value")
   expect_equal(names(output$headers), c("Content-Type", "Content-Disposition"))
   expect_equal(output$headers$`Content-Type`, "application/octet-stream")
   expect_equal(output$headers$`Content-Disposition`,
-               'attachment; filename="test_filename.zip"')
+               'attachment; filename="test_12345.zip"')
 })
 
 test_that("Schemas are draft-04", {

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -433,8 +433,8 @@ test_that("spectrum file download streams bytes", {
     r <- httr::GET(paste0(server$url, "/download/spectrum/", response$data$id))
     expect_equal(httr::status_code(r), 200)
     expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
-    expect_equal(httr::headers(r)$`content-disposition`,
-                 'attachment; filename="naomi_spectrum_digest.zip"')
+    expect_match(httr::headers(r)$`content-disposition`,
+                 'attachment; filename="naomi_spectrum_digest_\\w+.zip"')
     ## Size of bytes is close to expected
     size <- as.numeric(httr::headers(r)$`content-length`)
     expect_true(size - size/10 <
@@ -472,8 +472,8 @@ test_that("summary file download streams bytes", {
     r <- httr::GET(paste0(server$url, "/download/summary/", response$data$id))
     expect_equal(httr::status_code(r), 200)
     expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
-    expect_equal(httr::headers(r)$`content-disposition`,
-                 'attachment; filename="naomi_summary.zip"')
+    expect_match(httr::headers(r)$`content-disposition`,
+                 'attachment; filename="naomi_summary\\w+.zip"')
     ## Size of bytes is close to expected
     size <- as.numeric(httr::headers(r)$`content-length`)
     expect_true(size - size/10 <

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -434,6 +434,8 @@ test_that("spectrum file download streams bytes", {
     r <- httr::GET(paste0(server$url, "/download/spectrum/", response$data$id))
     expect_equal(httr::status_code(r), 200)
     expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
+    expect_equal(httr::headers(r)$`content-disposition`,
+                 'attachment; filename="naomi_spectrum_digest.zip"')
     ## Size of bytes is close to expected
     size <- as.numeric(httr::headers(r)$`content-length`)
     expect_true(size - size/10 <
@@ -446,6 +448,8 @@ test_that("spectrum file download streams bytes", {
   r <- httr::HEAD(paste0(server$url, "/download/spectrum/", response$data$id))
   expect_equal(httr::status_code(r), 200)
   expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
+  expect_equal(httr::headers(r)$`content-disposition`,
+    'attachment; filename="naomi_spectrum_digest.zip"')
 })
 
 test_that("summary file download streams bytes", {
@@ -469,6 +473,8 @@ test_that("summary file download streams bytes", {
     r <- httr::GET(paste0(server$url, "/download/summary/", response$data$id))
     expect_equal(httr::status_code(r), 200)
     expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
+    expect_equal(httr::headers(r)$`content-disposition`,
+                 'attachment; filename="naomi_summary.zip"')
     ## Size of bytes is close to expected
     size <- as.numeric(httr::headers(r)$`content-length`)
     expect_true(size - size/10 <
@@ -481,6 +487,8 @@ test_that("summary file download streams bytes", {
   r <- httr::HEAD(paste0(server$url, "/download/summary/", response$data$id))
   expect_equal(httr::status_code(r), 200)
   expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
+  expect_equal(httr::headers(r)$`content-disposition`,
+               'attachment; filename="naomi_summary.zip"')
 })
 
 test_that("can quit", {

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -447,7 +447,7 @@ test_that("spectrum file download streams bytes", {
   r <- httr::HEAD(paste0(server$url, "/download/spectrum/", response$data$id))
   expect_equal(httr::status_code(r), 200)
   expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
-  expect_equal(httr::headers(r)$`content-disposition`,
+  expect_match(httr::headers(r)$`content-disposition`,
     'attachment; filename="naomi_spectrum_digest_\\w+.zip"')
 })
 
@@ -473,7 +473,7 @@ test_that("summary file download streams bytes", {
     expect_equal(httr::status_code(r), 200)
     expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
     expect_match(httr::headers(r)$`content-disposition`,
-                 'attachment; filename="naomi_summary\\w+.zip"')
+                 'attachment; filename="naomi_summary_\\w+.zip"')
     ## Size of bytes is close to expected
     size <- as.numeric(httr::headers(r)$`content-length`)
     expect_true(size - size/10 <
@@ -486,7 +486,7 @@ test_that("summary file download streams bytes", {
   r <- httr::HEAD(paste0(server$url, "/download/summary/", response$data$id))
   expect_equal(httr::status_code(r), 200)
   expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
-  expect_equal(httr::headers(r)$`content-disposition`,
+  expect_match(httr::headers(r)$`content-disposition`,
                'attachment; filename="naomi_summary_\\w+.zip"')
 })
 

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -448,7 +448,7 @@ test_that("spectrum file download streams bytes", {
   expect_equal(httr::status_code(r), 200)
   expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
   expect_equal(httr::headers(r)$`content-disposition`,
-    'attachment; filename="naomi_spectrum_digest.zip"')
+    'attachment; filename="naomi_spectrum_digest_\\w+.zip"')
 })
 
 test_that("summary file download streams bytes", {
@@ -487,7 +487,7 @@ test_that("summary file download streams bytes", {
   expect_equal(httr::status_code(r), 200)
   expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
   expect_equal(httr::headers(r)$`content-disposition`,
-               'attachment; filename="naomi_summary.zip"')
+               'attachment; filename="naomi_summary_\\w+.zip"')
 })
 
 test_that("can quit", {


### PR DESCRIPTION
This PR will

* add `Content-Disposition: attachment; filename="filename.zip"` header to download endpoints

We should merge this after #72 has been looked at as it builds on that