### PR TITLE
mrc-496: add generic error handler

### DIFF
--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -484,13 +484,15 @@ hintr_404_handler <- function(req, res) {
 # It's not possible to get the traceback at this point
 hintr_error_handler <- function(req, res, error) {
   res$status <- 500L
+  if (is.null(error$call)) {
+    call <- "<call missing>"
+  } else {
+    call <- paste(deparse(error$call), collapse = " ")
+  }
   detail <- sprintf(
     "Unexpected server error in '%s' : '%s' while doing '%s %s'",
-    paste(deparse(error$call) %||% "<call missing>", collapse = " "),
-    error$message,
-    req$REQUEST_METHOD,
-    req$PATH_INFO)
-  message(detail)
+    call, error$message, req$REQUEST_METHOD, req$PATH_INFO)
+  api_log("ERROR: %s", detail)
   errors <- hintr_errors(list("SERVER_ERROR" = detail))
   # This seems at odds with the default handler present in the plumber
   # package, and it also seems entirely undocumented.

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -33,7 +33,8 @@ api_build <- function(queue) {
 
   pr$registerHook("preroute", api_log_start)
   pr$registerHook("postserialize", api_log_end)
-  pr$set404Handler(hintr_404)
+  pr$set404Handler(hintr_404_handler)
+  pr$setErrorHandler(hintr_error_handler)
 
   pr
 }
@@ -465,7 +466,7 @@ serializer_zip <- function(filename) {
   }
 }
 
-hintr_404 <- function(req, res) {
+hintr_404_handler <- function(req, res) {
   res$status <- 404L
   detail <- sprintf("%s %s is not a valid hintr path",
                     req$REQUEST_METHOD, req$PATH_INFO)
@@ -478,4 +479,25 @@ hintr_404 <- function(req, res) {
   # here we return the object that will be passed into
   # jsonlite::toJSON (all scalars being appropriately treated).
   hintr_response(value, as_json = FALSE)
+}
+
+# It's not possible to get the traceback at this point
+hintr_error_handler <- function(req, res, error) {
+  res$status <- 500L
+  detail <- sprintf(
+    "Unexpected server error in '%s' : '%s' while doing '%s %s'",
+    paste(deparse(error$call) %||% "<call missing>", collapse = " "),
+    error$message,
+    req$REQUEST_METHOD,
+    req$PATH_INFO)
+  message(detail)
+  errors <- hintr_errors(list("SERVER_ERROR" = detail))
+  # This seems at odds with the default handler present in the plumber
+  # package, and it also seems entirely undocumented.
+  value <- list(success = FALSE,
+                errors = errors)
+  res$body <- hintr_response(value, as_json = TRUE)
+  # Setting a header with setHeader should work, but here messes it up
+  res$headers[["Content-Type"]] <- "application/json"
+  res
 }

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -679,3 +679,21 @@ test_that("error handler", {
                list(list(error = "SERVER_ERROR", detail = detail)))
   expect_identical(res$status, 500L)
 })
+
+test_that("error handler with no call", {
+  err <- simpleCondition("some error", NULL)
+  res <- MockPlumberResponse$new()
+  req <- list(REQUEST_METHOD = "POST",
+              PATH_INFO = "/my/path")
+  ans <- hintr_error_handler(req, res, err)
+  expect_is(ans, "PlumberResponse")
+  expect_is(ans$body, "json")
+  validate_json_schema(ans$body, "Response")
+  dat <- jsonlite::fromJSON(ans$body, simplifyVector = FALSE)
+  expect_equal(dat$status, "failure")
+  detail <- paste("Unexpected server error in '<call missing>' :",
+                  "'some error' while doing 'POST /my/path'")
+  expect_equal(dat$errors,
+               list(list(error = "SERVER_ERROR", detail = detail)))
+  expect_identical(res$status, 500L)
+})

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -519,3 +519,20 @@ test_that("404 pages have sensible schema", {
   expect_equal(dat$errors[[1]]$detail,
                "GET /meaning-of-life is not a valid hintr path")
 })
+
+test_that("Error handler is triggered", {
+  ## This test is ugly because it probably should be fixed.
+  server <- hintr_server()
+  r <- httr::GET(paste0(server$url, "/download/summary/asdfasdfa"))
+  expect_equal(r$status_code, 500)
+  expect_equal(r$headers[["content-type"]], "application/json")
+
+  dat <- httr::content(r, "parsed", encoding = "UTF-8")
+  expect_equal(dat$status, "failure")
+  expect_equal(dat$errors[[1]]$error,
+               "SERVER_ERROR")
+  detail <- paste("Unexpected server error in 'val$id' :",
+                  "'$ operator is invalid for atomic vectors' while doing",
+                  "'GET /download/summary/asdfasdfa'")
+  expect_equal(dat$errors[[1]]$detail, detail)
+})

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -531,7 +531,7 @@ test_that("Error handler is triggered", {
   expect_equal(dat$status, "failure")
   expect_equal(dat$errors[[1]]$error,
                "SERVER_ERROR")
-  detail <- paste("Unexpected server error in 'val$id' :",
+  detail <- paste("Unexpected server error in '<call missing>' :",
                   "'$ operator is invalid for atomic vectors' while doing",
                   "'GET /download/summary/asdfasdfa'")
   expect_equal(dat$errors[[1]]$detail, detail)


### PR DESCRIPTION
This PR adds a generic error handler.  The test case I'm using is not ideal as it's really a hintr bug, but it was useful in working out how to make plumber do the right thing!