### PR TITLE
Update filters returned in metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     glue,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 0.0.16),
+    naomi (>= 0.0.18),
     plumber,
     R6,
     redux,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.0.18
+Version: 0.0.19
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 0.0.19
+
+* Update filter ordering and naming
+
 # hintr 0.0.18
 
 * Update input data structures including

--- a/R/filters.R
+++ b/R/filters.R
@@ -134,7 +134,6 @@ get_model_output_filters <- function(data) {
 }
 
 get_quarter_filters <- function(data) {
-  browser()
   calendar_quarters <- unique(data$calendar_quarter)
   calendar_quarters <- sort(calendar_quarters, decreasing = TRUE)
   lapply(calendar_quarters, function(quarter) {
@@ -149,6 +148,7 @@ get_quarter_label <- function(calendar_quarter) {
 
 get_year_filters <- function(data) {
   years <- unique(data$year)
+  years <- sort(years, decreasing = TRUE)
   lapply(years, function(year) {
     list(id = scalar(as.character(year)),
          label = scalar(as.character(year)))

--- a/R/filters.R
+++ b/R/filters.R
@@ -109,7 +109,8 @@ get_model_output_filters <- function(data) {
       id = scalar("area"),
       column_id = scalar("area_id"),
       label = scalar("Area"),
-      options =
+      options = scalar(NA),
+      use_shape_regions = scalar(TRUE)
     ),
     list(
       id = scalar("quarter"),
@@ -133,7 +134,9 @@ get_model_output_filters <- function(data) {
 }
 
 get_quarter_filters <- function(data) {
+  browser()
   calendar_quarters <- unique(data$calendar_quarter)
+  calendar_quarters <- sort(calendar_quarters, decreasing = TRUE)
   lapply(calendar_quarters, function(quarter) {
     list(id = scalar(as.character(quarter)),
          label = scalar(get_quarter_label(quarter)))

--- a/R/filters.R
+++ b/R/filters.R
@@ -12,6 +12,16 @@ construct_filter <- function(data, id, name) {
   })
 }
 
+get_sex_filters <- function(data) {
+  sexes <- unique(data$sex)
+  lapply(sexes, function(sex) {
+    list(
+      id = scalar(sex),
+      label = scalar(to_upper_first(sex))
+    )
+  })
+}
+
 get_age_labels <- function(age_group) {
   age_groups <- naomi::get_age_groups()
   groups <- age_groups$age_group %in% age_group
@@ -96,16 +106,28 @@ read_long_indicator_filters <- function(data, type) {
 get_model_output_filters <- function(data) {
   list(
     list(
-      id = scalar("age"),
-      column_id = scalar("age_group"),
-      label = scalar("Age"),
-      options = get_age_filters(data)
+      id = scalar("area"),
+      column_id = scalar("area_id"),
+      label = scalar("Area"),
+      options =
     ),
     list(
       id = scalar("quarter"),
       column_id = scalar("calendar_quarter"),
       label = scalar("Period"),
       options = get_quarter_filters(data)
+    ),
+    list(
+      id = scalar("sex"),
+      column_id = scalar("sex"),
+      label = scalar("Sex"),
+      options = get_sex_filters(data)
+    ),
+    list(
+      id = scalar("age"),
+      column_id = scalar("age_group"),
+      label = scalar("Age"),
+      options = get_age_filters(data)
     )
   )
 }

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -34,7 +34,7 @@ Check each combination is unique in configuration.")
 
 get_barchart_metadata <- function(output) {
   metadata <- naomi::get_metadata()
-  metadata[
+  metadata <- metadata[
     metadata$data_type == "output" & metadata$plot_type == "barchart",
     c("indicator", "value_column", "error_low_column", "error_high_column",
       "indicator_column", "indicator_value", "name")]
@@ -44,7 +44,7 @@ get_barchart_metadata <- function(output) {
 get_choropleth_metadata <- function(output) {
   iso3 <- get_root_node(output$area_id)
   metadata <- naomi::get_plotting_metadata(iso3)
-  metadata[
+  metadata <- metadata[
     metadata$data_type == "output" & metadata$plot_type == "choropleth",
     c("indicator", "value_column", "indicator_column", "indicator_value",
       "name", "min", "max", "colour", "invert_scale")]

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -39,3 +39,16 @@ get_barchart_metadata <- function(output) {
     c("indicator", "value_column", "error_low_column", "error_high_column",
       "indicator_column", "indicator_value", "name")]
 }
+
+get_choropleth_metadata <- function(output) {
+  iso3 <- get_root_node(output$area_id)
+  metadata <- naomi::get_plotting_metadata(iso3)
+  metadata[
+    metadata$data_type == "output" & metadata$plot_type == "choropleth",
+    c("indicator", "value_column", "indicator_column", "indicator_value",
+      "name", "min", "max", "colour", "invert_scale")]
+}
+
+get_root_node <- function(area_ids) {
+  unique(area_ids[!grepl("\\_", area_ids)])
+}

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -38,6 +38,7 @@ get_barchart_metadata <- function(output) {
     metadata$data_type == "output" & metadata$plot_type == "barchart",
     c("indicator", "value_column", "error_low_column", "error_high_column",
       "indicator_column", "indicator_value", "name")]
+  metadata[order(metadata$indicator_value), ]
 }
 
 get_choropleth_metadata <- function(output) {
@@ -47,7 +48,9 @@ get_choropleth_metadata <- function(output) {
     metadata$data_type == "output" & metadata$plot_type == "choropleth",
     c("indicator", "value_column", "indicator_column", "indicator_value",
       "name", "min", "max", "colour", "invert_scale")]
+  metadata[order(metadata$indicator_value), ]
 }
+
 
 get_root_node <- function(area_ids) {
   unique(area_ids[!grepl("\\_", area_ids)])

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -45,10 +45,15 @@ select_data <- function(data) {
 
 process_result <- function(model_output) {
   output <- readRDS(model_output$output_path)
+  output_filters <- get_model_output_filters(output)
   metadata <- list(
     barchart = list(
       indicators = get_barchart_metadata(output),
-      filters = get_model_output_filters(output)
+      filters = output_filters
+    ),
+    choropleth = list(
+      indicators = get_choropleth_metadata(output),
+      filters = output_filters
     )
   )
   list(data = select_data(output),

--- a/inst/schema/ChoroplethMetadata.schema.json
+++ b/inst/schema/ChoroplethMetadata.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties" : {
+    "indicators" : {
+      "type": "array",
+      "items": { "$ref": "ChoroplethIndicatorMetadata.schema.json" }
+    },
+    "filters" : {
+      "type": "array",
+      "items": { "$ref": "Filter.schema.json" }
+    }
+  },
+  "additonalProperties": "false",
+  "required": [ "indicators", "filters" ]
+}

--- a/inst/schema/Filter.schema.json
+++ b/inst/schema/Filter.schema.json
@@ -12,8 +12,11 @@
       "type": "string"
     },
     "options": {
-      "type": "array",
+      "type": [ "array", "null" ],
       "items": { "$ref": "FilterOption.schema.json" }
+    },
+    "use_shape_regions": {
+      "type": [ "boolean", "null" ]
     }
   },
   "additonalProperties": "false",

--- a/inst/schema/ModelResultResponse.schema.json
+++ b/inst/schema/ModelResultResponse.schema.json
@@ -3,13 +3,14 @@
   "type": "object",
   "properties": {
     "data": { "$ref": "ModelResultData.schema.json" },
-    "plottingMetadata": { 
+    "plottingMetadata": {
       "type": "object",
       "properties": {
-        "barchart": { "$ref": "BarchartMetadata.schema.json" }
+        "barchart": { "$ref": "BarchartMetadata.schema.json" },
+        "choropleth": { "$ref": "ChoroplethMetadata.schema.json" }
       },
       "additionalProperties": false,
-      "required" : [ "barchart" ]
+      "required" : [ "barchart", "choropleth" ]
     }
   }
 }

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -92,8 +92,8 @@ test_that("endpoint model run queues a model run", {
   expect_equal(filters[[3]], "sex")
   expect_equal(filters[[4]], "age_group")
   expect_length(barchart$filters[[2]]$options, 2)
-  expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2016Q1")
-  expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2018Q3")
+  expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jul-Sep 2018")
   expect_length(barchart$filters[[4]]$options, 29)
   expect_length(barchart$indicators, 7)
 
@@ -131,8 +131,8 @@ test_that("endpoint model run queues a model run", {
   expect_equal(filters[[3]], "sex")
   expect_equal(filters[[4]], "age_group")
   expect_length(choropleth$filters[[2]]$options, 2)
-  expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2016Q1")
-  expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2018Q3")
+  expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jul-Sep 2018")
   expect_length(choropleth$filters[[4]]$options, 29)
   expect_length(choropleth$indicators, 7)
 

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -78,72 +78,77 @@ test_that("endpoint model run queues a model run", {
   ## Barchart
   barchart <- result$data$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters"))
-  expect_length(barchart$filters, 2)
+  expect_length(barchart$filters, 4)
   expect_equal(names(barchart$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(barchart$filters[[2]]),
                c("id", "column_id", "label", "options"))
   ## Choropleth has the correct filters in correct order
   filters <- lapply(barchart$filters, function(filter) {
     filter$column_id
   })
-  expect_equal(filters[[1]], "area")
+  expect_equal(filters[[1]], "area_id")
   expect_equal(filters[[2]], "calendar_quarter")
   expect_equal(filters[[3]], "sex")
   expect_equal(filters[[4]], "age_group")
   expect_length(barchart$filters[[2]]$options, 2)
   expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2016Q1")
   expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_length(barchart$filters[[4]]$options, 29)
+  expect_length(barchart$indicators, 7)
+
+  ## Quarters are in descending order
   calendar_quarters <-
     lapply(barchart$filters[[2]]$options, function(option) {
       option$id
     })
+  expect_equal(unlist(calendar_quarters),
+               sort(unlist(calendar_quarters), decreasing = TRUE))
 
-  ## Quarters are in descending order
-  expect_equal(calendar_quarters, sort(calendar_quarters, decreasing = TRUE))
-
-  expect_length(barchart$filters[[4]]$options, 29)
-  expect_length(barchart$indicators, 7)
 
   ## Barchart indicators are in numeric id order
   indicators <- lapply(barchart$indicators, function(indicator) {
     indicator$indicator
   })
-  expect_equal(indicators,
+  expect_equal(unlist(indicators),
                c("population", "prevalence", "plhiv", "art_coverage",
                  "current_art", "incidence", "new_infections"))
 
   ## Choropleth
   choropleth <- result$data$plottingMetadata$choropleth
   expect_equal(names(choropleth), c("indicators", "filters"))
-  expect_length(choropleth$filters, 2)
+  expect_length(choropleth$filters, 4)
   expect_equal(names(choropleth$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(choropleth$filters[[2]]),
                c("id", "column_id", "label", "options"))
   ## Choropleth has the correct filters in correct order
   filters <- lapply(choropleth$filters, function(filter) {
     filter$column_id
   })
-  expect_equal(filters[[1]], "area")
+  expect_equal(filters[[1]], "area_id")
   expect_equal(filters[[2]], "calendar_quarter")
   expect_equal(filters[[3]], "sex")
   expect_equal(filters[[4]], "age_group")
   expect_length(choropleth$filters[[2]]$options, 2)
   expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2016Q1")
   expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_length(choropleth$filters[[4]]$options, 29)
+  expect_length(choropleth$indicators, 7)
+
+  ## Quarters are in descending order
   calendar_quarters <-
     lapply(choropleth$filters[[2]]$options, function(option) {
       option$id
-  })
-
-  ## Quarters are in descending order
-  expect_equal(calendar_quarters, sort(calendar_quarters, decreasing = TRUE))
-
-  expect_length(choropleth$filters[[4]]$options, 29)
-  expect_length(choropleth$indicators, 7)
+    })
+  expect_equal(unlist(calendar_quarters),
+               sort(unlist(calendar_quarters), decreasing = TRUE))
 
   ## Choropleth indicators are in numeric id order
   indicators <- lapply(choropleth$indicators, function(indicator) {
     indicator$indicator
   })
-  expect_equal(indicators,
+  expect_equal(unlist(indicators),
                c("population", "prevalence", "plhiv", "art_coverage",
                  "current_art", "incidence", "new_infections"))
 })

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -72,16 +72,43 @@ test_that("endpoint model run queues a model run", {
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator_id", "mode", "mean", "lower", "upper"))
   expect_length(result$data$data, 84042)
-  expect_equal(names(result$data$plottingMetadata), "barchart")
+  expect_equal(names(result$data$plottingMetadata), c("barchart", "choropleth"))
+
   barchart <- result$data$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters"))
   expect_length(barchart$filters, 2)
+  expect_equal(names(barchart$filters[[1]]),
+               c("id", "column_id", "label", "options"))
   expect_equal(barchart$filters[[1]]$id, "age")
   expect_equal(barchart$filters[[2]]$id, "quarter")
   expect_length(barchart$filters[[1]]$options, 29)
   expect_length(barchart$filters[[2]]$options, 2)
+  expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2016Q1")
   expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
   expect_length(barchart$indicators, 7)
+  out <- lapply(barchart$indicators, function(indicator) {
+    expect_true(indicator$indicator %in%
+                  c("prevalence", "art_coverage", "current_art", "population",
+                    "plhiv", "incidence", "new_infections"))
+  })
+
+  choropleth <- result$data$plottingMetadata$choropleth
+  expect_equal(names(choropleth), c("indicators", "filters"))
+  expect_length(choropleth$filters, 2)
+  expect_equal(names(choropleth$filters[[1]]),
+               c("id", "column_id", "label", "options"))
+  expect_equal(choropleth$filters[[1]]$id, "age")
+  expect_equal(choropleth$filters[[2]]$id, "quarter")
+  expect_length(choropleth$filters[[1]]$options, 29)
+  expect_length(choropleth$filters[[2]]$options, 2)
+  expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2016Q1")
+  expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_length(choropleth$indicators, 7)
+  out <- lapply(choropleth$indicators, function(indicator) {
+    expect_true(indicator$indicator %in%
+                  c("prevalence", "art_coverage", "current_art", "population",
+                    "plhiv", "incidence", "new_infections"))
+  })
 })
 
 test_that("endpoint_run_model returns error if queueing fails", {

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -74,41 +74,78 @@ test_that("endpoint model run queues a model run", {
   expect_length(result$data$data, 84042)
   expect_equal(names(result$data$plottingMetadata), c("barchart", "choropleth"))
 
+
+  ## Barchart
   barchart <- result$data$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters"))
   expect_length(barchart$filters, 2)
   expect_equal(names(barchart$filters[[1]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(barchart$filters[[1]]$id, "age")
-  expect_equal(barchart$filters[[2]]$id, "quarter")
-  expect_length(barchart$filters[[1]]$options, 29)
+  ## Choropleth has the correct filters in correct order
+  filters <- lapply(barchart$filters, function(filter) {
+    filter$column_id
+  })
+  expect_equal(filters[[1]], "area")
+  expect_equal(filters[[2]], "calendar_quarter")
+  expect_equal(filters[[3]], "sex")
+  expect_equal(filters[[4]], "age_group")
   expect_length(barchart$filters[[2]]$options, 2)
   expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2016Q1")
   expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
-  expect_length(barchart$indicators, 7)
-  out <- lapply(barchart$indicators, function(indicator) {
-    expect_true(indicator$indicator %in%
-                  c("prevalence", "art_coverage", "current_art", "population",
-                    "plhiv", "incidence", "new_infections"))
-  })
+  calendar_quarters <-
+    lapply(barchart$filters[[2]]$options, function(option) {
+      option$id
+    })
 
+  ## Quarters are in descending order
+  expect_equal(calendar_quarters, sort(calendar_quarters, decreasing = TRUE))
+
+  expect_length(barchart$filters[[4]]$options, 29)
+  expect_length(barchart$indicators, 7)
+
+  ## Barchart indicators are in numeric id order
+  indicators <- lapply(barchart$indicators, function(indicator) {
+    indicator$indicator
+  })
+  expect_equal(indicators,
+               c("population", "prevalence", "plhiv", "art_coverage",
+                 "current_art", "incidence", "new_infections"))
+
+  ## Choropleth
   choropleth <- result$data$plottingMetadata$choropleth
   expect_equal(names(choropleth), c("indicators", "filters"))
   expect_length(choropleth$filters, 2)
   expect_equal(names(choropleth$filters[[1]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(choropleth$filters[[1]]$id, "age")
-  expect_equal(choropleth$filters[[2]]$id, "quarter")
-  expect_length(choropleth$filters[[1]]$options, 29)
+  ## Choropleth has the correct filters in correct order
+  filters <- lapply(choropleth$filters, function(filter) {
+    filter$column_id
+  })
+  expect_equal(filters[[1]], "area")
+  expect_equal(filters[[2]], "calendar_quarter")
+  expect_equal(filters[[3]], "sex")
+  expect_equal(filters[[4]], "age_group")
   expect_length(choropleth$filters[[2]]$options, 2)
   expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2016Q1")
   expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
-  expect_length(choropleth$indicators, 7)
-  out <- lapply(choropleth$indicators, function(indicator) {
-    expect_true(indicator$indicator %in%
-                  c("prevalence", "art_coverage", "current_art", "population",
-                    "plhiv", "incidence", "new_infections"))
+  calendar_quarters <-
+    lapply(choropleth$filters[[2]]$options, function(option) {
+      option$id
   })
+
+  ## Quarters are in descending order
+  expect_equal(calendar_quarters, sort(calendar_quarters, decreasing = TRUE))
+
+  expect_length(choropleth$filters[[4]]$options, 29)
+  expect_length(choropleth$indicators, 7)
+
+  ## Choropleth indicators are in numeric id order
+  indicators <- lapply(choropleth$indicators, function(indicator) {
+    indicator$indicator
+  })
+  expect_equal(indicators,
+               c("population", "prevalence", "plhiv", "art_coverage",
+                 "current_art", "incidence", "new_infections"))
 })
 
 test_that("endpoint_run_model returns error if queueing fails", {

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -292,8 +292,8 @@ test_that("possible filters are returned for data", {
     )
   ))
   expect_length(response$data$filters$year, 8)
-  expect_equal(response$data$filters$year[[1]]$id, "2011")
-  expect_equal(response$data$filters$year[[1]]$label, "2011")
+  expect_equal(response$data$filters$year[[1]]$id, "2018")
+  expect_equal(response$data$filters$year[[1]]$label, "2018")
 
   expect_length(response$data$filters$indicators, 1)
   expect_equal(response$data$filters$indicators[[1]]$id, "current_art")
@@ -313,8 +313,8 @@ test_that("possible filters are returned for data", {
 
   expect_equal(names(response$data$filters), c("year", "indicators"))
   expect_length(response$data$filters$year, 8)
-  expect_equal(response$data$filters$year[[1]]$id, "2011")
-  expect_equal(response$data$filters$year[[1]]$label, "2011")
+  expect_equal(response$data$filters$year[[1]]$id, "2018")
+  expect_equal(response$data$filters$year[[1]]$label, "2018")
 
   expect_length(response$data$filters$indicators, 2)
   expect_equal(response$data$filters$indicators[[1]]$id, "prevalence")
@@ -515,10 +515,10 @@ test_that("endpoint_model_options returns model options", {
     c("id", "label"))
   expect_equal(
     anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
-    "2011")
+    "2018")
   expect_equal(
     anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
-    "2011")
+    "2018")
 })
 
 test_that("endpoint_model_options can be run without programme data", {

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -360,12 +360,12 @@ test_that("possible filters are returned for data", {
   expect_equal(response$data$filters$indicators[[1]]$label, "Prevalence")
   expect_equal(response$data$filters$indicators[[2]]$id, "art_coverage")
   expect_equal(response$data$filters$indicators[[2]]$label, "ART coverage")
-  expect_equal(response$data$filters$indicators[[3]]$id, "vls")
+  expect_equal(response$data$filters$indicators[[3]]$id, "recent")
   expect_equal(response$data$filters$indicators[[3]]$label,
-               "Viral load suppression")
-  expect_equal(response$data$filters$indicators[[4]]$id, "recent")
-  expect_equal(response$data$filters$indicators[[4]]$label,
                "Proportion recently infected")
+  expect_equal(response$data$filters$indicators[[4]]$id, "vls")
+  expect_equal(response$data$filters$indicators[[4]]$label,
+               "Viral load suppression")
 })
 
 test_that("endpoint_plotting_metadata gets metadata", {

--- a/tests/testthat/test-filters.R
+++ b/tests/testthat/test-filters.R
@@ -81,16 +81,16 @@ test_that("get_year_filters returns year labels and ids", {
   data <- data.frame(year = c(2010, 2013, 2016))
   expected_filters <- list(
     list(
-      id = scalar("2010"),
-      label = scalar("2010")
+      id = scalar("2016"),
+      label = scalar("2016")
     ),
     list(
       id = scalar("2013"),
       label = scalar("2013")
     ),
     list(
-      id = scalar("2016"),
-      label = scalar("2016")
+      id = scalar("2010"),
+      label = scalar("2010")
     )
   )
   expect_equal(get_year_filters(data), expected_filters)

--- a/tests/testthat/test-filters.R
+++ b/tests/testthat/test-filters.R
@@ -63,7 +63,7 @@ test_that("get_survey_filters gets available filter options and sorts them", {
 })
 
 test_that("get_quarter_filters gets quarter names from ids", {
-  data <- data.frame(calendar_quarter = c("CY2016Q1", "CY2013Q2"))
+  data <- data.frame(calendar_quarter = c("CY2013Q2", "CY2016Q1"))
   expected_filters <- list(
     list(
       id = scalar("CY2016Q1"),

--- a/tests/testthat/test-filters.R
+++ b/tests/testthat/test-filters.R
@@ -215,10 +215,10 @@ test_that("can get indicator filters for survey data", {
   expect_equal(filters[[1]]$label, scalar("Prevalence"))
   expect_equal(filters[[2]]$id, scalar("art_coverage"))
   expect_equal(filters[[2]]$label, scalar("ART coverage"))
-  expect_equal(filters[[3]]$id, scalar("vls"))
-  expect_equal(filters[[3]]$label, scalar("Viral load suppression"))
-  expect_equal(filters[[4]]$id, scalar("recent"))
-  expect_equal(filters[[4]]$label, scalar("Proportion recently infected"))
+  expect_equal(filters[[3]]$id, scalar("recent"))
+  expect_equal(filters[[3]]$label, scalar("Proportion recently infected"))
+  expect_equal(filters[[4]]$id, scalar("vls"))
+  expect_equal(filters[[4]]$label, scalar("Viral load suppression"))
 })
 
 test_that("can get indicator filters for programme data", {

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -118,8 +118,8 @@ test_that("do_endpoint_model_options correctly builds params list", {
                scalar("art_coverage"))
   expect_equal(params$survey_art_or_vls_options[[2]]$id, scalar("vls"))
   expect_length(params$anc_prevalence_year1_options, 8)
-  expect_equal(params$anc_prevalence_year1_options[[1]]$id, scalar("2011"))
-  expect_equal(params$anc_prevalence_year1_options[[1]]$label, scalar("2011"))
+  expect_equal(params$anc_prevalence_year1_options[[1]]$id, scalar("2018"))
+  expect_equal(params$anc_prevalence_year1_options[[1]]$label, scalar("2018"))
   expect_equal(params$anc_prevalence_year1_options,
                params$anc_prevalence_year2_options)
   expect_equal(params$anc_prevalence_year1_options,
@@ -293,10 +293,10 @@ test_that("can retrieve validated model options", {
     c("id", "label"))
   expect_equal(
     anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
-    "2011")
+    "2018")
   expect_equal(
     anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
-    "2011")
+    "2018")
 })
 
 

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -8,23 +8,39 @@ test_that("model can be run and filters extracted", {
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator_id", "mode", "mean", "lower", "upper"))
   expect_equal(nrow(model_run$data), 84042)
-  expect_equal(names(model_run$plottingMetadata), "barchart")
-  expect_equal(names(model_run$plottingMetadata$barchart),
-               c("indicators", "filters"))
-  expect_length(model_run$plottingMetadata$barchart$filters, 2)
-  expect_equal(names(model_run$plottingMetadata$barchart$filters[[1]]),
+  expect_equal(names(model_run$plottingMetadata), c("barchart", "choropleth"))
+  barchart <- model_run$plottingMetadata$barchart
+  expect_equal(names(barchart), c("indicators", "filters"))
+  expect_length(barchart$filters, 2)
+  expect_equal(names(barchart$filters[[1]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(model_run$plottingMetadata$barchart$filters[[1]]$id,
-               scalar("age"))
-  expect_equal(model_run$plottingMetadata$barchart$filters[[2]]$id,
-               scalar("quarter"))
-  expect_length(model_run$plottingMetadata$barchart$filters[[1]]$options, 29)
-  expect_length(model_run$plottingMetadata$barchart$filters[[2]]$options, 2)
-  expect_equal(model_run$plottingMetadata$barchart$filters[[2]]$options[[1]]$id,
-               scalar("CY2016Q1"))
-  expect_equal(model_run$plottingMetadata$barchart$filters[[2]]$options[[1]]$label,
+  expect_equal(barchart$filters[[1]]$id, scalar("age"))
+  expect_equal(barchart$filters[[2]]$id, scalar("quarter"))
+  expect_length(barchart$filters[[1]]$options, 29)
+  expect_length(barchart$filters[[2]]$options, 2)
+  expect_equal(barchart$filters[[2]]$options[[1]]$id, scalar("CY2016Q1"))
+  expect_equal(barchart$filters[[2]]$options[[1]]$label, scalar("Jan-Mar 2016"))
+  expect_equal(nrow(barchart$indicators), 7)
+  expect_true(all(c("prevalence", "art_coverage", "current_art", "population",
+                    "plhiv", "incidence", "new_infections") %in%
+                    barchart$indicators$indicator))
+
+  choropleth <- model_run$plottingMetadata$choropleth
+  expect_equal(names(choropleth), c("indicators", "filters"))
+  expect_length(choropleth$filters, 2)
+  expect_equal(names(choropleth$filters[[1]]),
+               c("id", "column_id", "label", "options"))
+  expect_equal(choropleth$filters[[1]]$id, scalar("age"))
+  expect_equal(choropleth$filters[[2]]$id, scalar("quarter"))
+  expect_length(choropleth$filters[[1]]$options, 29)
+  expect_length(choropleth$filters[[2]]$options, 2)
+  expect_equal(choropleth$filters[[2]]$options[[1]]$id, scalar("CY2016Q1"))
+  expect_equal(choropleth$filters[[2]]$options[[1]]$label,
                scalar("Jan-Mar 2016"))
-  expect_length(model_run$plottingMetadata$barchart$indicators, 7)
+  expect_equal(nrow(choropleth$indicators), 7)
+  expect_true(all(c("prevalence", "art_coverage", "current_art", "population",
+                    "plhiv", "incidence", "new_infections") %in%
+                    choropleth$indicators$indicator))
 })
 
 test_that("real model can be run", {

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -11,15 +11,19 @@ test_that("model can be run and filters extracted", {
   expect_equal(names(model_run$plottingMetadata), c("barchart", "choropleth"))
   barchart <- model_run$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters"))
-  expect_length(barchart$filters, 2)
+  expect_length(barchart$filters, 4)
   expect_equal(names(barchart$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(barchart$filters[[2]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(barchart$filters[[1]]$id, scalar("age"))
+  expect_equal(barchart$filters[[1]]$id, scalar("area"))
   expect_equal(barchart$filters[[2]]$id, scalar("quarter"))
-  expect_length(barchart$filters[[1]]$options, 29)
+  expect_equal(barchart$filters[[3]]$id, scalar("sex"))
+  expect_equal(barchart$filters[[4]]$id, scalar("age"))
+  expect_length(barchart$filters[[4]]$options, 29)
   expect_length(barchart$filters[[2]]$options, 2)
-  expect_equal(barchart$filters[[2]]$options[[1]]$id, scalar("CY2016Q1"))
-  expect_equal(barchart$filters[[2]]$options[[1]]$label, scalar("Jan-Mar 2016"))
+  expect_equal(barchart$filters[[2]]$options[[1]]$id, scalar("CY2018Q3"))
+  expect_equal(barchart$filters[[2]]$options[[1]]$label, scalar("Jul-Sep 2018"))
   expect_equal(nrow(barchart$indicators), 7)
   expect_true(all(c("prevalence", "art_coverage", "current_art", "population",
                     "plhiv", "incidence", "new_infections") %in%
@@ -27,16 +31,20 @@ test_that("model can be run and filters extracted", {
 
   choropleth <- model_run$plottingMetadata$choropleth
   expect_equal(names(choropleth), c("indicators", "filters"))
-  expect_length(choropleth$filters, 2)
+  expect_length(choropleth$filters, 4)
   expect_equal(names(choropleth$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(choropleth$filters[[2]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(choropleth$filters[[1]]$id, scalar("age"))
+  expect_equal(choropleth$filters[[1]]$id, scalar("area"))
   expect_equal(choropleth$filters[[2]]$id, scalar("quarter"))
-  expect_length(choropleth$filters[[1]]$options, 29)
+  expect_equal(choropleth$filters[[3]]$id, scalar("sex"))
+  expect_equal(choropleth$filters[[4]]$id, scalar("age"))
+  expect_length(choropleth$filters[[4]]$options, 29)
   expect_length(choropleth$filters[[2]]$options, 2)
-  expect_equal(choropleth$filters[[2]]$options[[1]]$id, scalar("CY2016Q1"))
+  expect_equal(choropleth$filters[[2]]$options[[1]]$id, scalar("CY2018Q3"))
   expect_equal(choropleth$filters[[2]]$options[[1]]$label,
-               scalar("Jan-Mar 2016"))
+               scalar("Jul-Sep 2018"))
   expect_equal(nrow(choropleth$indicators), 7)
   expect_true(all(c("prevalence", "art_coverage", "current_art", "population",
                     "plhiv", "incidence", "new_infections") %in%

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -195,16 +195,44 @@ test_that("model interactions", {
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator_id", "mode", "mean", "lower", "upper"))
   expect_length(response$data$data, 84042)
-  expect_equal(names(response$data$plottingMetadata), "barchart")
+  expect_equal(names(response$data$plottingMetadata),
+               c("barchart", "choropleth"))
+
   barchart <- response$data$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters"))
   expect_length(barchart$filters, 2)
+  expect_equal(names(barchart$filters[[1]]),
+               c("id", "column_id", "label", "options"))
   expect_equal(barchart$filters[[1]]$id, "age")
   expect_equal(barchart$filters[[2]]$id, "quarter")
   expect_length(barchart$filters[[1]]$options, 29)
   expect_length(barchart$filters[[2]]$options, 2)
+  expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2016Q1")
   expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
   expect_length(barchart$indicators, 7)
+  out <- lapply(barchart$indicators, function(indicator) {
+    expect_true(indicator$indicator %in%
+                  c("prevalence", "art_coverage", "current_art", "population",
+                    "plhiv", "incidence", "new_infections"))
+  })
+
+  choropleth <- response$data$plottingMetadata$choropleth
+  expect_equal(names(choropleth), c("indicators", "filters"))
+  expect_length(choropleth$filters, 2)
+  expect_equal(names(choropleth$filters[[1]]),
+               c("id", "column_id", "label", "options"))
+  expect_equal(choropleth$filters[[1]]$id, "age")
+  expect_equal(choropleth$filters[[2]]$id, "quarter")
+  expect_length(choropleth$filters[[1]]$options, 29)
+  expect_length(choropleth$filters[[2]]$options, 2)
+  expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2016Q1")
+  expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_length(choropleth$indicators, 7)
+  out <- lapply(choropleth$indicators, function(indicator) {
+    expect_true(indicator$indicator %in%
+                  c("prevalence", "art_coverage", "current_art", "population",
+                    "plhiv", "incidence", "new_infections"))
+  })
 })
 
 test_that("real model can be run by API", {
@@ -255,16 +283,44 @@ test_that("real model can be run by API", {
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator_id", "mode", "mean", "lower", "upper"))
   expect_length(response$data$data, 84042)
-  expect_equal(names(response$data$plottingMetadata), "barchart")
+  expect_equal(names(response$data$plottingMetadata),
+               c("barchart", "choropleth"))
+
   barchart <- response$data$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters"))
   expect_length(barchart$filters, 2)
+  expect_equal(names(barchart$filters[[1]]),
+               c("id", "column_id", "label", "options"))
   expect_equal(barchart$filters[[1]]$id, "age")
   expect_equal(barchart$filters[[2]]$id, "quarter")
   expect_length(barchart$filters[[1]]$options, 29)
   expect_length(barchart$filters[[2]]$options, 2)
+  expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2016Q1")
   expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
   expect_length(barchart$indicators, 7)
+  out <- lapply(barchart$indicators, function(indicator) {
+    expect_true(indicator$indicator %in%
+                  c("prevalence", "art_coverage", "current_art", "population",
+                    "plhiv", "incidence", "new_infections"))
+  })
+
+  choropleth <- response$data$plottingMetadata$choropleth
+  expect_equal(names(choropleth), c("indicators", "filters"))
+  expect_length(choropleth$filters, 2)
+  expect_equal(names(choropleth$filters[[1]]),
+               c("id", "column_id", "label", "options"))
+  expect_equal(choropleth$filters[[1]]$id, "age")
+  expect_equal(choropleth$filters[[2]]$id, "quarter")
+  expect_length(choropleth$filters[[1]]$options, 29)
+  expect_length(choropleth$filters[[2]]$options, 2)
+  expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2016Q1")
+  expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_length(choropleth$indicators, 7)
+  out <- lapply(choropleth$indicators, function(indicator) {
+    expect_true(indicator$indicator %in%
+                  c("prevalence", "art_coverage", "current_art", "population",
+                    "plhiv", "incidence", "new_infections"))
+  })
 })
 
 test_that("plotting metadata is exposed", {

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -200,15 +200,19 @@ test_that("model interactions", {
 
   barchart <- response$data$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters"))
-  expect_length(barchart$filters, 2)
+  expect_length(barchart$filters, 4)
   expect_equal(names(barchart$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(barchart$filters[[2]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(barchart$filters[[1]]$id, "age")
-  expect_equal(barchart$filters[[2]]$id, "quarter")
-  expect_length(barchart$filters[[1]]$options, 29)
+  expect_equal(barchart$filters[[1]]$id, "area_id")
+  expect_equal(barchart$filters[[2]]$id, "calendar_quarter")
+  expect_equal(barchart$filters[[3]]$id, "sex")
+  expect_equal(barchart$filters[[4]]$id, "age_group")
+  expect_length(barchart$filters[[4]]$options, 29)
   expect_length(barchart$filters[[2]]$options, 2)
-  expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2016Q1")
-  expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2018Q3")
+  expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jul-Sep 2018")
   expect_length(barchart$indicators, 7)
   out <- lapply(barchart$indicators, function(indicator) {
     expect_true(indicator$indicator %in%
@@ -218,15 +222,19 @@ test_that("model interactions", {
 
   choropleth <- response$data$plottingMetadata$choropleth
   expect_equal(names(choropleth), c("indicators", "filters"))
-  expect_length(choropleth$filters, 2)
+  expect_length(choropleth$filters, 4)
   expect_equal(names(choropleth$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(choropleth$filters[[2]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(choropleth$filters[[1]]$id, "age")
-  expect_equal(choropleth$filters[[2]]$id, "quarter")
-  expect_length(choropleth$filters[[1]]$options, 29)
+  expect_equal(choropleth$filters[[1]]$id, "area_id")
+  expect_equal(choropleth$filters[[2]]$id, "calendar_quarter")
+  expect_equal(choropleth$filters[[3]]$id, "sex")
+  expect_equal(choropleth$filters[[4]]$id, "age_group")
+  expect_length(choropleth$filters[[4]]$options, 29)
   expect_length(choropleth$filters[[2]]$options, 2)
-  expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2016Q1")
-  expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2018Q3")
+  expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jul-Sep 2018")
   expect_length(choropleth$indicators, 7)
   out <- lapply(choropleth$indicators, function(indicator) {
     expect_true(indicator$indicator %in%
@@ -288,15 +296,19 @@ test_that("real model can be run by API", {
 
   barchart <- response$data$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters"))
-  expect_length(barchart$filters, 2)
+  expect_length(barchart$filters, 4)
   expect_equal(names(barchart$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(barchart$filters[[2]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(barchart$filters[[1]]$id, "age")
-  expect_equal(barchart$filters[[2]]$id, "quarter")
-  expect_length(barchart$filters[[1]]$options, 29)
+  expect_equal(barchart$filters[[1]]$id, "area_id")
+  expect_equal(barchart$filters[[2]]$id, "calendar_quarter")
+  expect_equal(barchart$filters[[3]]$id, "sex")
+  expect_equal(barchart$filters[[4]]$id, "age_group")
+  expect_length(barchart$filters[[4]]$options, 29)
   expect_length(barchart$filters[[2]]$options, 2)
-  expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2016Q1")
-  expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2018Q3")
+  expect_equal(barchart$filters[[2]]$options[[1]]$label, "Jul-Sep 2018")
   expect_length(barchart$indicators, 7)
   out <- lapply(barchart$indicators, function(indicator) {
     expect_true(indicator$indicator %in%
@@ -306,15 +318,19 @@ test_that("real model can be run by API", {
 
   choropleth <- response$data$plottingMetadata$choropleth
   expect_equal(names(choropleth), c("indicators", "filters"))
-  expect_length(choropleth$filters, 2)
+  expect_length(choropleth$filters, 4)
   expect_equal(names(choropleth$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(choropleth$filters[[2]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(choropleth$filters[[1]]$id, "age")
-  expect_equal(choropleth$filters[[2]]$id, "quarter")
-  expect_length(choropleth$filters[[1]]$options, 29)
+  expect_equal(choropleth$filters[[1]]$id, "area_id")
+  expect_equal(choropleth$filters[[2]]$id, "calendar_quarter")
+  expect_equal(choropleth$filters[[3]]$id, "sex")
+  expect_equal(choropleth$filters[[4]]$id, "age_group")
+  expect_length(choropleth$filters[[4]]$options, 29)
   expect_length(choropleth$filters[[2]]$options, 2)
-  expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2016Q1")
-  expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jan-Mar 2016")
+  expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2018Q3")
+  expect_equal(choropleth$filters[[2]]$options[[1]]$label, "Jul-Sep 2018")
   expect_length(choropleth$indicators, 7)
   out <- lapply(choropleth$indicators, function(indicator) {
     expect_true(indicator$indicator %in%

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -205,10 +205,10 @@ test_that("model interactions", {
                c("id", "column_id", "label", "options", "use_shape_regions"))
   expect_equal(names(barchart$filters[[2]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(barchart$filters[[1]]$id, "area_id")
-  expect_equal(barchart$filters[[2]]$id, "calendar_quarter")
+  expect_equal(barchart$filters[[1]]$id, "area")
+  expect_equal(barchart$filters[[2]]$id, "quarter")
   expect_equal(barchart$filters[[3]]$id, "sex")
-  expect_equal(barchart$filters[[4]]$id, "age_group")
+  expect_equal(barchart$filters[[4]]$id, "age")
   expect_length(barchart$filters[[4]]$options, 29)
   expect_length(barchart$filters[[2]]$options, 2)
   expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2018Q3")
@@ -227,10 +227,10 @@ test_that("model interactions", {
                c("id", "column_id", "label", "options", "use_shape_regions"))
   expect_equal(names(choropleth$filters[[2]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(choropleth$filters[[1]]$id, "area_id")
-  expect_equal(choropleth$filters[[2]]$id, "calendar_quarter")
+  expect_equal(choropleth$filters[[1]]$id, "area")
+  expect_equal(choropleth$filters[[2]]$id, "quarter")
   expect_equal(choropleth$filters[[3]]$id, "sex")
-  expect_equal(choropleth$filters[[4]]$id, "age_group")
+  expect_equal(choropleth$filters[[4]]$id, "age")
   expect_length(choropleth$filters[[4]]$options, 29)
   expect_length(choropleth$filters[[2]]$options, 2)
   expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2018Q3")
@@ -301,10 +301,10 @@ test_that("real model can be run by API", {
                c("id", "column_id", "label", "options", "use_shape_regions"))
   expect_equal(names(barchart$filters[[2]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(barchart$filters[[1]]$id, "area_id")
-  expect_equal(barchart$filters[[2]]$id, "calendar_quarter")
+  expect_equal(barchart$filters[[1]]$id, "area")
+  expect_equal(barchart$filters[[2]]$id, "quarter")
   expect_equal(barchart$filters[[3]]$id, "sex")
-  expect_equal(barchart$filters[[4]]$id, "age_group")
+  expect_equal(barchart$filters[[4]]$id, "age")
   expect_length(barchart$filters[[4]]$options, 29)
   expect_length(barchart$filters[[2]]$options, 2)
   expect_equal(barchart$filters[[2]]$options[[1]]$id, "CY2018Q3")
@@ -323,10 +323,10 @@ test_that("real model can be run by API", {
                c("id", "column_id", "label", "options", "use_shape_regions"))
   expect_equal(names(choropleth$filters[[2]]),
                c("id", "column_id", "label", "options"))
-  expect_equal(choropleth$filters[[1]]$id, "area_id")
-  expect_equal(choropleth$filters[[2]]$id, "calendar_quarter")
+  expect_equal(choropleth$filters[[1]]$id, "area")
+  expect_equal(choropleth$filters[[2]]$id, "quarter")
   expect_equal(choropleth$filters[[3]]$id, "sex")
-  expect_equal(choropleth$filters[[4]]$id, "age_group")
+  expect_equal(choropleth$filters[[4]]$id, "age")
   expect_length(choropleth$filters[[4]]$options, 29)
   expect_length(choropleth$filters[[2]]$options, 2)
   expect_equal(choropleth$filters[[2]]$options[[1]]$id, "CY2018Q3")
@@ -455,10 +455,10 @@ test_that("model run options are exposed", {
     c("id", "label"))
   expect_equal(
     anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$id,
-    "2011")
+    "2018")
   expect_equal(
     anc_section$controlGroups[[1]]$controls[[1]]$options[[1]]$label,
-    "2011")
+    "2018")
 })
 
 test_that("version information is returned", {

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -87,8 +87,8 @@ test_that("do_validate_programme validates programme file", {
   )
   expect_equal(data$filters$age, expected_age_filters)
   expect_length(data$filters$year, 8)
-  expect_equal(data$filters$year[[1]]$id, scalar("2011"))
-  expect_equal(data$filters$year[[1]]$label, scalar("2011"))
+  expect_equal(data$filters$year[[1]]$id, scalar("2018"))
+  expect_equal(data$filters$year[[1]]$label, scalar("2018"))
 
   expect_length(data$filters$indicators, 1)
   expect_equal(data$filters$indicators[[1]]$id, scalar("current_art"))
@@ -106,8 +106,8 @@ test_that("do_validate_anc validates ANC file and gets data for plotting", {
 
   expect_equal(names(data$filters), c("year", "indicators"))
   expect_length(data$filters$year, 8)
-  expect_equal(data$filters$year[[1]]$id, scalar("2011"))
-  expect_equal(data$filters$year[[1]]$label, scalar("2011"))
+  expect_equal(data$filters$year[[1]]$id, scalar("2018"))
+  expect_equal(data$filters$year[[1]]$label, scalar("2018"))
 
   expect_length(data$filters$indicators, 2)
   expect_equal(data$filters$indicators[[1]]$id, scalar("prevalence"))
@@ -145,12 +145,12 @@ test_that("do_validate_survey validates survey file", {
   expect_equal(data$filters$indicators[[1]]$label, scalar("Prevalence"))
   expect_equal(data$filters$indicators[[2]]$id, scalar("art_coverage"))
   expect_equal(data$filters$indicators[[2]]$label, scalar("ART coverage"))
-  expect_equal(data$filters$indicators[[3]]$id, scalar("vls"))
+  expect_equal(data$filters$indicators[[3]]$id, scalar("recent"))
   expect_equal(data$filters$indicators[[3]]$label,
-               scalar("Viral load suppression"))
-  expect_equal(data$filters$indicators[[4]]$id, scalar("recent"))
-  expect_equal(data$filters$indicators[[4]]$label,
                scalar("Proportion recently infected"))
+  expect_equal(data$filters$indicators[[4]]$id, scalar("vls"))
+  expect_equal(data$filters$indicators[[4]]$label,
+               scalar("Viral load suppression"))
 })
 
 test_that("do_validate_programme returns useful error from shapefile comparison", {


### PR DESCRIPTION
This PR will

* Fix missing choropleth filters in output
* Update ordering of returned indicators and filters

I'm expecting there will be some front end work where ordering of filters is hardcoded.

After this is merged and is updated in the front end on the inputs we should have filters (in this order)

* Area
* Period - in decreasing order
* Sex
* Age
* Survey - in decreasing order

Outputs will have

* Area
* Period - In decreasing order
* Sex
* Age

The indicators in the top right choropleth should also be in order
For inputs
* Prevalence
* ART Coverage
* Proportion Recently Infected
* VLS

The output indicators in order of their indicator ID so as of time of writing
* Population
* Prevalence
* PLHIV
* ART coverage
* ART number
* Incidence
* New Infections

See https://vimc.myjetbrains.com/youtrack/issue/mrc-781 for corresponding front end ticket
This should be merged after #78 
