### PR TITLE
mrc-1169: Update region code validation and add regression test

### DIFF
--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -61,7 +61,8 @@ do_validate_shape <- function(shape) {
   json <- hintr_geojson_read(shape)
   assert_single_parent_region(json)
   assert_single_country(json, "shape")
-  assert_properties_exist(json, c("spectrum_region_code", "area_id"))
+  assert_properties_exist(json, "area_id")
+  assert_region_codes_valid(json)
   # Then we have to *reread* the file now that we know that it is
   # valid, but but this is not too slow, especially as the file is now
   # in cache (but still ~1/20s)

--- a/R/validation_asserts.R
+++ b/R/validation_asserts.R
@@ -58,12 +58,27 @@ assert_properties_exist <- function(json, properties) {
  invisible(TRUE)
 }
 
-assert_property_exists <- function(property, json) {
-  contains_id <- vapply(json$features, function(x) {
+assert_region_codes_valid <- function(json) {
+  contains_property <- features_contain_property(json, "spectrum_region_code")
+  missing_count <- sum(!contains_property)
+  if (missing_count > 1) {
+    stop(sprintf(
+      "Shape file contains %s regions with missing spectrum region code, code can only be missing for country level region.",
+      missing_count))
+  }
+  invisible(TRUE)
+}
+
+features_contain_property <- function(json, property) {
+  vapply(json$features, function(x) {
     !is_empty(x$properties[[property]])
   }, logical(1))
-  if (!all(contains_id)) {
-    missing_count <- sum(!contains_id)
+}
+
+assert_property_exists <- function(property, json) {
+  contains_property <- features_contain_property(json, property)
+  if (!all(contains_property)) {
+    missing_count <- sum(!contains_property)
     stop(
       sprintf(
         "Shape file does not contain property %s for each region. Missing ID for %s %s.",

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -131,6 +131,23 @@ test_that("endpoint_validate_baseline support shape file", {
   expect_equal(names(response$data$filters), c("regions", "level_labels"))
 })
 
+test_that("country can have null spectrum region code for country level region", {
+  ## Regression test for bug mrc-1169
+  skip_if_sensitive_data_missing()
+  shape <- file.path("testdata", "sensitive", "ZWE", "data",
+                     "zwe_areas.geojson")
+  req <- list(postBody = '{"type": "shape", "file": {"path": "path/to/file", "hash": "12345", "filename": "original"}}')
+  res <- MockPlumberResponse$new()
+  file <- list(path = shape, hash = "12345", filename = "original")
+  response <- endpoint_validate_baseline(req, res, "shape", file)
+  response <- jsonlite::parse_json(response)
+  expect_equal(response$status, "success")
+  expect_equal(response$data$hash, "12345")
+  expect_true(all(c("type", "features") %in% names(response$data$data)))
+  expect_equal(names(response$data$filters), c("regions", "level_labels"))
+  expect_equal(res$status, 200)
+})
+
 test_that("endpoint_validate_baseline supports population file", {
   population <- file.path("testdata", "population.csv")
   res <- MockPlumberResponse$new()

--- a/tests/testthat/test-validation-asserts.R
+++ b/tests/testthat/test-validation-asserts.R
@@ -161,3 +161,20 @@ test_that("can check file extensions", {
                                      c("PJNZ", "pjnz", "zip")),
                "File must be of type PJNZ, pjnz, zip, got type csv.")
 })
+
+test_that("can check region file spectrum codes are valid", {
+  shape <- file_object(file.path("testdata", "malawi.geojson"))
+  json <- hintr_geojson_read(shape)
+  expect_true(assert_region_codes_valid(json))
+
+  mock_contains_property <- mockery::mock(c(FALSE, TRUE, TRUE))
+  with_mock("hintr:::features_contain_property" = mock_contains_property, {
+    expect_true(assert_region_codes_valid(json))
+  })
+
+  mock_contains_property <- mockery::mock(c(FALSE, FALSE, TRUE))
+  with_mock("hintr:::features_contain_property" = mock_contains_property, {
+    expect_error(assert_region_codes_valid(json),
+                 "Shape file contains 2 regions with missing spectrum region code, code can only be missing for country level region.")
+  })
+})


### PR DESCRIPTION
This PR will
* Update spectrum region code validation to allow 1 region with a null region code. This happens in countries with multiple subnational PJNZ files. There is no spectrum file for the country level region so it can be null

Adds a regression test for the specific data set which showed this error.