### PR TITLE
mrc-1174: Restore previous behaviour of results dir

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -5,15 +5,22 @@ main_api_args <- function(args = commandArgs(TRUE)) {
 Options:
 --workers=N         Number of workers to spawn [default: 2]
 --port=PORT         Port to use [default: 8888]
---results-dir=PATH  Directory to store model results in [default: results]
---prerun-dir=PATH   Directory to find prerun results in [default: prerun]"
+--results-dir=PATH  Directory to store model results in
+--prerun-dir=PATH   Directory to find prerun results in"
 
+  validate_path <- function(path) {
+    if (is.null(path)) {
+      path <- tempfile()
+      dir.create(path, FALSE, TRUE)
+    }
+    path
+  }
   dat <- docopt::docopt(usage, args)
   list(port = as.integer(dat$port),
        queue_id = dat$queue_id,
        workers = as.integer(dat$workers),
-       results_dir = dat[["results-dir"]],
-       prerun_dir = dat[["prerun-dir"]])
+       results_dir = validate_path(dat[["results-dir"]]),
+       prerun_dir = validate_path(dat[["prerun-dir"]]))
 }
 
 main_api <- function(args = commandArgs(TRUE)) {
@@ -26,7 +33,6 @@ main_api <- function(args = commandArgs(TRUE)) {
 main_worker_args <- function(args = commandArgs(TRUE)) {
   usage <- "Usage:
 hintr_worker [<queue_id>]"
-
   dat <- docopt::docopt(usage, args)
   list(queue_id = dat$queue_id)
 }

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -1,18 +1,17 @@
 context("main")
 
 test_that("main_api_args", {
-  expect_equal(main_api_args(c()),
-               list(port = 8888, queue_id = NULL, workers = 2,
-                    results_dir = "results", prerun_dir = "prerun"))
+  default <- main_api_args(c())
+  expect_equal(default$port, 8888)
+  expect_null(default$queue_id)
+  expect_equal(default$workers, 2)
+  expect_true(file.exists(default$results_dir))
+  expect_true(file.exists(default$prerun_dir))
   expect_equal(
     main_api_args(c("--workers=0", "--port", "80", "--results-dir=out",
                     "--prerun-dir=pr", "hintr")),
     list(port = 80, queue_id = "hintr", workers = 0, results_dir = "out",
          prerun_dir = "pr"))
-  expect_equal(
-    main_api_args(c("--workers=0", "--port", "80", "hintr")),
-    list(port = 80, queue_id = "hintr", workers = 0,
-         results_dir = "results", prerun_dir = "prerun"))
 })
 
 test_that("main_worker_args", {


### PR DESCRIPTION
This PR will restore the previous behaviour of using a temporary directory for the results when running locally