### PR TITLE
Fix issue when model results don't contain country level region

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.0.24
+Version: 0.0.25
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/R/filters.R
+++ b/R/filters.R
@@ -139,7 +139,7 @@ get_barchart_defaults <- function(output, output_filters) {
     x_axis_id = scalar("age"),
     disaggregate_by_id = scalar("sex"),
     selected_filter_options = list(
-      area = get_country_filter_option(output),
+      area = get_area_level_filter_option(output),
       quarter = get_selected_filter_options(output_filters, "quarter")[1],
       sex = get_selected_filter_options(output_filters, "sex",
                                         c("female", "male")),
@@ -180,11 +180,10 @@ get_selected_filter_options <- function(output_filters, filter_type, ids = NULL)
   options
 }
 
-get_country_filter_option <- function(output) {
-  option <- unique(output[output$area_level == 0, c("area_id", "area_name")])
-  if (nrow(option) != 1) {
-    stop(sprintf("Got %s top level areas from output.", nrow(option)))
-  }
+get_area_level_filter_option <- function(output) {
+  ## We expect the areas to be returned in order - return the first region
+  ## level as the default
+  option <- output[1, c("area_id", "area_name")]
   list(
     list(
       id = scalar(option$area_id),

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -42,7 +42,8 @@ get_barchart_metadata <- function(output) {
 }
 
 get_choropleth_metadata <- function(output) {
-  iso3 <- get_root_node(output$area_id)
+  browser()
+  iso3 <- get_country_iso3(output$area_id)
   metadata <- naomi::get_plotting_metadata(iso3)
   metadata <- metadata[
     metadata$data_type == "output" & metadata$plot_type == "choropleth",
@@ -52,6 +53,6 @@ get_choropleth_metadata <- function(output) {
 }
 
 
-get_root_node <- function(area_ids) {
-  unique(area_ids[!grepl("\\_", area_ids)])
+get_country_iso3 <- function(area_ids) {
+  sub("([A-Z]{3}).*", "\\1", area_ids[1])
 }

--- a/tests/testthat/test-filters.R
+++ b/tests/testthat/test-filters.R
@@ -252,10 +252,10 @@ test_that("error thrown for unknown type", {
                "Can't get indicator filters for data type unknown.")
 })
 
-test_that("can get output country filter option", {
+test_that("can get area filter option", {
   test_mock_model_available()
   output <- readRDS(mock_model$output_path)
-  expect_equal(get_country_filter_option(output), list(
+  expect_equal(get_area_level_filter_option(output), list(
     list(
       id = scalar("MWI"),
       label = scalar("Malawi")
@@ -263,8 +263,20 @@ test_that("can get output country filter option", {
   ))
 
   output$area_name[[1]] <- "test"
-  expect_error(get_country_filter_option(output),
-               "Got 2 top level areas from output.")
+  expect_equal(get_area_level_filter_option(output), list(
+    list(
+      id = scalar("MWI"),
+      label = scalar("test")
+    )
+  ))
+
+  output <- output[output$area_level != 0, ]
+  expect_equal(get_area_level_filter_option(output), list(
+    list(
+      id = scalar("MWI_1_1"),
+      label = scalar("Northern")
+    )
+  ))
 })
 
 test_that("can get defaults for bar chart", {

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -51,6 +51,63 @@ test_that("model can be run and filters extracted", {
                     choropleth$indicators$indicator))
 })
 
+test_that("model without national level results can be processed", {
+  test_mock_model_available()
+  output <- readRDS(mock_model$output_path)
+  output <- output[output$area_level != 0, ]
+  output_temp <- tempfile()
+  saveRDS(output, output_temp)
+  model_run <- process_result(list(output_path = output_temp))
+  expect_equal(names(model_run), c("data", "plottingMetadata"))
+  expect_equal(names(model_run$data),
+               c("area_id", "sex", "age_group", "calendar_quarter",
+                 "indicator_id", "mode", "mean", "lower", "upper"))
+  expect_true(nrow(model_run$data) > 84042)
+  expect_equivalent(as.data.frame(model_run$data[1, "area_id"]), "MWI_1_1")
+  expect_equal(names(model_run$plottingMetadata), c("barchart", "choropleth"))
+  barchart <- model_run$plottingMetadata$barchart
+  expect_equal(names(barchart), c("indicators", "filters", "defaults"))
+  expect_length(barchart$filters, 4)
+  expect_equal(names(barchart$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(barchart$filters[[2]]),
+               c("id", "column_id", "label", "options"))
+  expect_equal(barchart$filters[[1]]$id, scalar("area"))
+  expect_equal(barchart$filters[[2]]$id, scalar("quarter"))
+  expect_equal(barchart$filters[[3]]$id, scalar("sex"))
+  expect_equal(barchart$filters[[4]]$id, scalar("age"))
+  expect_true(length(barchart$filters[[4]]$options) >= 29)
+  expect_length(barchart$filters[[2]]$options, 2)
+  expect_equal(barchart$filters[[2]]$options[[1]]$id, scalar("CY2018Q3"))
+  expect_equal(barchart$filters[[2]]$options[[1]]$label, scalar("Jul-Sep 2018"))
+  expect_equal(nrow(barchart$indicators), 7)
+  expect_true(all(c("prevalence", "art_coverage", "current_art", "population",
+                    "plhiv", "incidence", "new_infections") %in%
+                    barchart$indicators$indicator))
+
+  choropleth <- model_run$plottingMetadata$choropleth
+  expect_equal(names(choropleth), c("indicators", "filters"))
+  expect_length(choropleth$filters, 4)
+  expect_equal(names(choropleth$filters[[1]]),
+               c("id", "column_id", "label", "options", "use_shape_regions"))
+  expect_equal(names(choropleth$filters[[2]]),
+               c("id", "column_id", "label", "options"))
+  expect_equal(choropleth$filters[[1]]$id, scalar("area"))
+  expect_equal(choropleth$filters[[2]]$id, scalar("quarter"))
+  expect_equal(choropleth$filters[[3]]$id, scalar("sex"))
+  expect_equal(choropleth$filters[[4]]$id, scalar("age"))
+  expect_true(length(choropleth$filters[[4]]$options) >= 29)
+  expect_length(choropleth$filters[[2]]$options, 2)
+  expect_equal(choropleth$filters[[2]]$options[[1]]$id, scalar("CY2018Q3"))
+  expect_equal(choropleth$filters[[2]]$options[[1]]$label,
+               scalar("Jul-Sep 2018"))
+  expect_equal(nrow(choropleth$indicators), 7)
+  expect_true(all(c("prevalence", "art_coverage", "current_art", "population",
+                    "plhiv", "incidence", "new_infections") %in%
+                    choropleth$indicators$indicator))
+
+})
+
 test_that("real model can be run", {
   data <- list(
     pjnz = file.path("testdata", "Malawi2019.PJNZ"),


### PR DESCRIPTION
This PR will

* Add a test and bug fixes which ensures that model results where the model has been run at a level lower than the entire country can still return results

We should check that this works in the front end too - will the map plotting still work?