### PR TITLE
mrc-1256: Catch and translate rrq message

### DIFF
--- a/R/queue.R
+++ b/R/queue.R
@@ -71,7 +71,15 @@ Queue <- R6::R6Class(
     },
 
     result = function(id) {
-      self$queue$task_result(id)
+      ## NOTE: this is not completely ideal because we don't know
+      ## *why* this error is being thrown here. It is almost certainly
+      ## because the result is just not there but it's also possible
+      ## that it is a communication error with the server.
+      tryCatch(
+        self$queue$task_result(id),
+        error = function(e) {
+          stop(t_("QUEUE_RESULT_MISSING"))
+        })
     },
 
     remove = function(id) {

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -57,5 +57,6 @@
     "QUEUE_CACHE": "Creating cache",
     "QUEUE_STOPPING_WORKERS": "Stopping workers",
     "QUEUE_ID_NOT_SET": "Environment variable 'HINTR_QUEUE_ID' is not set",
+    "QUEUE_RESULT_MISSING": "Failed to fetch result",
     "METADATA_BUILD_INDICATOR": "Expected only 1 row for indicator, data type, plot type combination.\nCheck each combination is unique in configuration."
 }

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -57,5 +57,6 @@
     "QUEUE_CACHE": "Création d'un cache",
     "QUEUE_STOPPING_WORKERS": "Arrêt des processus de travail",
     "QUEUE_ID_NOT_SET": "Variable d'environnement 'HINTR_QUEUE_ID' n'est pas définie",
+    "QUEUE_RESULT_MISSING": "Echec de la récupération du résultat",
     "METADATA_BUILD_INDICATOR": "Attendu seulement 1 ligne pour l'indicateur, le type de données, et la combinaison de type de graphique. Vérifiez que chaque combinaison est unique dans votre configuration"
 }

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -228,7 +228,7 @@ test_that("querying for result of missing job returns useful error", {
   expect_length(result$data, 0)
   expect_length(result$errors, 1)
   expect_equal(result$errors[[1]]$error, "FAILED_TO_RETRIEVE_RESULT")
-  expect_equal(result$errors[[1]]$detail, "Missing some results")
+  expect_equal(result$errors[[1]]$detail, "Failed to fetch result")
 })
 
 test_that("querying for an orphan task returns sensible error", {
@@ -315,7 +315,7 @@ test_that("querying for result of incomplete jobs returns useful error", {
   expect_length(result$data, 0)
   expect_length(result$errors, 1)
   expect_equal(result$errors[[1]]$error, "FAILED_TO_RETRIEVE_RESULT")
-  expect_equal(result$errors[[1]]$detail, "Missing some results")
+  expect_equal(result$errors[[1]]$detail, "Failed to fetch result")
 })
 
 test_that("erroring model run returns useful messages", {


### PR DESCRIPTION
Catch and translate string that makes it out to the front end. The note in the code is not that serious - practically the only error that will make it out is the one that is translated (and indeed that is the one in the tests). Doing better would require an overhaul of error management in rrq itself