### PR TITLE
Set default area level to the lowest level available in the data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.0.27
+Version: 0.0.28
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",
@@ -22,7 +22,7 @@ Imports:
     heartbeatr,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 0.0.44),
+    naomi (>= 0.0.48),
     plumber,
     R6,
     redux,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 0.0.28
+
+* Add default values for area level and calendar quarter to generate estimates for
+
 # hintr 0.0.27
 
 * Support for stopping jobs (mrc-732)

--- a/R/model_options.R
+++ b/R/model_options.R
@@ -53,8 +53,6 @@ do_endpoint_model_options <- function(shape, survey, programme, anc) {
     area_level_default = area_level_options[[length(area_level_options)]]$id,
     calendar_quarter_t1_options = time_options,
     calendar_quarter_t2_options = time_options,
-    ## Hardcoded t2 default expecting this to change each estimates round
-    calendar_quarter_t2_default = scalar("CY2019Q4"),
     survey_prevalence_options = survey_prevalence_options,
     survey_art_coverage_options = survey_art_coverage_options,
     survey_recently_infected_options = survey_recently_infected_options,

--- a/R/model_options.R
+++ b/R/model_options.R
@@ -50,8 +50,11 @@ do_endpoint_model_options <- function(shape, survey, programme, anc) {
     area_scope_options = list(regions),
     area_scope_default = parent_region_id,
     area_level_options = area_level_options,
+    area_level_default = area_level_options[[length(area_level_options)]]$id,
     calendar_quarter_t1_options = time_options,
     calendar_quarter_t2_options = time_options,
+    ## Hardcoded t2 default expecting this to change each estimates round
+    calendar_quarter_t2_default = scalar("CY2019Q4"),
     survey_prevalence_options = survey_prevalence_options,
     survey_art_coverage_options = survey_art_coverage_options,
     survey_recently_infected_options = survey_recently_infected_options,

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -352,15 +352,3 @@ test_that("area level is prepopualted to lowest region", {
   expect_equal(json$controlSections[[1]]$controlGroups[[2]]$label, "Area level")
   expect_equal(json$controlSections[[1]]$controlGroups[[2]]$controls[[1]]$value, "4")
 })
-
-test_that("quarter to generate estiamtes is prepopulated to estimate round time", {
-  shape <- file_object(file.path("testdata", "malawi.geojson"))
-  survey <- file_object(file.path("testdata", "survey.csv"))
-  json <- do_endpoint_model_options(shape, survey, NULL, NULL)
-
-  json <- jsonlite::parse_json(json)
-
-  expect_equal(json$controlSections[[1]]$controlGroups[[3]]$label, 
-    "Calendar quarter to generate estimates")
-  expect_equal(json$controlSections[[1]]$controlGroups[[3]]$controls[[1]]$value, "CY2019Q4")
-})

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -341,3 +341,26 @@ test_that("model options can be validated", {
   expect_equal(names(valid), "valid")
   expect_equal(valid$valid, scalar(TRUE))
 })
+
+test_that("area level is prepopualted to lowest region", {
+  shape <- file_object(file.path("testdata", "malawi.geojson"))
+  survey <- file_object(file.path("testdata", "survey.csv"))
+  json <- do_endpoint_model_options(shape, survey, NULL, NULL)
+
+  json <- jsonlite::parse_json(json)
+
+  expect_equal(json$controlSections[[1]]$controlGroups[[2]]$label, "Area level")
+  expect_equal(json$controlSections[[1]]$controlGroups[[2]]$controls[[1]]$value, "4")
+})
+
+test_that("quarter to generate estiamtes is prepopulated to estimate round time", {
+  shape <- file_object(file.path("testdata", "malawi.geojson"))
+  survey <- file_object(file.path("testdata", "survey.csv"))
+  json <- do_endpoint_model_options(shape, survey, NULL, NULL)
+
+  json <- jsonlite::parse_json(json)
+
+  expect_equal(json$controlSections[[1]]$controlGroups[[3]]$label, 
+    "Calendar quarter to generate estimates")
+  expect_equal(json$controlSections[[1]]$controlGroups[[3]]$controls[[1]]$value, "CY2019Q4")
+})

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -58,7 +58,8 @@ test_that("do_endpoint_model_options correctly builds params list", {
   expect_true(grepl('"label": "ANC"', args[[1]][[1]]))
   params <- args[[1]][[2]]
   expect_equal(names(params),
-               c("area_scope_options", "area_scope_default", "area_level_options",
+               c("area_scope_options", "area_scope_default",
+                 "area_level_options", "area_level_default",
                  "calendar_quarter_t1_options", "calendar_quarter_t2_options",
                  "survey_prevalence_options", "survey_art_coverage_options",
                  "survey_recently_infected_options",
@@ -135,7 +136,8 @@ test_that("do_endpoint_model_options without programme data", {
   expect_false(grepl('"label": "ANC"', args[[1]][[1]]))
   params <- args[[1]][[2]]
   expect_equal(names(params),
-               c("area_scope_options", "area_scope_default", "area_level_options",
+               c("area_scope_options", "area_scope_default",
+                 "area_level_options", "area_level_default",
                  "calendar_quarter_t1_options", "calendar_quarter_t2_options",
                  "survey_prevalence_options", "survey_art_coverage_options",
                  "survey_recently_infected_options",


### PR DESCRIPTION
This PR will

* Set the default area level to the lowest level available in the data

We need to merge the naomi PR https://github.com/mrc-ide/naomi/pull/78 first then this will pass.