### PR TITLE
Translate filter option labels for outputs

### DIFF
--- a/R/filters.R
+++ b/R/filters.R
@@ -107,26 +107,26 @@ get_model_output_filters <- function(data) {
     list(
       id = scalar("area"),
       column_id = scalar("area_id"),
-      label = scalar("Area"),
+      label = scalar(t_("OUTPUT_FILTER_AREA")),
       options = scalar(NA),
       use_shape_regions = scalar(TRUE)
     ),
     list(
       id = scalar("quarter"),
       column_id = scalar("calendar_quarter"),
-      label = scalar("Period"),
+      label = scalar(t_("OUTPUT_FILTER_PERIOD")),
       options = get_quarter_filters(data)
     ),
     list(
       id = scalar("sex"),
       column_id = scalar("sex"),
-      label = scalar("Sex"),
+      label = scalar(t_("OUTPUT_FILTER_SEX")),
       options = get_sex_filters(data)
     ),
     list(
       id = scalar("age"),
       column_id = scalar("age_group"),
-      label = scalar("Age"),
+      label = scalar(t_("OUTPUT_FILTER_AGE")),
       options = get_age_filters(data)
     )
   )

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -59,5 +59,10 @@
     "QUEUE_CACHE": "Creating cache",
     "QUEUE_STOPPING_WORKERS": "Stopping workers",
     "QUEUE_ID_NOT_SET": "Environment variable 'HINTR_QUEUE_ID' is not set",
-    "METADATA_BUILD_INDICATOR": "Expected only 1 row for indicator, data type, plot type combination.\nCheck each combination is unique in configuration."
+    "METADATA_BUILD_INDICATOR": "Expected only 1 row for indicator, data type, plot type combination.\nCheck each combination is unique in configuration.",
+    "OUTPUT_FILTER_AREA": "Area",
+    "OUTPUT_FILTER_PERIOD": "Period",
+    "OUTPUT_FILTER_SEX": "Sex",
+    "OUTPUT_FILTER_AGE": "Age"
+
 }

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -59,5 +59,9 @@
     "QUEUE_CACHE": "Création du cache",
     "QUEUE_STOPPING_WORKERS": "Arrêt des travailleurs",
     "QUEUE_ID_NOT_SET": "La variable d'environnement « HINTR_QUEUE_ID » n'est pas définie",
-    "METADATA_BUILD_INDICATOR": "1 ligne seule est attendue pour l'indicateur, le type de données, la combinaison de type de graphique.\nVérifiez que chaque combinaison est unique dans sa configuration."
+    "METADATA_BUILD_INDICATOR": "1 ligne seule est attendue pour l'indicateur, le type de données, la combinaison de type de graphique.\nVérifiez que chaque combinaison est unique dans sa configuration.",
+    "OUTPUT_FILTER_AREA": "Zone",
+    "OUTPUT_FILTER_PERIOD": "Période",
+    "OUTPUT_FILTER_SEX": "Sexe",
+    "OUTPUT_FILTER_AGE": "Âge"
 }


### PR DESCRIPTION
This PR will

* Add translations for output filters

These are used in bar chart and bubble plot. This will fix the titles on the filter options and also fix the listed options in disaggregate by/y axis choices on the bar chart.

I am leaving untranslated sex and age options for another PR as it required some decision about what we want to do. Will make more detailed in naomi PR coming soon.