### PR TITLE
Update progress tests to recreate issue and fix

### DIFF
--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -415,7 +415,7 @@ prepare_status_response <- function(value, id) {
   }
 
   response_value <- lapply(value[names(value) != "progress"], scalar)
-  response_value$progress <- lapply(value$progress, set_scalar)
+  response_value$progress <- lapply(unname(value$progress), set_scalar)
   response_value$id <- scalar(id)
   response_value
 }

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -1,12 +1,12 @@
 run_model <- function(data, options, path_results, path_prerun = NULL) {
   if (use_mock_model()) {
     progress_start <- list(
-      list(
+      started = list(
         started = TRUE,
         complete = FALSE,
         name = t_("RUN_MODEL_MOCK_START")
       ),
-      list(
+      complete = list(
         started = FALSE,
         complete = FALSE,
         name = t_("RUN_MODEL_MOCK_FINISH")
@@ -17,12 +17,12 @@ run_model <- function(data, options, path_results, path_prerun = NULL) {
                               class = c("progress", "condition")))
     Sys.sleep(5)
     progress_complete <- list(
-      list(
+      started = list(
         started = TRUE,
         complete = TRUE,
         name = t_("RUN_MODEL_MOCK_START")
       ),
-      list(
+      complete = list(
         started = TRUE,
         complete = FALSE,
         name = t_("RUN_MODEL_MOCK_FINISH")

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -420,12 +420,12 @@ test_that("endpoint_plotting_metadata returns default data for missing country",
 
 test_that("can convert model status to scalar", {
   progress <- list(
-    list(
+    started = list(
       started = TRUE,
       complete = FALSE,
       name = "Started mock model"
     ),
-    list(
+    complete = list(
       started = FALSE,
       complete = FALSE,
       name = "Finished mock model"


### PR DESCRIPTION
This PR will

* Update unit tests `Progress` type to match the type used by real model
* un-name each progress stage before converting it to json (so that we deliver an array as the front end are expecting over an object)