### PR TITLE
mrc-1310: Add a progress bar

### DIFF
--- a/R/debug.R
+++ b/R/debug.R
@@ -13,8 +13,11 @@
 ##'   data will be unpacked into a directory corresponding to the run
 ##'   id within this, so it is safe to use a common directory.
 ##'
+##' @param verbose Add a progress bar
+##'
 ##' @export
-download_debug <- function(id, server = NULL, dest = tempfile()) {
+download_debug <- function(id, server = NULL, dest = tempfile(),
+                           verbose = TRUE) {
   if (is.null(server)) {
     server <- "http://naomi.dide.ic.ac.uk:8888"
   }
@@ -22,7 +25,8 @@ download_debug <- function(id, server = NULL, dest = tempfile()) {
     stop(sprintf("Path '%s' already exists at destination '%s'", id, dest))
   }
   url <- sprintf("%s/model/debug/%s", server, id)
-  r <- httr::GET(url)
+  progress <- if (verbose) httr::progress() else NULL
+  r <- httr::GET(url, progress)
   httr::stop_for_status(r)
 
   zip <- tempfile(fileext = ".zip")

--- a/man/download_debug.Rd
+++ b/man/download_debug.Rd
@@ -4,7 +4,7 @@
 \alias{download_debug}
 \title{Get debug output from naomi}
 \usage{
-download_debug(id, server = NULL, dest = tempfile())
+download_debug(id, server = NULL, dest = tempfile(), verbose = TRUE)
 }
 \arguments{
 \item{id}{The model run id to download. This will be printed at
@@ -17,6 +17,8 @@ the staging instance.  You can change this if running locally.}
 \item{dest}{The destination for the downloaded data.  The actual
 data will be unpacked into a directory corresponding to the run
 id within this, so it is safe to use a common directory.}
+
+\item{verbose}{Add a progress bar}
 }
 \description{
 Get debug output from naomi

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -200,7 +200,8 @@ test_that("model interactions", {
   dat <- readRDS(file.path(tmp, response$data$id, "data.rds"))
   expect_equal(dat$objects$data$pjnz, "testdata/Malawi2019.PJNZ")
 
-  path <- download_debug(response$data$id, server = server$url)
+  path <- download_debug(response$data$id, server = server$url,
+                         verbose = FALSE)
   expect_equal(dir(path, recursive = TRUE),
                dir(file.path(tmp, response$data$id), recursive = TRUE))
 


### PR DESCRIPTION
This PR adds a progress bar to the debug download output, which is considerably less cryptic when it takes a while, which it typically will.

Jeff - you can test by running:

```
p <- hintr::download_debug(id)
```

with the id I send you over slack, while on the VPN, and you can download an error that Megan saw earlier.  If you are not on the VPN then you'll get a curl timeout error after 10s.  The value `p` will be the path to the downloaded files, the formats of which will be fairly self explanatory (that functionality was all merged in #159)