### PR TITLE
mrc-1319: Add helper script

### DIFF
--- a/docker/bin/hintr_stop_workers
+++ b/docker/bin/hintr_stop_workers
@@ -1,0 +1,3 @@
+#!/usr/bin/env Rscript
+rrq <- rrq::rrq_controller("hintr", redux::hiredis())
+rrq$message_send("STOP")


### PR DESCRIPTION
This PR adds a little script for gracefully stopping the workers. While we have memory leaks this will be useful for trying to stop idle workers so that we can later restart them.