### PR TITLE
mrc-1312: improvements to debug endpoint

### DIFF
--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -140,6 +140,10 @@ endpoint_model_debug <- function(queue) {
     path <- file.path(tmp, id)
     dir.create(path, FALSE, TRUE)
 
+    data$sessionInfo <- utils::sessionInfo()
+    data$objects$data <- lapply(data$objects$data,
+                                function(x) if (!is.null(x)) basename(x))
+
     path_files <- file.path(path, "files")
     dir.create(path_files)
     file_copy(files, file.path(path_files, basename(files)))

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -653,6 +653,10 @@ test_that("Debug endpoint returns debug information", {
   expect_true("id" %in% names(response$data))
   expect_equal(res$status, 200)
 
+  basename2 <- function(x) {
+    if (is.null(x)) NULL else basename(x)
+  }
+
   id <- response$data$id
   bin <- model_debug(NULL, NULL, id)
   tmp <- tempfile()
@@ -665,6 +669,8 @@ test_that("Debug endpoint returns debug information", {
     c("data.rds", "files"))
   info <- readRDS(file.path(dest, id, "data.rds"))
   expect_equal(info$objects$options, list(a = 1, b = 2))
+  expect_is(info$sessionInfo, "sessionInfo")
+  expect_equal(info$objects$data, lapply(data, basename2))
   expect_setequal(
     dir(file.path(dest, id, "files")),
     basename(unlist(data, FALSE, FALSE)))

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -198,7 +198,7 @@ test_that("model interactions", {
   expect_setequal(dir(file.path(tmp, response$data$id)),
                   c("data.rds", "files"))
   dat <- readRDS(file.path(tmp, response$data$id, "data.rds"))
-  expect_equal(dat$objects$data$pjnz, "testdata/Malawi2019.PJNZ")
+  expect_equal(dat$objects$data$pjnz, "Malawi2019.PJNZ")
 
   path <- download_debug(response$data$id, server = server$url,
                          verbose = FALSE)


### PR DESCRIPTION
As suggested by @jeffeaton on #161, relating to #159 - this PR adds the session info to the output and strips paths to the basename. Practically for us this is fine because the stripped path will always be `/uploads` so we return just the useful bit.