### PR TITLE
mrc-1471: Add buildkite support

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^id_rsa\.enc$
 ^id_rsa$
 ^tests/testthat/testdata/sensitive$
+^buildkite$

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -1,0 +1,13 @@
+steps:
+  - label: ":whale: Build"
+    command: docker/build
+
+  - wait
+
+  - label: ":hammer: Test"
+    command: docker/test
+
+  - wait
+
+  - label: ":shipit: Push images"
+    command: docker/push

--- a/docker/build
+++ b/docker/build
@@ -31,8 +31,10 @@ ENTRYPOINT ["/bin/bash"]
 EOF
 
 rm -rf naomi
-## TODO: optionally pick branch here based on buildkite envvar
 git clone https://github.com/mrc-ide/naomi
+if [ -z $NAOMI_SHA ]; then
+    git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
+fi
 
 docker build --pull \
        -t $TAG_SHA \

--- a/docker/build
+++ b/docker/build
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 HERE=$(dirname $0)
 . $HERE/common
+
+function cleanup {
+    echo "Cleaning up"
+    rm -rf $PACKAGE_ROOT/naomi
+    rm -f $PACKAGE_ROOT/docker/Dockerfile.worker
+    rm -f $PACKAGE_ROOT/docker/Dockerfile.test
+}
+trap cleanup EXIT
 
 cat << EOF > $HERE/Dockerfile.worker
 FROM $TAG_SHA
@@ -23,30 +31,23 @@ ENTRYPOINT ["/bin/bash"]
 EOF
 
 rm -rf naomi
-
+## TODO: optionally pick branch here based on buildkite envvar
 git clone https://github.com/mrc-ide/naomi
 
 docker build --pull \
        -t $TAG_SHA \
-       -t $TAG_BRANCH \
-       -t $TAG_VERSION \
        -f docker/Dockerfile \
-       .
+       $PACKAGE_ROOT
 
 docker build \
        -t $TAG_WORKER_SHA \
-       -t $TAG_WORKER_BRANCH \
-       -t $TAG_WORKER_VERSION \
        -f docker/Dockerfile.worker \
-       .
+       $PACKAGE_ROOT
 
 docker build \
       -t hintr_tests:${GIT_SHA} \
       -f docker/Dockerfile.test \
-      .
-
-rm -f docker/Dockerfile.worker
-rm -f docker/Dockerfile.test
+      $PACKAGE_ROOT
 
 # We always push the SHA tagged versions, for debugging if the tests
 # after this step fail

--- a/docker/common
+++ b/docker/common
@@ -2,24 +2,34 @@
 PACKAGE_ROOT=$(realpath $HERE/..)
 PACKAGE_NAME=hintr
 PACKAGE_ORG=mrcide
+PACKAGE_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION | \
+                      grep '^Version:' | sed 's/^.*: *//')
 
-WORKER_NAME=hintr-worker
-
-GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
-PKG_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION | grep '^Version:' | sed 's/^.*: *//')
+# Buildkite doesn't check out a full history from the remote (just the
+# single commit) so you end up with a detached head and git rev-parse
+# doesn't work
+if [ "$BUILDKITE" = "true" ]; then
+    GIT_SHA=${BUILDKITE_COMMIT:0:7}
+else
+    GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
+fi
 
 if [ "$TRAVIS" = "true" ]; then
     GIT_BRANCH=$TRAVIS_BRANCH
+elif [ "$BUILDKITE" = "true" ]; then
+    GIT_BRANCH=$BUILDKITE_BRANCH
 else
     GIT_BRANCH=$(git -C "$PACKAGE_ROOT" symbolic-ref --short HEAD)
 fi
 
 TAG_SHA="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_SHA}"
 TAG_BRANCH="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_BRANCH}"
-TAG_VERSION="${PACKAGE_ORG}/${PACKAGE_NAME}:v${PKG_VERSION}"
+TAG_VERSION="${PACKAGE_ORG}/${PACKAGE_NAME}:v${PACKAGE_VERSION}"
 TAG_LATEST="${PACKAGE_ORG}/${PACKAGE_NAME}:latest"
 
+## Then worker bits:
+WORKER_NAME=hintr-worker
 TAG_WORKER_SHA="${PACKAGE_ORG}/${WORKER_NAME}:${GIT_SHA}"
 TAG_WORKER_BRANCH="${PACKAGE_ORG}/${WORKER_NAME}:${GIT_BRANCH}"
-TAG_WORKER_VERSION="${PACKAGE_ORG}/${WORKER_NAME}:v${PKG_VERSION}"
+TAG_WORKER_VERSION="${PACKAGE_ORG}/${WORKER_NAME}:v${PACKAGE_VERSION}"
 TAG_WORKER_LATEST="${PACKAGE_ORG}/${WORKER_NAME}:latest"

--- a/docker/push
+++ b/docker/push
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 HERE=$(dirname $0)
 . $HERE/common
 
+# In case we switch agents between steps
+[ ! -z $(docker images -q $TAG_SHA) ] || docker pull $TAG_SHA
+
 # Push the human-readable tagged versions here (the SHA versions were
 # pushed during build)
+docker tag $TAG_SHA $TAG_BRANCH
 docker push $TAG_BRANCH
-docker push $TAG_VERSION
 
+docker tag $TAG_WORKER_SHA $TAG_WORKER_BRANCH
 docker push $TAG_WORKER_BRANCH
-docker push $TAG_WORKER_VERSION
 
 if [ $GIT_BRANCH == "master" ]; then
-   docker tag $TAG_BRANCH $TAG_LATEST
-   docker tag $TAG_WORKER_BRANCH $TAG_WORKER_LATEST
-
+   docker tag $TAG_SHA $TAG_LATEST
+   docker tag $TAG_SHA $TAG_VERSION
    docker push $TAG_LATEST
+   docker push $TAG_VERSION
+
+   docker tag $TAG_WORKER_SHA $TAG_WORKER_LATEST
+   docker tag $TAG_WORKER_SHA $TAG_WORKER_VERSION
    docker push $TAG_WORKER_LATEST
+   docker push $TAG_WORKER_VERSION
 fi

--- a/docker/teamcity
+++ b/docker/teamcity
@@ -3,4 +3,4 @@ set -e
 HERE=$(dirname $0)
 $HERE/build
 $HERE/test
-$HERE/push
+#$HERE/push

--- a/docker/test
+++ b/docker/test
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 HERE=$(dirname $0)
 . $HERE/common
+
+# In case we switch agents between steps
+[ ! -z $(docker images -q $TAG_SHA) ] || docker pull $TAG_SHA
 
 NAME_REDIS=hintr_redis
 NAME_SERVER=hintr_server
@@ -24,20 +27,6 @@ docker volume create $NAME_VOLUME
 
 docker run --rm -d --network=$NAME_NETWORK --network-alias=redis \
        --name hintr_redis redis
-
-#docker run --rm --network=$NAME_NETWORK \
-#      -e REDIS_URL=redis://redis:6379 \
-#      -e VALIDATE_JSON_SCHEMAS=true \
-#      -e USE_MOCK_MODEL=true \
-#      --mount type=volume,src=$NAME_VOLUME,dst=/uploads \
-#      --mount type=volume,src=$NAME_VOLUME,dst=/results \
-#      --name hintr_tests hintr_tests:${GIT_SHA}\
-#      -c "R CMD check *.tar.gz --no-manual"
-
-#if [ $? == 1 ]; then
-#    echo "FAIL"
-#    exit 1
-#fi
 
 docker run --rm -d --network=$NAME_NETWORK \
        -p 8888:8888 \


### PR DESCRIPTION
This PR adds buildkite support following the same pattern as the orderly chain, with one difference - in `docker/build` we respond to the environment variable `$NAOMI_SHA` to check out the appropriate version of naomi to build against.  Apart from that this alters the scripts minimally to cope with switching agents, and to be robust to directory changes (we have a mix of assuming we're running from the root directory and being robust to that, which is weird).

We can remove the support for teamcity entirely from this build, or in a separate PR.  I think that this (plus the companion PR for hintr) also remove the need for the naomi bot