### PR TITLE
Add cleanup function on queue and manually clean up workers in tests

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -38,9 +38,11 @@ set_cache <- function(id) {
 }
 
 clear_cache <- function(id) {
-  x <- hintenv$cache[[id]]
-  if (!is.null(x)) {
-    x$destroy()
-    hintenv$cache[[id]] <- NULL
+  if (!is.null(id)) {
+    x <- hintenv$cache[[id]]
+    if (!is.null(x)) {
+      x$destroy()
+      hintenv$cache[[id]] <- NULL
+    }
   }
 }

--- a/R/queue.R
+++ b/R/queue.R
@@ -89,13 +89,19 @@ Queue <- R6::R6Class(
       self$queue$destroy(delete = TRUE)
     },
 
-    finalize = function(queue) {
+    cleanup = function() {
       clear_cache(self$queue$keys$queue_id)
-      if (self$cleanup_on_exit) {
+      if (self$cleanup_on_exit && !is.null(self$queue$con)) {
         message(t_("QUEUE_STOPPING_WORKERS"))
         self$queue$worker_stop()
         self$destroy()
       }
+    }
+  ),
+
+  private = list(
+    finalize = function() {
+      self$cleanup()
     }
   )
 )

--- a/tests/testthat/helper-queue.R
+++ b/tests/testthat/helper-queue.R
@@ -18,3 +18,12 @@ MockQueue <- R6::R6Class(
     }
   )
 )
+
+test_queue <- function(workers = 2) {
+  queue <- Queue$new(workers = workers)
+  withr::defer_parent({
+    message("cleaning up workers")
+    queue$cleanup()
+  })
+  queue
+}

--- a/tests/testthat/test-endpoints-download.R
+++ b/tests/testthat/test-endpoints-download.R
@@ -30,7 +30,7 @@ test_that("indicator download returns bytes", {
   res <- MockPlumberResponse$new()
 
   ## Call the endpoint
-  queue <- Queue$new()
+  queue <- test_queue()
   model_submit <- endpoint_model_submit(queue)
   response <- model_submit(req, res, data, options, cfg$version_info)
   response <- jsonlite::parse_json(response)
@@ -79,7 +79,7 @@ test_that("spectrum download returns bytes", {
   res <- MockPlumberResponse$new()
 
   ## Call the endpoint
-  queue <- Queue$new()
+  queue <- test_queue()
   model_submit <- endpoint_model_submit(queue)
   response <- model_submit(req, res, data, options, cfg$version_info)
   response <- jsonlite::parse_json(response)

--- a/tests/testthat/test-endpoints-hintr.R
+++ b/tests/testthat/test-endpoints-hintr.R
@@ -11,7 +11,7 @@ test_that("endpoint hintr works", {
 
 test_that("endpoint worker status works", {
   test_redis_available()
-  queue <- Queue$new()
+  queue <- test_queue()
   endpoint <- endpoint_hintr_worker_status(queue)
 
   response <- jsonlite::parse_json(endpoint())
@@ -29,7 +29,7 @@ test_that("endpoint worker status works", {
 
 test_that("stop calls quit and stop_workers", {
   test_redis_available()
-  queue <- Queue$new(workers = 0)
+  queue <- test_queue(workers = 0)
   unlockBinding("worker_stop", queue$queue)
   queue$queue$worker_stop <- mockery::mock()
   mock_quit <- mockery::mock()

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -30,7 +30,7 @@ test_that("endpoint model run queues a model run", {
   res <- MockPlumberResponse$new()
 
   ## Call the endpoint
-  queue <- Queue$new()
+  queue <- test_queue()
   model_submit <- endpoint_model_submit(queue)
   response <- model_submit(req, res, data, options, cfg$version_info)
   response <- jsonlite::parse_json(response)
@@ -184,7 +184,7 @@ test_that("endpoint_run_model returns error if queueing fails", {
 
   ## Create mocks
   res <- MockPlumberResponse$new()
-  queue <- Queue$new()
+  queue <- test_queue()
   mock_submit <- function(data, options) { stop("Failed to queue") }
 
   ## Call the endpoint
@@ -203,7 +203,7 @@ test_that("querying for status of missing job returns useful message", {
   test_redis_available()
 
   res <- MockPlumberResponse$new()
-  queue <- Queue$new()
+  queue <- test_queue()
   model_status <- endpoint_model_status(queue)
   status <- model_status(NULL, res, "ID")
   status <- jsonlite::parse_json(status)
@@ -219,7 +219,7 @@ test_that("querying for result of missing job returns useful error", {
   test_redis_available()
 
   res <- MockPlumberResponse$new()
-  queue <- Queue$new()
+  queue <- test_queue()
   model_result <- endpoint_model_result(queue)
   result <- model_result(NULL, res, "ID")
   result <- jsonlite::parse_json(result)
@@ -234,7 +234,7 @@ test_that("querying for result of missing job returns useful error", {
 test_that("querying for an orphan task returns sensible error", {
   test_redis_available()
   res <- MockPlumberResponse$new()
-  queue <- Queue$new(workers = 0)
+  queue <- test_queue(workers = 0)
   model_result <- endpoint_model_result(queue)
 
   id <- ids::random_id()
@@ -255,7 +255,7 @@ test_that("endpoint_run_status returns error if query for status fails", {
 
   ## Create mocks
   res <- MockPlumberResponse$new()
-  queue <- Queue$new()
+  queue <- test_queue()
   mock_status <- function(data, parameters) { stop("Failed to get status") }
 
   ## Call the endpoint
@@ -300,7 +300,7 @@ test_that("querying for result of incomplete jobs returns useful error", {
   res <- MockPlumberResponse$new()
 
   ## Call the endpoint
-  queue <- Queue$new()
+  queue <- test_queue()
   model_submit <- endpoint_model_submit(queue)
   response <- model_submit(req, res, data, options, cfg$version_info)
   response <- jsonlite::parse_json(response)
@@ -376,7 +376,7 @@ test_that("running model with old version throws an error", {
   res <- MockPlumberResponse$new()
 
   ## Call the endpoint
-  queue <- Queue$new()
+  queue <- test_queue()
   model_submit <- endpoint_model_submit(queue)
   version <- list(
     hintr = "0.0.12",
@@ -419,7 +419,7 @@ test_that("model run can be cancelled", {
               "options": {}
               }')
 
-  queue <- Queue$new()
+  queue <- test_queue()
 
   model_submit <- endpoint_model_submit(queue)
   model_cancel <- endpoint_model_cancel(queue)
@@ -494,7 +494,7 @@ test_that("translation of progress", {
   res <- MockPlumberResponse$new()
 
   ## Call the endpoint
-  queue <- Queue$new()
+  queue <- test_queue()
   model_submit <- endpoint_model_submit(queue)
   model_status <- endpoint_model_status(queue)
 
@@ -581,7 +581,7 @@ test_that("error messages from naomi are translated", {
   res <- MockPlumberResponse$new()
 
   queue <- withr::with_envvar(c("USE_MOCK_MODEL" = "false"),
-                              Queue$new())
+                              test_queue())
   model_submit <- endpoint_model_submit(queue)
   model_result <- endpoint_model_result(queue)
 
@@ -603,7 +603,7 @@ test_that("failed cancel sends reasonable message", {
   test_redis_available()
   test_mock_model_available()
   ## Create request data
-  queue <- Queue$new()
+  queue <- test_queue()
   model_cancel <- endpoint_model_cancel(queue)
 
   id <- ids::random_id()
@@ -653,7 +653,7 @@ test_that("Debug endpoint returns debug information", {
   res <- MockPlumberResponse$new()
 
   ## Call the endpoint
-  queue <- Queue$new()
+  queue <- test_queue()
   model_submit <- endpoint_model_submit(queue)
   model_debug <- endpoint_model_debug(queue)
 
@@ -691,7 +691,7 @@ test_that("Debug endpoint returns debug information", {
 test_that("Debug endpoint errors on nonexistant id", {
   test_redis_available()
   res <- MockPlumberResponse$new()
-  queue <- Queue$new()
+  queue <- test_queue()
   model_debug <- endpoint_model_debug(queue)
   id <- ids::random_id()
   response <- model_debug(list(), res, id)

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -2,18 +2,18 @@ context("model-options")
 
 test_that("can build JSON from template", {
   json <- build_json("test <+param1+>", list(param1 = scalar("test string")))
-  expect_equivalent(json, 'test "test string"')
+  expect_equal(json, 'test "test string"')
 
   json <- build_json("<+param1+> test, <+param_2+>",
                      list(param1 = scalar("x"), param_2 = scalar("y")))
-  expect_equivalent(json, '"x" test, "y"')
+  expect_equal(json, '"x" test, "y"')
 
   json <- build_json('{"options": <+options+>, "test": <+test+>}',
                      list(options = c(scalar("MWI"),
                                       scalar("MWI_1_1"),
                                       scalar("MWI_1_2")),
                           test = scalar("test_value")))
-  expect_equivalent(json,
+  expect_equal(json,
                '{"options": ["MWI","MWI_1_1","MWI_1_2"], "test": "test_value"}')
 
   json <- build_json('{"options": <+options+>, "test": <+test+>, "text": "Age < 5"}',
@@ -25,16 +25,16 @@ test_that("can build JSON from template", {
                        list(id = scalar("MWI_1_2"),
                             label = scalar("Central"))),
                        test = scalar("test_value")))
-  expect_equivalent(json,
+  expect_equal(json,
                '{"options": [{"id":"MWI","label":"Malawi"},{"id":"MWI_1_1","label":"Northern"},{"id":"MWI_1_2","label":"Central"}], "test": "test_value", "text": "Age < 5"}')
 
   ## Additional params are ignored
   json <- build_json("test <+param+>", list(param = scalar("test"), param2 = scalar("test2")))
-  expect_equivalent(json, 'test "test"')
+  expect_equal(json, 'test "test"')
 
   ## Null params
   json <- build_json('{"options": <+param+>}', list(param = scalar(NULL)))
-  expect_equivalent(json, '{"options": {}}')
+  expect_equal(json, '{"options": {}}')
 })
 
 test_that("JSON build fails if params are missing", {


### PR DESCRIPTION
This PR will 
* Add a cleanup function
* Add a helper to tests which manually cleans up to remove workers after tests

Will be useful in https://github.com/mrc-ide/hintr2/pull/4