### PR TITLE
update schema to match pkgapi

### DIFF
--- a/inst/schema/Response.schema.json
+++ b/inst/schema/Response.schema.json
@@ -9,7 +9,7 @@
       "type": ["object", "null"]
     },
     "errors": {
-      "type": "array",
+      "type": ["array", "null"],
       "items": { "$ref": "Error.schema.json" }
     },
     "version": { "$ref": "VersionInfo.schema.json" }


### PR DESCRIPTION
This change brings the hintr response schema in line with the [pkgapi](https://github.com/reside-ic/pkgapi) one. We want to continue to include this schema because it goes beyond the pkgapi response schema in specifying additional properties (version, stack trace.) 