### PR TITLE
Add test and fix for file naming bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 0.1.1
+
+* Fix file naming to work with old model runs where country name is not available
+
 # hintr 0.1.0
 
 * Switch API implementation to use pkgapi

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -200,10 +200,8 @@ download <- function(queue, type, filename) {
                      "summary" = res$summary_path)
       bytes <- readBin(path, "raw", n = file.size(path))
       bytes <- pkgapi::pkgapi_add_headers(bytes, list(
-        "Content-Disposition" =
-          sprintf('attachment; filename="%s_%s_%s.zip"',
-                  paste(res$metadata$areas, collapse = ", "),
-                  iso_time_str(), filename),
+        "Content-Disposition" = build_content_disp_header(res$metadata$areas,
+                                                          filename),
         "Content-Length" = length(bytes)))
       bytes
     },
@@ -215,6 +213,11 @@ download <- function(queue, type, filename) {
       }
     })
   }
+}
+
+build_content_disp_header <- function(areas, filename) {
+  sprintf('attachment; filename="%s.zip"',
+          paste(c(areas, iso_time_str(), filename), collapse = "_"))
 }
 
 download_model_debug <- function(queue) {

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -793,6 +793,16 @@ test_that("api can call endpoint_download_summary", {
     system_file("output", "malawi_summary_download.zip")))
 })
 
+test_that("content disposition header is formatted correctly", {
+  expect_match(build_content_disp_header("MWI", "naomi_spectrum_digest"),
+               'attachment; filename="MWI_\\d+-\\d+_naomi_spectrum_digest.zip"')
+  expect_match(build_content_disp_header(NULL, "naomi_spectrum_digest"),
+               'attachment; filename="\\d+-\\d+_naomi_spectrum_digest.zip"')
+  expect_match(
+    build_content_disp_header(c("MWI.1", "MWI.2"), "naomi_spectrum_digest"),
+    'attachment; filename="MWI.1_MWI.2_\\d+-\\d+_naomi_spectrum_digest.zip"')
+})
+
 test_that("returning_binary_head ensures no body in response", {
   returning <- returning_binary_head()
   data <- charToRaw("test")


### PR DESCRIPTION
Reported a bug where a user downloading spectrum digest from an old model run was getting a filename like

`_20200916-103008_naomi_spectrum_digest.zip`

This is because we try and prefix with the country the run is for, this info comes from metadata in the response from the model run and hasn't always been available. So in old runs where this metadata isn't there then it produces a string as above with this blank. Really what should happen is there is no preceding `_` if that country info isn't available.