### PR TITLE
MRC-1797: Add endpoint for calibrating model run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ docker/Dockerfile.worker
 inst/output/malawi_output.rds
 inst/output/malawi_spectrum_download.zip
 inst/output/malawi_coarse_output_download.zip
+inst/output/malawi_calibration.rds
 id_rsa
 tests/testthat/testdata/sensitive

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     heartbeatr,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 1.0.4),
+    naomi (>= 1.0.5),
     pkgapi (>= 0.0.9),
     R6,
     redux,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     heartbeatr,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 1.0.6),
+    naomi (>= 1.0.7),
     pkgapi (>= 0.0.9),
     R6,
     redux,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 0.1.3
+
+* Add placeholder model calibration endpoint
+
 # hintr 0.1.1
 
 * Fix file naming to work with old model runs where country name is not available

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # hintr 0.1.3
 
-* Add placeholder model calibration endpoint
+* Add model calibration endpoint
 
 # hintr 0.1.1
 

--- a/R/api.R
+++ b/R/api.R
@@ -12,6 +12,7 @@ api_build <- function(queue) {
   api$handle(endpoint_model_cancel(queue))
   api$handle(endpoint_model_debug(queue))
   api$handle(endpoint_model_calibration_options())
+  api$handle(endpoint_model_calibrate(queue))
   api$handle(endpoint_plotting_metadata())
   api$handle(endpoint_download_spectrum(queue))
   api$handle(endpoint_download_spectrum_head(queue))
@@ -266,6 +267,20 @@ endpoint_model_calibration_options <- function() {
   pkgapi::pkgapi_endpoint$new("POST",
                               "/model/calibration-options",
                               calibration_options,
+                              returning = response,
+                              validate = TRUE)
+}
+
+endpoint_model_calibrate <- function(queue) {
+  input <- pkgapi::pkgapi_input_body_json("input",
+                                          "ModelCalibrateRequest.schema",
+                                          schema_root())
+  response <- pkgapi::pkgapi_returning_json("ModelResultResponse.schema",
+                                            schema_root())
+  pkgapi::pkgapi_endpoint$new("POST",
+                              "/model/calibrate/<id>",
+                              model_calibrate(queue),
+                              input,
                               returning = response,
                               validate = TRUE)
 }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -178,6 +178,9 @@ model_calibrate <- function(queue) {
   function(id, input) {
     verify_result_available(queue, id)
     calibration_options <- jsonlite::fromJSON(input)
+    if (!is_current_version(calibration_options$version)) {
+      hintr_error(t_("MODEL_SUBMIT_OLD"), "VERSION_OUT_OF_DATE")
+    }
     calibrated_result <- calibrate_result(queue$result(id), calibration_options)
     process_result(calibrated_result)
   }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -181,21 +181,12 @@ model_calibrate <- function(queue) {
     if (!is_current_version(calibration_options$version)) {
       hintr_error(t_("MODEL_SUBMIT_OLD"), "VERSION_OUT_OF_DATE")
     }
-    calibrated_result <- calibrate_result(queue$result(id), calibration_options)
+    browser()
+    calibrated_result <- naomi::hintr_calibrate(queue$result(id),
+                                                calibration_options)
     process_result(calibrated_result)
   }
 }
-
-## TODO: Temporary placeholder function just returns result without
-## calibration. To be replaced by call to naomi calibration function once
-## implemented
-calibrate_result <- function(result, input) {
-  ## TODO: when naomi supported call naomi calibration function
-  ## Either in naomi or here we will need to read out paths to results and use
-  ## to construct R objects needed for calibration
-  result
-}
-
 
 model_cancel <- function(queue) {
   function(id) {

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -181,9 +181,8 @@ model_calibrate <- function(queue) {
     if (!is_current_version(calibration_options$version)) {
       hintr_error(t_("MODEL_SUBMIT_OLD"), "VERSION_OUT_OF_DATE")
     }
-    browser()
     calibrated_result <- naomi::hintr_calibrate(queue$result(id),
-                                                calibration_options)
+                                                calibration_options$options)
     process_result(calibrated_result)
   }
 }

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -41,11 +41,15 @@ run_model <- function(data, options, path_results, path_prerun = NULL,
     )
     signalCondition(structure(progress_complete,
                               class = c("progress", "condition")))
-    return(list(output_path = system_file("output", "malawi_output.rds"),
-         spectrum_path = system_file("output", "malawi_spectrum_download.zip"),
-         coarse_output_path =
-           system_file("output", "malawi_coarse_output_download.zip"),
-         metadata = list(areas = "MWI")))
+    output <- list(output_path = system_file("output", "malawi_output.rds"),
+                   spectrum_path = system_file("output", "malawi_spectrum_download.zip"),
+                   coarse_output_path =
+                     system_file("output", "malawi_coarse_output_download.zip"),
+                   calibration_path = system_file("output",
+                                                  "malawi_calibration.rds"),
+                   metadata = list(areas = "MWI"))
+    class(output) <- "hintr_output"
+    return(output)
   }
 
   if (!is.null(path_prerun)) {
@@ -62,6 +66,7 @@ run_model <- function(data, options, path_results, path_prerun = NULL,
   output_path <- tempfile(tmpdir = path_results, fileext = ".rds")
   spectrum_path <- tempfile(tmpdir = path_results, fileext = ".zip")
   coarse_output_path <- tempfile(tmpdir = path_results, fileext = ".zip")
+  calibration_path <- tempfile(tmpdir = path_results, fileext = ".rds")
 
   ## Fix some labels to match what naomi requires
   data$art_number <- data$programme
@@ -70,7 +75,7 @@ run_model <- function(data, options, path_results, path_prerun = NULL,
   data$anc <- NULL
 
   naomi::hintr_run_model(data, options, output_path, spectrum_path,
-                         coarse_output_path)
+                         coarse_output_path, calibration_path)
 }
 
 select_data <- function(data) {

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone --single-branch --branch mrc-1790 https://github.com/mrc-ide/naomi
+git clone https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone --single-branch --branch improve-error-message https://github.com/mrc-ide/naomi
+git clone https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone --single-branch --branch improve-error-message https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/inst/schema/ModelCalibrateRequest.schema.json
+++ b/inst/schema/ModelCalibrateRequest.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "options" : { "type": "object" },
+    "version": { "$ref": "VersionInfo.schema.json" }
+  },
+  "additionalProperties": false,
+  "required": [
+    "options",
+    "version"
+  ]
+}

--- a/scripts/build_test_data
+++ b/scripts/build_test_data
@@ -2,7 +2,8 @@
 
 paths <- list(output_path = "inst/output/malawi_output.rds",
               spectrum_path = "inst/output/malawi_spectrum_download.zip",
-              coarse_output_path = "inst/output/malawi_coarse_output_download.zip")
+              coarse_output_path = "inst/output/malawi_coarse_output_download.zip",
+              calibration_path = "inst/output/malawi_calibration.rds")
 
 dir.create("inst/output", showWarnings = FALSE)
 invisible(lapply(paths, function(path) {
@@ -16,7 +17,8 @@ out <- system2("./scripts/run_model",
     "--payload", "./scripts/payload.json",
     "--output-path", paths$output_path,
     "--spectrum-path", paths$spectrum_path,
-    "--coarse-output-path", paths$coarse_output_path))
+    "--coarse-output-path", paths$coarse_output_path,
+    "--calibration-path", paths$calibration_path))
 
 if (out != 0) {
   quit(save = "no", status = 1)

--- a/scripts/run_model
+++ b/scripts/run_model
@@ -1,7 +1,7 @@
 #!/usr/bin/env Rscript
 "Run a model and save outputs at specified paths
 Usage:
-  run_model (--payload=<payload> --output-path=<output-path> --spectrum-path=<spectrum-path> --coarse-output-path=<coarse-output-path>)
+  run_model (--payload=<payload> --output-path=<output-path> --spectrum-path=<spectrum-path> --coarse-output-path=<coarse-output-path> --calibration-path=<calibration-path>)
 
 Options:
   -h --help                                    Show this screen.
@@ -9,6 +9,7 @@ Options:
   --output-path=<output-path>                  Path to output data RDS.
   --spectrum-path=<spectrum-path>              Path to spectrum zip download.
   --coarse-output-path=<coarse-output-path>    Path to summary zip download.
+  --calibration-path=<calibration-path>        Path to calibration data.
 " -> usage
 
 dat <- docopt::docopt(usage)
@@ -25,7 +26,8 @@ output <- naomi::hintr_run_model(payload$data,
                                  payload$options,
                                  dat$output_path,
                                  dat$spectrum_path,
-                                 dat$coarse_output_path)
+                                 dat$coarse_output_path,
+                                 dat$calibration_path)
 
 message(sprintf("Saving output at %s", normalizePath(dat$output_path,
                                                      mustWork = TRUE)))
@@ -34,3 +36,5 @@ message(
                                                           mustWork = TRUE)))
 message(sprintf("Saving output at %s", normalizePath(dat$coarse_output_path,
                                                      mustWork = TRUE)))
+message(sprintf("Saving calibration at %s",
+                normalizePath(dat$calibration_path, mustWork = TRUE)))

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -8,7 +8,9 @@ mock_model <- list(
                               package = "hintr"),
   coarse_output_path =
     system.file("output", "malawi_coarse_output_download.zip",
-                package = "hintr"))
+                package = "hintr"),
+  calibration_path = system.file("output", "malawi_calibration.rds",
+                                 package = "hintr"))
 class(mock_model) <- "hintr_output"
 
 test_mock_model_available <- function() {
@@ -19,6 +21,17 @@ test_mock_model_available <- function() {
     }
   }))
 }
+
+## Model output as returned by
+## hintr version 0.1.2 and naomi version 1.0.4
+mock_model_v0.1.2 <- list(
+  output_path = system.file("output", "malawi_output.rds", package = "hintr"),
+  spectrum_path = system.file("output", "malawi_spectrum_download.zip",
+                              package = "hintr"),
+  coarse_output_path =
+    system.file("output", "malawi_coarse_output_download.zip",
+                package = "hintr"))
+class(mock_model_v0.1.2) <- "hintr_output"
 
 ## Model output as returned by
 ## hintr version 0.1.1 and naomi version 1.0.3
@@ -63,8 +76,12 @@ clone_model_output <- function(output) {
   file.copy(output$spectrum_path, spectrum_path)
   coarse_output_path <- tempfile(fileext = ".zip")
   file.copy(output$coarse_output_path, coarse_output_path)
-  calibration_path <- tempfile(fileext = ".rds")
-  file.copy(output$calibration_path, calibration_path)
+  if (!is.null(output$calibration_path)) {
+    calibration_path <- tempfile(fileext = ".rds")
+    file.copy(output$calibration_path, calibration_path)
+  } else {
+    calibration_path <- NULL
+  }
   out <- list(output_path = output_path,
               spectrum_path = spectrum_path,
               coarse_output_path = coarse_output_path,

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -9,6 +9,7 @@ mock_model <- list(
   coarse_output_path =
     system.file("output", "malawi_coarse_output_download.zip",
                 package = "hintr"))
+class(mock_model) <- "hintr_output"
 
 test_mock_model_available <- function() {
   invisible(lapply(mock_model, function(x) {
@@ -52,4 +53,23 @@ setup_calibrate_payload <- function(version = NULL) {
   payload <- gsub("<version_info>", version, payload, fixed = TRUE)
   writeLines(payload, path)
   path
+}
+
+
+clone_model_output <- function(output) {
+  output_path <- tempfile()
+  file.copy(output$output_path, output_path)
+  spectrum_path <- tempfile(fileext = ".zip")
+  file.copy(output$spectrum_path, spectrum_path)
+  coarse_output_path <- tempfile(fileext = ".zip")
+  file.copy(output$coarse_output_path, coarse_output_path)
+  calibration_path <- tempfile(fileext = ".rds")
+  file.copy(output$calibration_path, calibration_path)
+  out <- list(output_path = output_path,
+              spectrum_path = spectrum_path,
+              coarse_output_path = coarse_output_path,
+              calibration_path = calibration_path,
+              metadata = output$metadata)
+  class(out) <- "hintr_output"
+  out
 }

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -32,3 +32,14 @@ setup_submit_payload <- function(version = NULL, include_anc_art = TRUE) {
   writeLines(payload, path)
   path
 }
+
+setup_calibrate_payload <- function(version = NULL) {
+  path <- tempfile()
+  if (is.null(version)) {
+    version <- to_json(cfg$version_info)
+  }
+  payload <- readLines("payload/model_calibrate_payload.json")
+  payload <- gsub("<version_info>", version, payload, fixed = TRUE)
+  writeLines(payload, path)
+  path
+}

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -268,7 +268,7 @@ test_that("model interactions", {
   })
 })
 
-test_that("real model can be run by API", {
+test_that("real model can be run & calibrated by API", {
   payload <- setup_submit_payload()
   ## Results can be stored in specified results directory
   results_dir <- tempfile("results")
@@ -310,7 +310,8 @@ test_that("real model can be run by API", {
   })
 
   ## Get the result
-  r <- httr::GET(paste0(server$url, "/model/result/", response$data$id))
+  id <- response$data$id
+  r <- httr::GET(paste0(server$url, "/model/result/", id))
   expect_equal(httr::status_code(r), 200)
   response <- response_from_json(r)
   expect_equal(response$status, "success")
@@ -369,6 +370,25 @@ test_that("real model can be run by API", {
                     "plhiv", "incidence", "new_infections", "receiving_art",
                     "anc_prevalence", "anc_art_coverage"))
   })
+
+  ## Calibrate
+  payload <- setup_calibrate_payload()
+  r <- httr::POST(paste0(server$url, "/model/calibrate/", id),
+                  body = httr::upload_file(payload, type = "application/json"),
+                  encode = "json")
+  expect_equal(httr::status_code(r), 200)
+
+  ## Response has same structure content as model result endpoint
+  response <- response_from_json(r)
+  expect_equal(response$status, "success")
+  expect_equal(response$errors, NULL)
+  expect_equal(names(response$data), c("data", "plottingMetadata"))
+  expect_equal(names(response$data$data[[1]]),
+               c("area_id", "sex", "age_group", "calendar_quarter",
+                 "indicator_id", "mode", "mean", "lower", "upper"))
+  expect_true(length(response$data$data) > 84042)
+  expect_equal(names(response$data$plottingMetadata),
+               c("barchart", "choropleth"))
 })
 
 test_that("plotting metadata is exposed", {
@@ -793,51 +813,4 @@ test_that("endpoint_model_submit can be run without anc or programme data", {
   expect_equal(response$status, "success")
   expect_equal(response$errors, NULL)
   expect_equal(names(response$data), c("id"))
-})
-
-
-test_that("model can be calibrated", {
-  test_mock_model_available()
-  payload <- setup_submit_payload()
-  server <- hintr_server()
-
-  ## Submit a model run
-  r <- httr::POST(paste0(server$url, "/model/submit"),
-                  body = httr::upload_file(payload, type = "application/json"),
-                  encode = "json")
-  expect_equal(httr::status_code(r), 200)
-  response <- response_from_json(r)
-  expect_equal(response$status, "success")
-  expect_equal(response$errors, NULL)
-  expect_equal(names(response$data), c("id"))
-
-  ## Get the status
-  testthat::try_again(4, {
-    Sys.sleep(2)
-    r <- httr::GET(paste0(server$url, "/model/status/", response$data$id))
-    expect_equal(httr::status_code(r), 200)
-    response <- response_from_json(r)
-    expect_equal(response$status, "success")
-    expect_equal(response$data$status, "COMPLETE")
-    expect_equal(response$data$success, TRUE)
-  })
-
-  ## Calibrate
-  payload <- setup_calibrate_payload()
-  r <- httr::POST(paste0(server$url, "/model/calibrate/", response$data$id),
-                 body = httr::upload_file(payload, type = "application/json"),
-                 encode = "json")
-  expect_equal(httr::status_code(r), 200)
-
-  ## Response has same content as model result endpoint
-  response <- response_from_json(r)
-  expect_equal(response$status, "success")
-  expect_equal(response$errors, NULL)
-  expect_equal(names(response$data), c("data", "plottingMetadata"))
-  expect_equal(names(response$data$data[[1]]),
-               c("area_id", "sex", "age_group", "calendar_quarter",
-                 "indicator_id", "mode", "mean", "lower", "upper"))
-  expect_true(length(response$data$data) > 84042)
-  expect_equal(names(response$data$plottingMetadata),
-               c("barchart", "choropleth"))
 })

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -805,3 +805,50 @@ test_that("endpoint_model_submit can be run without anc or programme data", {
   expect_equal(response$errors, NULL)
   expect_equal(names(response$data), c("id"))
 })
+
+
+test_that("model can be calibrated", {
+  test_mock_model_available()
+  payload <- setup_submit_payload()
+  server <- hintr_server()
+
+  ## Submit a model run
+  r <- httr::POST(paste0(server$url, "/model/submit"),
+                  body = httr::upload_file(payload, type = "application/json"),
+                  encode = "json")
+  expect_equal(httr::status_code(r), 200)
+  response <- response_from_json(r)
+  expect_equal(response$status, "success")
+  expect_equal(response$errors, NULL)
+  expect_equal(names(response$data), c("id"))
+
+  ## Get the status
+  testthat::try_again(4, {
+    Sys.sleep(2)
+    r <- httr::GET(paste0(server$url, "/model/status/", response$data$id))
+    expect_equal(httr::status_code(r), 200)
+    response <- response_from_json(r)
+    expect_equal(response$status, "success")
+    expect_equal(response$data$status, "COMPLETE")
+    expect_equal(response$data$success, TRUE)
+  })
+
+  ## Calibrate
+  payload <- setup_calibrate_payload()
+  r <- httr::POST(paste0(server$url, "/model/calibrate/", response$data$id),
+                 body = httr::upload_file(payload, type = "application/json"),
+                 encode = "json")
+  expect_equal(httr::status_code(r), 200)
+
+  ## Response has same content as model result endpoint
+  response <- response_from_json(r)
+  expect_equal(response$status, "success")
+  expect_equal(response$errors, NULL)
+  expect_equal(names(response$data), c("data", "plottingMetadata"))
+  expect_equal(names(response$data$data[[1]]),
+               c("area_id", "sex", "age_group", "calendar_quarter",
+                 "indicator_id", "mode", "mean", "lower", "upper"))
+  expect_true(length(response$data$data) > 84042)
+  expect_equal(names(response$data$plottingMetadata),
+               c("barchart", "choropleth"))
+})

--- a/tests/testthat/payload/model_calibrate_payload.json
+++ b/tests/testthat/payload/model_calibrate_payload.json
@@ -1,0 +1,11 @@
+{
+  "options": {
+    "spectrum_plhiv_calibration_level": "none",
+    "spectrum_plhiv_calibration_strat": "sex_age_group",
+    "spectrum_artnum_calibration_level": "none",
+    "spectrum_artnum_calibration_strat": "age_coarse",
+    "spectrum_infections_calibration_level": "none",
+    "spectrum_infections_calibration_strat": "age_coarse"
+  },
+  "version": <version_info>
+}

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -1100,11 +1100,8 @@ test_that("endpoint_model_calibrate can be run", {
 
   endpoint <- endpoint_model_calibrate(queue)
   out <- queue$queue$task_wait(run_response$data$id)
-  calibration_options <- list(
-    "calibrate_option_1" = scalar("placeholder")
-  )
-  response <- endpoint$run(run_response$data$id,
-                           jsonlite::toJSON(calibration_options))
+  path <- setup_calibrate_payload()
+  response <- endpoint$run(run_response$data$id, readLines(path))
 
   expect_equal(response$status_code, 200)
   expect_equal(names(response$data), c("data", "plottingMetadata"))

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -458,10 +458,8 @@ test_that("can calibrate a model result", {
   ## Calibrate the result
   mock_calibrate <- mockery::mock(queue$result(response$id))
   path <- setup_calibrate_payload()
-  with_mock("hintr:::calibrate_result" = mock_calibrate, {
-    calibrate <- model_calibrate(queue)
-    calibrated_result <- calibrate(response$id, readLines(path))
-  })
+  calibrate <- model_calibrate(queue)
+  calibrated_result <- calibrate(response$id, readLines(path))
 
   expect_equal(calibrated_result, result)
   args <- mockery::mock_args(mock_calibrate)

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -11,7 +11,7 @@ test_that("plumber api can be built", {
                  "survey-and-programme", "options"))
   expect_equal(names(api$routes$model),
                c("options", "submit", "status", "result", "cancel", "debug",
-                 "calibration-options", "clibrate"))
+                 "calibration-options", "calibrate"))
   expect_equal(names(api$routes$meta), "plotting")
 })
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -11,7 +11,7 @@ test_that("plumber api can be built", {
                  "survey-and-programme", "options"))
   expect_equal(names(api$routes$model),
                c("options", "submit", "status", "result", "cancel", "debug",
-                 "calibration-options"))
+                 "calibration-options", "clibrate"))
   expect_equal(names(api$routes$meta), "plotting")
 })
 

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -48,7 +48,8 @@ test_that("queue works as intended", {
   ## Result can be retrieved after task has completed
   res <- queue$result(job_id)
   expect_equal(names(res), c("output_path", "spectrum_path",
-                             "coarse_output_path", "metadata"))
+                             "coarse_output_path", "calibration_path",
+                             "metadata"))
   expect_length(queue$queue$task_list(), 1)
 
   ## task can be cleaned up

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -156,7 +156,8 @@ test_that("real model can be run", {
     model_run <- run_model(data, options, tempdir())
   })
   expect_equal(names(model_run), c("output_path", "spectrum_path",
-                                   "coarse_output_path", "metadata"))
+                                   "coarse_output_path", "calibration_path",
+                                   "metadata"))
 
   output <- readRDS(model_run$output_path)
   expect_equal(colnames(output),
@@ -229,7 +230,8 @@ test_that("real model can be run with csv2 data", {
   })
 
   expect_equal(names(model_run), c("output_path", "spectrum_path",
-                                   "coarse_output_path", "metadata"))
+                                   "coarse_output_path", "calibration_path",
+                                   "metadata"))
 
   output <- readRDS(model_run$output_path)
   expect_equal(colnames(output),


### PR DESCRIPTION
This PR will
* Add a placeholder endpoint for calibrating model run

Note this builds on #197 and should be merged after that

The full impl of this endpoint is blocked on naomi impl to do the calibration. This at the moment just returns the same result as the model result will without any calibration.
