### PR TITLE
Fix memory problems

### DIFF
--- a/R/queue.R
+++ b/R/queue.R
@@ -93,7 +93,7 @@ Queue <- R6::R6Class(
       clear_cache(self$queue$keys$queue_id)
       if (self$cleanup_on_exit && !is.null(self$queue$con)) {
         message(t_("QUEUE_STOPPING_WORKERS"))
-        self$queue$worker_stop()
+        self$queue$worker_stop(type = "kill")
         self$destroy()
       }
     }

--- a/R/queue.R
+++ b/R/queue.R
@@ -33,7 +33,8 @@ Queue <- R6::R6Class(
 
     start = function(workers) {
       if (workers > 0L) {
-        rrq::worker_spawn(self$queue, workers)
+        ids <- rrq::worker_spawn(self$queue, workers)
+        self$queue$message_send_and_wait("TIMEOUT_SET", 300, ids)
       }
     },
 

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -1,7 +1,5 @@
 context("server")
 
-gc()
-
 test_that("Root", {
   server <- hintr_server()
 
@@ -270,9 +268,6 @@ test_that("model interactions", {
   })
 })
 
-## Add garbage collects to avoid intermittent failures
-gc()
-
 test_that("real model can be run by API", {
   payload <- setup_submit_payload()
   ## Results can be stored in specified results directory
@@ -375,9 +370,6 @@ test_that("real model can be run by API", {
                     "anc_prevalence", "anc_art_coverage"))
   })
 })
-
-## Add garbage collects to avoid intermittent failures
-gc()
 
 test_that("plotting metadata is exposed", {
   server <- hintr_server()
@@ -601,9 +593,6 @@ test_that("spectrum file download streams bytes", {
     system_file("output", "malawi_spectrum_download.zip")))
 })
 
-## Add garbage collects to avoid intermittent failures
-gc()
-
 test_that("summary file download streams bytes", {
   test_mock_model_available()
   server <- hintr_server()
@@ -786,9 +775,6 @@ test_that("download_debug prevents overwriting", {
     download_debug(id, dest = tmp),
     "Path 'abc' already exists at destination")
 })
-
-## Add garbage collects to avoid intermittent failures
-gc()
 
 test_that("endpoint_model_submit can be run without anc or programme data", {
   test_mock_model_available()

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -292,9 +292,6 @@ test_that("endpoint_model_options", {
   expect_true(all(grepl("^(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)$", body$version)))
 })
 
-## Add garbage collects to avoid intermittent failures
-gc()
-
 test_that("endpoint_model_options works", {
   test_redis_available()
   queue <- test_queue(workers = 0)
@@ -424,12 +421,9 @@ test_that("api can call endpoint_model_options_validate", {
   expect_true(body$data$valid)
 })
 
-## Add garbage collects to avoid intermittent failures
-gc()
-
 test_that("endpoint_model_submit can be run", {
   test_redis_available()
-  queue <- test_queue()
+  queue <- test_queue(workers = 1)
   endpoint <- endpoint_model_submit(queue)
   path <- setup_submit_payload()
   response <- endpoint$run(readLines(path))
@@ -723,9 +717,6 @@ test_that("returning_json_version adds version", {
                unclass(cfg$version_info$traduire))
 })
 
-## Add garbage collects to avoid intermittent failures
-gc()
-
 test_that("endpoint_download_spectrum can be run", {
   test_redis_available()
   test_mock_model_available()
@@ -998,9 +989,6 @@ test_that("api can call endpoint_model_debug", {
   ## Download contains data
   expect_true(length(res$body) > 1000000)
 })
-
-## Add garbage collects to avoid intermittent failures
-gc()
 
 test_that("endpoint_hintr_version works", {
   endpoint <- endpoint_hintr_version()

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -423,7 +423,7 @@ test_that("api can call endpoint_model_options_validate", {
 
 test_that("endpoint_model_submit can be run", {
   test_redis_available()
-  queue <- test_queue(workers = 1)
+  queue <- test_queue(workers = 0)
   endpoint <- endpoint_model_submit(queue)
   path <- setup_submit_payload()
   response <- endpoint$run(readLines(path))

--- a/tests/testthat/test-endpoints-model-options.R
+++ b/tests/testthat/test-endpoints-model-options.R
@@ -1,8 +1,5 @@
 context("endpoints-model-options")
 
-## Add garbage collects to avoid intermittent failures
-gc()
-
 test_that("endpoint_model_options returns model options", {
   input <- model_options_input(file.path("testdata", "malawi.geojson"),
                                file.path("testdata", "survey.csv"),

--- a/tests/testthat/test-endpoints-validate-baseline-all.R
+++ b/tests/testthat/test-endpoints-validate-baseline-all.R
@@ -1,9 +1,5 @@
 context("endpoints-validate-baseline")
 
-## Force a garbage collect here, as otherwise we get a really
-## difficult to deal with error.
-gc()
-
 test_that("endpoint_validate_baseline_combined correctly validates data", {
   input <- validate_baseline_all_input(file.path("testdata", "Malawi2019.PJNZ"),
                                        file.path("testdata", "malawi.geojson"),

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -97,9 +97,6 @@ test_that("error thrown if more than 1 country with a 0 spectrum region code", {
   expect_equal(error$status_code, 400)
 })
 
-## Add garbage collects to avoid intermittent failures
-gc()
-
 test_that("validate_baseline supports shape files", {
   input <- validate_baseline_input(file.path("testdata", "malawi.geojson"),
                                    "shape")

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -82,3 +82,12 @@ test_that("queue_id is returned if supplied", {
     c("HINTR_QUEUE_ID" = NA),
     expect_equal(hintr_queue_id("myqueue", TRUE), "myqueue"))
 })
+
+test_that("test queue starts workers with timeout", {
+  queue <- test_queue(workers = 2)
+  timeout <- queue$queue$message_send_and_wait("TIMEOUT_GET",
+                                               queue$queue$worker_list())
+  expect_length(timeout, 2)
+  expect_equal(timeout[[1]][["timeout"]], 300.0)
+  expect_equal(timeout[[2]][["timeout"]], 300.0)
+})

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -10,11 +10,16 @@ test_that("queue works as intended", {
   worker_1 <- queue$queue$worker_list()[[1]]
   worker_2 <- queue$queue$worker_list()[[2]]
 
-  expect_equal(nrow(queue$queue$worker_log_tail(worker_1)), 1)
-  expect_equal(queue$queue$worker_log_tail(worker_1)$command, "ALIVE")
+  expect_equal(nrow(queue$queue$worker_log_tail(worker_1, 3)), 3)
+  expect_equal(queue$queue$worker_log_tail(worker_1, 3)[1, "command"], "ALIVE")
+  expect_equal(queue$queue$worker_log_tail(worker_1, 3)[3, "message"],
+               "TIMEOUT_SET")
 
-  expect_equal(nrow(queue$queue$worker_log_tail(worker_2)), 1)
-  expect_equal(queue$queue$worker_log_tail(worker_2)$command, "ALIVE")
+  expect_equal(nrow(queue$queue$worker_log_tail(worker_2, 3)), 3)
+  expect_equal(queue$queue$worker_log_tail(worker_2, 3)[1, "command"], "ALIVE")
+  expect_equal(queue$queue$worker_log_tail(worker_2, 3)[3, "message"],
+               "TIMEOUT_SET")
+
 
   expect_length(queue$queue$task_list(), 0)
 


### PR DESCRIPTION
Special 200th PR :confetti_ball: :champagne: :partying_face: 

This PR will
* Make sure workers are killed
* Workers spawned by queue have a timeout of 5 mins

This (hopefully) fixes all the annoying memory issues I've had working with hintr. The problem was in particular tests where they start a job on a worker and then the test completes before the job finishes the call to `cleanup` would not kill the worker processes. This meant after running test suite you would end up with several orphaned worker processes using up memory