### PR TITLE
Add test and fix for backward compatability for model output downloads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     heartbeatr,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 1.0.4),
+    naomi (== 1.0.4),
     pkgapi (>= 0.0.9),
     R6,
     redux,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     heartbeatr,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (== 1.0.4),
+    naomi (== 1.0.5),
     pkgapi (>= 0.0.9),
     R6,
     redux,

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -205,9 +205,20 @@ download <- function(queue, type, filename) {
       if (is_error(res)) {
         hintr_error(res$message, "MODEL_RUN_FAILED")
       }
+      ## We renamed download from "summary" to "coarse_output" to be more
+      ## representative of the actual content of the download and in
+      ## preparation for adding a summary report.
+      ## To be backwards compatible with old model results from the app
+      ## we need to fallback to old name if the new name isn't available in
+      ## the model result.
+      if ("coarse_output_path" %in% names(res)) {
+        coarse_output <- res$coarse_output_path
+      } else {
+        coarse_output <- res$summary_path
+      }
       path <- switch(type,
                      "spectrum" = res$spectrum_path,
-                     "coarse_output" = res$coarse_output_path)
+                     "coarse_output" = coarse_output)
       bytes <- readBin(path, "raw", n = file.size(path))
       bytes <- pkgapi::pkgapi_add_headers(bytes, list(
         "Content-Disposition" = build_content_disp_header(res$metadata$areas,

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone --single-branch --branch mrc-1790 https://github.com/mrc-ide/naomi
+git clone --single-branch --branch mrc-1792 https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone --single-branch --branch mrc-1792 https://github.com/mrc-ide/naomi
+git clone --single-branch --branch mrc-1790 https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone --single-branch --branch mrc-1790 https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -6,8 +6,9 @@ mock_model <- list(
   output_path = system.file("output", "malawi_output.rds", package = "hintr"),
   spectrum_path = system.file("output", "malawi_spectrum_download.zip",
                               package = "hintr"),
-  summary_path = system.file("output", "malawi_coarse_output_download.zip",
-                             package = "hintr"))
+  coarse_output_path =
+    system.file("output", "malawi_coarse_output_download.zip",
+                package = "hintr"))
 
 test_mock_model_available <- function() {
   invisible(lapply(mock_model, function(x) {
@@ -17,6 +18,15 @@ test_mock_model_available <- function() {
     }
   }))
 }
+
+## Model output as returned by
+## hintr version 0.1.1 and naomi version 1.0.3
+mock_model_v0.1.1 <- list(
+  output_path = system.file("output", "malawi_output.rds", package = "hintr"),
+  spectrum_path = system.file("output", "malawi_spectrum_download.zip",
+                              package = "hintr"),
+  summary_path = system.file("output", "malawi_coarse_output_download.zip",
+                             package = "hintr"))
 
 setup_submit_payload <- function(version = NULL, include_anc_art = TRUE) {
   path <- tempfile()

--- a/tests/testthat/test-endpoints-download.R
+++ b/tests/testthat/test-endpoints-download.R
@@ -82,3 +82,20 @@ test_that("download returns useful error if model result can't be retrieved", {
   expect_equal(error$status_code, 400)
 })
 
+test_that("download works with v0.1.1 model run result", {
+  test_redis_available()
+  test_mock_model_available()
+
+  ## Setup payload
+  path <- setup_submit_payload()
+
+  ## Return v0.1.1 model results
+  queue <- MockQueue$new()
+  unlockBinding("result", queue)
+  queue$result <- mockery::mock(mock_model_v0.1.1)
+  coarse_output <- download_coarse_output(queue)
+  download <- coarse_output("id")
+  expect_type(download, "raw")
+  expect_length(download, file.size(
+    system_file("output", "malawi_coarse_output_download.zip")))
+})


### PR DESCRIPTION
I should probably have realised this when changing the name :see_no_evil: 