### PR TITLE
mrc-1874: Don't set timeout outside of our test environment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/tests/testthat/helper-queue.R
+++ b/tests/testthat/helper-queue.R
@@ -20,7 +20,7 @@ MockQueue <- R6::R6Class(
 )
 
 test_queue <- function(workers = 2) {
-  queue <- Queue$new(workers = workers)
+  queue <- Queue$new(workers = workers, timeout = 300)
   withr::defer_parent({
     message("cleaning up workers")
     queue$cleanup()

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -97,3 +97,13 @@ test_that("test queue starts workers with timeout", {
   expect_equal(timeout[[1]][["timeout"]], 300.0)
   expect_equal(timeout[[2]][["timeout"]], 300.0)
 })
+
+
+test_that("queue starts up normally without a timeout", {
+  queue <- Queue$new(workers = 1)
+  on.exit(queue$cleanup())
+  timeout <- queue$queue$message_send_and_wait("TIMEOUT_GET",
+                                               queue$queue$worker_list(),
+                                               progress = FALSE)
+  expect_equal(timeout[[1]], c("timeout" = Inf, remaining = Inf))
+})

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -4,7 +4,7 @@ test_that("queue works as intended", {
   test_redis_available()
   test_mock_model_available()
 
-  queue <- Queue$new()
+  queue <- Queue$new(timeout = 300)
   expect_equal(queue$queue$worker_len(), 2)
 
   worker_1 <- queue$queue$worker_list()[[1]]


### PR DESCRIPTION
This PR removes the timeout from spawned workers outside of `test_queue`, which means that workers started in hint development will not turn themselves off