### PR TITLE
Pin to naomi@anc-testing-cascade

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.11
+Version: 0.1.12
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",
@@ -22,7 +22,7 @@ Imports:
     heartbeatr,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 2.0.6),
+    naomi (>= 2.1.0),
     porcelain (>= 0.1.0),
     R6,
     redux,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 0.1.12
+
+* Pin to naomi@anc-testing-cascade
+
 # hintr 0.1.11
 
 * Add endpoint `<+calendar_quarter_t1_default+>` to select most recent survey calendar 

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone --single-branch --branch anc-testing-cascade https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -62,7 +62,7 @@ test_that("endpoint model run queues a model run", {
   expect_equal(barchart$filters[[2]]$options[[2]]$label,
                scalar("September 2018"))
   expect_true(length(barchart$filters[[4]]$options) >= 29)
-  expect_equal(nrow(barchart$indicators), 10)
+  expect_equal(nrow(barchart$indicators), 17)
 
   ## Quarters are in descending order
   calendar_quarters <-
@@ -77,7 +77,10 @@ test_that("endpoint model run queues a model run", {
   expect_equal(barchart$indicators$indicator,
                c("population", "prevalence", "plhiv", "art_coverage",
                  "art_current_residents", "art_current", "incidence",
-                 "infections", "anc_prevalence", "anc_art_coverage"))
+                 "infections", "anc_prevalence", "anc_art_coverage",
+                 "anc_clients", "anc_plhiv", "anc_already_art",
+                 "anc_art_new", "anc_known_pos",
+                 "anc_tested_pos", "anc_tested_neg"))
 
   ## Choropleth
   choropleth <- result$plottingMetadata$choropleth

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -24,7 +24,7 @@ test_that("model can be run and filters extracted", {
   expect_length(barchart$filters[[2]]$options, 3)
   expect_equal(barchart$filters[[2]]$options[[2]]$id, scalar("CY2018Q3"))
   expect_equal(barchart$filters[[2]]$options[[2]]$label, scalar("September 2018"))
-  expect_equal(nrow(barchart$indicators), 10)
+  expect_equal(nrow(barchart$indicators), 17)
   expect_true(all(c("population", "prevalence", "plhiv", "art_coverage",
                     "art_current_residents", "art_current", "incidence",
                     "infections", "anc_prevalence", "anc_art_coverage") %in%
@@ -84,7 +84,7 @@ test_that("model without national level results can be processed", {
   expect_length(barchart$filters[[2]]$options, 3)
   expect_equal(barchart$filters[[2]]$options[[2]]$id, scalar("CY2018Q3"))
   expect_equal(barchart$filters[[2]]$options[[2]]$label, scalar("September 2018"))
-  expect_equal(nrow(barchart$indicators), 10)
+  expect_equal(nrow(barchart$indicators), 17)
   expect_true(all(c("population", "prevalence", "plhiv", "art_coverage",
                     "art_current_residents", "art_current", "incidence",
                     "infections", "anc_prevalence", "anc_art_coverage") %in%


### PR DESCRIPTION
This pins to Naomi issue 157 to implement the ANC testing cascade outputs: https://github.com/mrc-ide/naomi/pull/157

This includes edits to the model options page and adds output indicators. But I don't think it should affect hintr. Fingers crossed.

Thanks,
Jeff