### PR TITLE
Turn off multithreading for TMB

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,5 +32,8 @@ RUN R CMD INSTALL /src
 
 EXPOSE 8888
 ENV HINTR_QUEUE_ID=hintr
+## Model run will try to parallelise over as many threads as are available
+## potentially slowing the application, manually limit threads to 1
+ENV OMP_NUM_THREADS=1
 
 ENTRYPOINT ["/usr/local/bin/hintr_api"]

--- a/docker/bin/hintr_worker
+++ b/docker/bin/hintr_worker
@@ -1,2 +1,5 @@
 #!/usr/bin/env Rscript
+## TMB will try to use as many cores as possible (potentially slowing the
+## rest of the application down) unless we explicitly limit it to only 1 core.
+TMB::openmp(1)
 hintr:::main_worker()

--- a/docker/bin/hintr_worker
+++ b/docker/bin/hintr_worker
@@ -1,5 +1,2 @@
 #!/usr/bin/env Rscript
-## TMB will try to use as many cores as possible (potentially slowing the
-## rest of the application down) unless we explicitly limit it to only 1 core.
-TMB::openmp(1)
 hintr:::main_worker()


### PR DESCRIPTION
Not sure how to test this, running locally without this change it isn't running on more than 1 CPU and staging has only 1 CPU available as it is a vagrant box. Open to suggestions. I can at least test on staging to make sure it doesn't break anything.