### PR TITLE
Validate survey data survey_mid_calendar_quarter column

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# hintr 0.1.14
+
+* Generalize functions `assert_calendar_quarter_column()` and `assert_year_column()` to 
+  accept argument `col_name=` to check columns of required specification with different name.
+
+  
 # hintr 0.1.13
 
 * Pin to naomi@issue-142

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -187,10 +187,11 @@ do_validate_survey <- function(survey, shape) {
   assert_consistent_regions(read_regions(shape, "shape"),
                             read_regions(survey, "survey"),
                             "survey")
+  assert_calendar_quarter_column(data, "survey_mid_calendar_quarter")
   assert_unique_combinations(data, c("area_id", "survey_id", "sex", "age_group", "indicator"))
   assert_expected_values(data, "sex", c("male", "female", "both"))
   assert_expected_values(data, "age_group", naomi::get_age_groups()$age_group)
-  assert_column_positive_numeric(data, c("n_clusters", "n_observations",
+  assert_column_positive_numeric(data, c("n_clusters", "n_observations", "n_eff_kish",
                                          "estimate", "std_error", "ci_lower", "ci_upper"))
   list(data = data,
        filters = list("age" = get_age_filters(data),

--- a/R/validation_asserts.R
+++ b/R/validation_asserts.R
@@ -67,12 +67,12 @@ assert_column_matches <- function(data, column_name, pattern) {
   invisible(TRUE)
 }
 
-assert_calendar_quarter_column <- function(data) {
-  assert_column_matches(data, "calendar_quarter", "^CY[12][901][0-9]{2}Q[1-4]$")
+assert_calendar_quarter_column <- function(data, col_name = "calendar_quarter") {
+  assert_column_matches(data, col_name, "^CY[12][901][0-9]{2}Q[1-4]$")
 }
 
-assert_year_column <- function(data) {
-  assert_column_matches(data, "year", "^[12][901][0-9][0-9]$")
+assert_year_column <- function(data, col_name = "year") {
+  assert_column_matches(data, col_name, "^[12][901][0-9][0-9]$")
 }
 
 #' Check that the values of a column are not NA

--- a/tests/testthat/test-validation-asserts.R
+++ b/tests/testthat/test-validation-asserts.R
@@ -228,6 +228,23 @@ test_that("can check column values for expected patterns", {
 
 })
 
+test_that("assert_calendar_quarter() generalises column name", {
+
+  data <- data.frame("survey_calendar_quarter" = "CY2020Q3",
+                     "survey_year" = 2020)
+  expect_error(
+    assert_calendar_quarter_column(data),
+    "Data does not contain required column: calendar_quarter"
+  )
+  expect_true(assert_calendar_quarter_column(data, "survey_calendar_quarter"))
+
+  expect_error(
+    assert_year_column(data),
+    "Data does not contain required column: year"
+  )
+  expect_true(assert_year_column(data, "survey_year"))
+})
+
 test_that("can check data comes from a single source", {
   data <- data.frame(source=c("NSO", "NSO", "NSO"))
 


### PR DESCRIPTION
This PR:
* Revises the functions `assert_calendar_quarter_column()` and `assert_year_column()` to accept an argument `col_type = ` to apply the validation to columns with a different name but same specification.
* Adds assertion check to for `survey_mid_calendar_quarter` column in `do_validate_survey()`

This would catch the error from Tuesday just before the UNAIDS ToT due to misspecified survey_mid_calendar_quarter upon data upload.