### PR TITLE
pin to naomi@option-output-aware

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.13
+Version: 0.1.14
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# # hintr 0.1.14
+
+* Pin to naomi@option-output-aware
+
 # hintr 0.1.13
 
 * Pin to naomi@issue-142

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone --single-branch --branch option-output-aware https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/inst/schema/ModelRunOptions.schema.json
+++ b/inst/schema/ModelRunOptions.schema.json
@@ -72,7 +72,7 @@
         "controlGroups": { 
           "type": "array", 
           "items": { "$ref": "#/definitions/controlGroup" }
-	}
+        }
       },
       "additionalProperties": false,
       "required": [ "label", "controlGroups" ]

--- a/inst/schema/ModelRunOptions.schema.json
+++ b/inst/schema/ModelRunOptions.schema.json
@@ -67,10 +67,12 @@
       "properties": {
         "label": { "type": "string" },
         "description": { "type": "string" },
+	"collapsible": { "type": "boolean" },
+	"collapsed" : { "type": "boolean" },
         "controlGroups": { 
           "type": "array", 
           "items": { "$ref": "#/definitions/controlGroup" }
-        }
+	}
       },
       "additionalProperties": false,
       "required": [ "label", "controlGroups" ]


### PR DESCRIPTION
Let's try this again. This is pinned to naomi@option-output-aware (mrc-ide/naomi#178).

* adds an advanced option "output_aware_plhiv" and
* makes advanced options block collapsible

The ModelRunOptions.schema needs `collapsible` and `collapsed` added: 
https://github.com/mrc-ide/hintr/blob/master/inst/schema/ModelRunOptions.schema.json#L73