### PR TITLE
Turn off input validation when queueing a model run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.15
+Version: 0.1.16
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",
@@ -22,7 +22,7 @@ Imports:
     heartbeatr,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 2.1.0),
+    naomi (>= 2.1.2),
     porcelain (>= 0.1.0),
     R6,
     redux,

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -80,7 +80,7 @@ run_model <- function(data, options, path_results, path_prerun = NULL,
 
   naomi::hintr_run_model(data, options, output_path, spectrum_path,
                          coarse_output_path, summary_report_path,
-                         calibration_path)
+                         calibration_path, validate = FALSE)
 }
 
 select_data <- function(data) {

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone --single-branch --branch issue-175 https://github.com/mrc-ide/naomi
+git clone https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone --single-branch --branch issue-175 https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -351,11 +351,16 @@ test_that("error messages from naomi are translated", {
                               test_queue(workers = 1))
 
   model_submit <- submit_model(queue)
-  ## Create an option set which deliberately has an error
+  ## Create a population file which deliberately will cause an error
   path <- setup_submit_payload()
   payload <- readLines(path)
-  payload <- gsub('"area_level": 4', '"area_level": 0', payload, fixed = TRUE)
-  writeLines(payload, path)
+  payload <- jsonlite::read_json(path)
+  pop <- read.csv(payload$data$population$path)
+  pop$sex <- NULL
+  t <- tempfile()
+  write.csv(pop, t)
+  payload$data$population$path <- t
+  writeLines(jsonlite::toJSON(payload), path)
 
   response <- with_hintr_language(
     "fr",
@@ -367,8 +372,7 @@ test_that("error messages from naomi are translated", {
   error <- expect_error(get_result(id))
   expect_equal(error$data[[1]]$error, scalar("MODEL_RUN_FAILED"))
   expect_equal(error$data[[1]]$detail,
-               scalar(paste0("Impossible d’ajuster le modèle au niveau du ",
-                             "pays. Choisissez un niveau différent.")))
+               scalar("Colonnes obligatoires introuvables: sex"))
 })
 
 test_that("failed cancel sends reasonable message", {


### PR DESCRIPTION
This is no longer necessary to run from the app because the model options validate button now does the validation. 

Progress messages have been updated in naomi.