### PR TITLE
Turn off calibration on calibration endpoint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.18
+Version: 0.1.19
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",
@@ -22,7 +22,7 @@ Imports:
     heartbeatr,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 2.1.5),
+    naomi (>= 2.1.8),
     porcelain (>= 0.1.0),
     R6,
     redux,

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -181,9 +181,9 @@ model_calibrate <- function(queue) {
     if (!is_current_version(calibration_options$version)) {
       hintr_error(t_("MODEL_SUBMIT_OLD"), "VERSION_OUT_OF_DATE")
     }
-    calibrated_result <- naomi::hintr_calibrate(queue$result(id),
-                                                calibration_options$options)
-    process_result(calibrated_result)
+    ## TODO: run calibration asynchronously, takes too long to do sync
+    ## see mrc-2040
+    process_result(queue$result(id))
   }
 }
 

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone --single-branch --branch calibration-hotfix https://github.com/mrc-ide/naomi
+git clone https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone --single-branch --branch calibration-hotfix https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/tests/testthat/test-endpoints-model-options.R
+++ b/tests/testthat/test-endpoints-model-options.R
@@ -233,7 +233,7 @@ test_that("invalid model options returns error", {
 test_that("can get calibration options", {
   options <- calibration_options()
   expect_length(options, 1)
-  expect_true(any(grepl("Calibration options", options)))
+  expect_true(any(grepl("Post model fit calibration", options)))
   expect_true(any(grepl("controlSections", options)))
 })
 

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -504,6 +504,7 @@ test_that("model calibration fails is version out of date", {
 })
 
 test_that("trying to calibrate old model result returns error", {
+  skip("Re-enable when calibration is run again, see mrc-2040")
   test_mock_model_available()
 
   ## Mock model run

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -524,3 +524,27 @@ test_that("trying to calibrate old model result returns error", {
   expect_equal(error$message, paste0("Can't calibrate this model output please",
                                      " re-run model and try calibration again"))
 })
+
+test_that("Calibration returns processed result and doesn't use naomi", {
+  test_mock_model_available()
+
+  ## Mock model run
+  queue <- test_queue(workers = 0)
+  unlockBinding("result", queue)
+  ## Clone model output as it modifies in place
+  out <- clone_model_output(mock_model)
+  queue$result <- mockery::mock(out)
+  unlockBinding("queue", queue)
+  unlockBinding("task_status", queue$queue)
+  queue$queue$task_status <- mockery::mock("COMPLETE")
+
+  ## Calibrate the result
+  path <- setup_calibrate_payload()
+  mock_naomi_calibrate <- mockery::mock()
+  with_mock("naomi::hintr_calibrate" = mock_naomi_calibrate, {
+    calibrate <- model_calibrate(queue)
+    calibrated_result <- calibrate("id", readLines(path))
+  })
+  expect_equal(calibrated_result, process_result(mock_model))
+  mockery::expect_called(mock_naomi_calibrate, 0)
+})


### PR DESCRIPTION
This PR will
* Stop calling `naomi::hintr_calibrate` as this is too slow to run on the API

see https://github.com/mrc-ide/naomi/pull/191 for more details