### PR TITLE
mrc-2049: Add a generic submit method to queue

### DIFF
--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -128,7 +128,7 @@ submit_model <- function(queue) {
       hintr_error(t_("MODEL_SUBMIT_OLD"), "VERSION_OUT_OF_DATE")
     }
     tryCatch(
-      list(id = scalar(queue$submit(input$data, input$options))),
+      list(id = scalar(queue$submit_model_run(input$data, input$options))),
       error = function(e) {
         hintr_error(e$message, "FAILED_TO_QUEUE")
       }

--- a/R/queue.R
+++ b/R/queue.R
@@ -41,11 +41,15 @@ Queue <- R6::R6Class(
       }
     },
 
-    submit = function(data, options) {
+    submit = function(job, environment = parent.frame()) {
+      self$queue$enqueue_(job, environment)
+    },
+
+    submit_model_run = function(data, options) {
       results_dir <- self$results_dir
       prerun_dir <- self$prerun_dir
       language <- traduire::translator()$language()
-      self$queue$enqueue_(quote(
+      self$submit(quote(
         hintr:::run_model(data, options, results_dir, prerun_dir, language)))
     },
 

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -134,11 +134,11 @@ test_that("endpoint_run_model returns error if queueing fails", {
 
   ## Create mocks
   queue <- test_queue()
-  mock_submit <- function(data, options) { stop("Failed to queue") }
+  mock_submit_model_run <- function(data, options) { stop("Failed to queue") }
 
   ## Call the endpoint
   model_submit <- submit_model(queue)
-  mockery::stub(model_submit, "queue$submit", mock_submit)
+  mockery::stub(model_submit, "queue$submit_model_run", mock_submit_model_run)
   error <- expect_error(model_submit(readLines(path)))
 
   expect_equal(error$data[[1]]$error, scalar("FAILED_TO_QUEUE"))


### PR DESCRIPTION
So that we can have some confidence that status & result will work with model run & calibration & any future async work