### PR TITLE
naomi-mrc-2078: Pin to naomi mrc-2078

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.21
+Version: 0.1.22
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",
@@ -22,7 +22,7 @@ Imports:
     heartbeatr,
     ids,
     jsonlite (>= 1.2.2),
-    naomi (>= 2.1.13),
+    naomi (>= 2.1.14),
     porcelain (>= 0.1.0),
     R6,
     redux,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# hintr 0.1.22
+
+* Add endpoints to enable async calibration
+   * /calibrate/submit - queue a model calibration
+   * /calibrate/status - get status of a calibration run
+   * /calibrate/result - get result of a calibration
+* Add calibration options back in and remove from run options
+
 # hintr 0.1.21
 
 * Update to naomi v2.1.10 (branch pin naomi@infections-metadata).

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone --single-branch --branch mrc-2078 https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/tests/testthat/test-endpoints-model-options.R
+++ b/tests/testthat/test-endpoints-model-options.R
@@ -233,7 +233,7 @@ test_that("invalid model options returns error", {
 test_that("can get calibration options", {
   options <- calibration_options()
   expect_length(options, 1)
-  expect_true(any(grepl("Post model fit calibration", options)))
+  expect_true(any(grepl("Calibration options", options)))
   expect_true(any(grepl("controlSections", options)))
 })
 


### PR DESCRIPTION
This PR will
* Pin to naomi branch mrc-2078 (which adds options back to calibration step)
* Also up the hintr version no and add a news item