### PR TITLE
Remove deprecated calibrate endpoint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.33
+Version: 0.1.34
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 0.1.34
+
+* Remove deprecated `/model/calibrate/<id>` endpoint
+
 # hintr 0.1.33
 
 * Return upload metadata from calibrate result response

--- a/R/api.R
+++ b/R/api.R
@@ -12,7 +12,6 @@ api_build <- function(queue) {
   api$handle(endpoint_model_cancel(queue))
   api$handle(endpoint_model_debug(queue))
   api$handle(endpoint_model_calibrate_options())
-  api$handle(endpoint_model_calibrate(queue))
   api$handle(endpoint_model_calibrate_submit(queue))
   api$handle(endpoint_model_calibrate_status(queue))
   api$handle(endpoint_model_calibrate_result(queue))
@@ -259,20 +258,6 @@ endpoint_model_calibrate_options <- function() {
   porcelain::porcelain_endpoint$new("POST",
                                     "/calibrate/options",
                                     calibration_options,
-                                    returning = response)
-}
-
-endpoint_model_calibrate <- function(queue) {
-  ## TODO: Remove this once async calibration implemented in front end
-  input <- porcelain::porcelain_input_body_json("input",
-                                                "ModelCalibrateRequest.schema",
-                                                schema_root())
-  response <- porcelain::porcelain_returning_json(
-    "CalibrateResultResponse.schema", schema_root())
-  porcelain::porcelain_endpoint$new("POST",
-                                    "/model/calibrate/<id>",
-                                    model_calibrate(queue),
-                                    input,
                                     returning = response)
 }
 

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -202,19 +202,6 @@ verify_result_available <- function(queue, id) {
   }
 }
 
-model_calibrate <- function(queue) {
-  function(id, input) {
-    verify_result_available(queue, id)
-    calibration_options <- jsonlite::fromJSON(input)
-    if (!is_current_version(calibration_options$version)) {
-      hintr_error(t_("MODEL_SUBMIT_OLD"), "VERSION_OUT_OF_DATE")
-    }
-    ## TODO: run calibration asynchronously, takes too long to do sync
-    ## see mrc-2040
-    process_result(queue$result(id))
-  }
-}
-
 model_cancel <- function(queue) {
   function(id) {
     tryCatch({

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -1258,32 +1258,3 @@ test_that("api can call endpoint_model_calibrate", {
   expect_equal(names(result_body$data$plottingMetadata),
                c("barchart", "choropleth"))
 })
-
-test_that("endpoint_model_calibrate can be run synchronously", {
-  ## TODO: Remove this once async calibration has been added in front end
-  test_mock_model_available()
-
-  ## Mock model run
-  queue <- test_queue(workers = 0)
-  unlockBinding("result", queue)
-  ## Clone model output as it modifies in place
-  out <- clone_model_output(mock_model)
-  queue$result <- mockery::mock(out, cycle = TRUE)
-  unlockBinding("queue", queue)
-  unlockBinding("task_status", queue$queue)
-  queue$queue$task_status <- mockery::mock("COMPLETE", cycle = TRUE)
-
-  endpoint <- endpoint_model_calibrate(queue)
-  path <- setup_calibrate_payload()
-  response <- endpoint$run("id", readLines(path))
-
-  expect_equal(response$status_code, 200)
-  expect_equal(names(response$data),
-               c("data", "plottingMetadata", "uploadMetadata"))
-  expect_equal(colnames(response$data$data),
-               c("area_id", "sex", "age_group", "calendar_quarter",
-                 "indicator", "mode", "mean", "lower", "upper"))
-  expect_true(nrow(response$data$data) > 84042)
-  expect_equal(names(response$data$plottingMetadata),
-               c("barchart", "choropleth"))
-})

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -11,8 +11,7 @@ test_that("plumber api can be built", {
                   c("baseline-individual", "baseline-combined",
                     "survey-and-programme", "options"))
   expect_setequal(names(api$routes$model),
-                  c("options", "submit", "status", "result", "cancel", "debug",
-                    "calibrate"))
+                  c("options", "submit", "status", "result", "cancel", "debug"))
   expect_setequal(names(api$routes$calibrate),
                   c("options", "submit", "status", "result"))
   expect_equal(names(api$routes$meta), "plotting")


### PR DESCRIPTION
The front end now uses async calibrate endpoint so this should be safe to remove