### PR TITLE
mrc-2429: Shorten downloaded file names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.34
+Version: 0.1.35
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 0.1.35
+
+* Shorted output file names
+
 # hintr 0.1.34
 
 * Remove deprecated `/model/calibrate/<id>` endpoint

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -259,7 +259,7 @@ download <- function(queue, type, filename, ext) {
                      "summary" = res$summary_report_path)
       if (is.null(path)) {
         hintr_error(t_("MODEL_RESULT_OLD",
-                       list(type = gsub("_", " ",
+                       list(type = gsub("-", " ",
                                         tools::file_path_sans_ext(filename)))),
                     "MODEL_RESULT_OUT_OF_DATE")
       }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -224,18 +224,18 @@ plotting_metadata <- function(iso3) {
 }
 
 download_spectrum <- function(queue) {
-  download(queue, "spectrum", "naomi_spectrum_digest.zip")
+  download(queue, "spectrum", "naomi-output", ".zip")
 }
 
 download_coarse_output <- function(queue) {
-  download(queue, "coarse_output", "naomi_coarse_age_groups.zip")
+  download(queue, "coarse_output", "coarse-output", ".zip")
 }
 
 download_summary <- function(queue) {
-  download(queue, "summary", "summary_report.html")
+  download(queue, "summary", "summary-report", ".html")
 }
 
-download <- function(queue, type, filename) {
+download <- function(queue, type, filename, ext) {
   function(id) {
     tryCatch({
       res <- queue$result(id)
@@ -266,7 +266,7 @@ download <- function(queue, type, filename) {
       bytes <- readBin(path, "raw", n = file.size(path))
       bytes <- porcelain::porcelain_add_headers(bytes, list(
         "Content-Disposition" = build_content_disp_header(res$metadata$areas,
-                                                          filename),
+                                                          filename, ext),
         "Content-Length" = length(bytes)))
       bytes
     },
@@ -280,9 +280,10 @@ download <- function(queue, type, filename) {
   }
 }
 
-build_content_disp_header <- function(areas, filename) {
+build_content_disp_header <- function(areas, filename, ext) {
   sprintf('attachment; filename="%s"',
-          paste(c(areas, iso_time_str(), filename), collapse = "_"))
+          paste0(paste(c(areas, filename, iso_time_str()), collapse = "_"),
+                 ext))
 }
 
 download_model_debug <- function(queue) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,7 +93,7 @@ read_binary <- function(path) {
 }
 
 iso_time_str <- function(time = Sys.time()) {
-  strftime(time, "%Y%m%d-%H%M%S")
+  strftime(time, "%Y%m%d-%H%M")
 }
 
 schema_root <- function() {

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -512,7 +512,7 @@ test_that("spectrum file download streams bytes", {
     expect_equal(httr::status_code(r), 200)
     expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
     expect_match(httr::headers(r)$`content-disposition`,
-                 'attachment; filename="MWI_\\d+-\\d+_naomi_spectrum_digest.zip"')
+                 'attachment; filename="MWI_naomi-output_\\d+-\\d+.zip"')
 
     size <- length(httr::content(r))
     content_length <- as.numeric(httr::headers(r)$`content-length`)
@@ -526,7 +526,7 @@ test_that("spectrum file download streams bytes", {
   expect_equal(httr::status_code(r), 200)
   expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
   expect_match(httr::headers(r)$`content-disposition`,
-               'attachment; filename="MWI_\\d+-\\d+_naomi_spectrum_digest.zip"')
+               'attachment; filename="MWI_naomi-output_\\d+-\\d+.zip"')
 
   size <- length(httr::content(r))
   content_length <- as.numeric(httr::headers(r)$`content-length`)
@@ -560,7 +560,7 @@ test_that("coarse_output file download streams bytes", {
     expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
     expect_match(
       httr::headers(r)$`content-disposition`,
-      'attachment; filename="MWI_\\d+-\\d+_naomi_coarse_age_groups.zip"')
+      'attachment; filename="MWI_coarse-output_\\d+-\\d+.zip"')
 
     size <- length(httr::content(r))
     content_length <- as.numeric(httr::headers(r)$`content-length`)
@@ -576,7 +576,7 @@ test_that("coarse_output file download streams bytes", {
   expect_equal(httr::headers(r)$`content-type`, "application/octet-stream")
   expect_match(
     httr::headers(r)$`content-disposition`,
-    'attachment; filename="MWI_\\d+-\\d+_naomi_coarse_age_groups.zip"')
+    'attachment; filename="MWI_coarse-output_\\d+-\\d+.zip"')
 
   size <- length(httr::content(r))
   content_length <- as.numeric(httr::headers(r)$`content-length`)

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -730,7 +730,7 @@ test_that("endpoint_download_spectrum can be run", {
 
   expect_equal(response$status_code, 200)
   expect_match(response$headers$`Content-Disposition`,
-               'attachment; filename="MWI_\\d+-\\d+_naomi_spectrum_digest.zip"')
+               'attachment; filename="MWI_naomi-output_\\d+-\\d+.zip"')
   size <- length(response$data)
   expect_equal(response$headers$`Content-Length`, size)
   expect_equal(size, file.size(
@@ -758,7 +758,7 @@ test_that("api can call endpoint_download_spectrum", {
   expect_equal(res$status, 200)
   expect_equal(res$headers$`Content-Type`, "application/octet-stream")
   expect_match(res$headers$`Content-Disposition`,
-               'attachment; filename="MWI_\\d+-\\d+_naomi_spectrum_digest.zip"')
+               'attachment; filename="MWI_naomi-output_\\d+-\\d+.zip"')
   ## Size of bytes is close to expected
   size <- length(res$body)
   expect_equal(res$headers$`Content-Length`, size)
@@ -783,7 +783,7 @@ test_that("endpoint_download_coarse_output can be run", {
   expect_equal(response$status_code, 200)
   expect_match(
     response$headers$`Content-Disposition`,
-    'attachment; filename="MWI_\\d+-\\d+_naomi_coarse_age_groups.zip"')
+    'attachment; filename="MWI_coarse-output_\\d+-\\d+.zip"')
   size <- length(response$data)
   expect_equal(response$headers$`Content-Length`, size)
   expect_equal(size, file.size(
@@ -813,7 +813,7 @@ test_that("api can call endpoint_download_coarse_output", {
   expect_equal(res$headers$`Content-Type`, "application/octet-stream")
   expect_match(
     res$headers$`Content-Disposition`,
-    'attachment; filename="MWI_\\d+-\\d+_naomi_coarse_age_groups.zip"')
+    'attachment; filename="MWI_coarse-output_\\d+-\\d+.zip"')
   size <- length(res$body)
   expect_equal(res$headers$`Content-Length`, size)
   expect_equal(size, file.size(
@@ -821,13 +821,13 @@ test_that("api can call endpoint_download_coarse_output", {
 })
 
 test_that("content disposition header is formatted correctly", {
-  expect_match(build_content_disp_header("MWI", "naomi_spectrum_digest.zip"),
-               'attachment; filename="MWI_\\d+-\\d+_naomi_spectrum_digest.zip"')
-  expect_match(build_content_disp_header(NULL, "naomi_spectrum_digest.zip"),
-               'attachment; filename="\\d+-\\d+_naomi_spectrum_digest.zip"')
+  expect_match(build_content_disp_header("MWI", "naomi-output", ".zip"),
+               'attachment; filename="MWI_naomi-output_\\d+-\\d+.zip"')
+  expect_match(build_content_disp_header(NULL, "naomi-output", ".zip"),
+               'attachment; filename="naomi-output_\\d+-\\d+.zip"')
   expect_match(
-    build_content_disp_header(c("MWI.1", "MWI.2"), "naomi_spectrum_digest.zip"),
-    'attachment; filename="MWI.1_MWI.2_\\d+-\\d+_naomi_spectrum_digest.zip"')
+    build_content_disp_header(c("MWI.1", "MWI.2"), "naomi-output", ".zip"),
+    'attachment; filename="MWI.1_MWI.2_naomi-output_\\d+-\\d+.zip"')
 })
 
 test_that("returning_binary_head ensures no body in response", {
@@ -854,7 +854,7 @@ test_that("endpoint_download_spectrum_head returns headers only", {
   expect_equal(response$status_code, 200)
   expect_equal(response$content_type, "application/octet-stream")
   expect_match(response$headers$`Content-Disposition`,
-               'attachment; filename="MWI_\\d+-\\d+_naomi_spectrum_digest.zip"')
+               'attachment; filename="MWI_naomi-output_\\d+-\\d+.zip"')
   expect_equal(response$headers$`Content-Length`, file.size(
     system_file("output", "malawi_spectrum_download.zip")))
   expect_null(response$body, NULL)
@@ -881,7 +881,7 @@ test_that("api endpoint_download_spectrum_head returns headers only", {
   expect_equal(res$status, 200)
   expect_equal(res$headers$`Content-Type`, "application/octet-stream")
   expect_match(res$headers$`Content-Disposition`,
-               'attachment; filename="MWI_\\d+-\\d+_naomi_spectrum_digest.zip"')
+               'attachment; filename="MWI_naomi-output_\\d+-\\d+.zip"')
   expect_equal(res$headers$`Content-Length`, file.size(
     system_file("output", "malawi_spectrum_download.zip")))
   ## Plumber uses an empty string to represent an empty body
@@ -906,7 +906,7 @@ test_that("endpoint_download_coarse_output_head returns headers only", {
   expect_equal(response$content_type, "application/octet-stream")
   expect_match(
     response$headers$`Content-Disposition`,
-    'attachment; filename="MWI_\\d+-\\d+_naomi_coarse_age_groups.zip"')
+    'attachment; filename="MWI_coarse-output_\\d+-\\d+.zip"')
   expect_equal(response$headers$`Content-Length`, file.size(
     system_file("output", "malawi_coarse_output_download.zip")))
   expect_null(response$body, NULL)
@@ -935,7 +935,7 @@ test_that("api endpoint_download_coarse_output_head returns headers only", {
   expect_equal(res$headers$`Content-Type`, "application/octet-stream")
   expect_match(
     res$headers$`Content-Disposition`,
-    'attachment; filename="MWI_\\d+-\\d+_naomi_coarse_age_groups.zip"')
+    'attachment; filename="MWI_coarse-output_\\d+-\\d+.zip"')
   expect_equal(res$headers$`Content-Length`, file.size(
     system_file("output", "malawi_coarse_output_download.zip")))
   ## Plumber uses an empty string to represent an empty body
@@ -959,7 +959,7 @@ test_that("endpoint_download_summary can be run", {
   expect_equal(response$status_code, 200)
   expect_match(
     response$headers$`Content-Disposition`,
-    'attachment; filename="MWI_\\d+-\\d+_summary_report.html"')
+    'attachment; filename="MWI_summary-report_\\d+-\\d+.html"')
   size <- length(response$data)
   expect_equal(response$headers$`Content-Length`, size)
   expect_equal(size, file.size(
@@ -973,7 +973,7 @@ test_that("endpoint_download_summary can be run", {
   expect_equal(response$content_type, "application/octet-stream")
   expect_match(
     response$headers$`Content-Disposition`,
-    'attachment; filename="MWI_\\d+-\\d+_summary_report.html"')
+    'attachment; filename="MWI_summary-report_\\d+-\\d+.html"')
   expect_equal(response$headers$`Content-Length`, file.size(
     system_file("output", "malawi_summary_report.html")))
   expect_null(response$body, NULL)
@@ -1001,7 +1001,7 @@ test_that("api can call endpoint_download_summary", {
   expect_equal(res$headers$`Content-Type`, "application/octet-stream")
   expect_match(
     res$headers$`Content-Disposition`,
-    'attachment; filename="MWI_\\d+-\\d+_summary_report.html"')
+    'attachment; filename="MWI_summary-report_\\d+-\\d+.html"')
   size <- length(res$body)
   expect_equal(res$headers$`Content-Length`, size)
   expect_equal(size, file.size(
@@ -1014,7 +1014,7 @@ test_that("api can call endpoint_download_summary", {
   expect_equal(res$headers$`Content-Type`, "application/octet-stream")
   expect_match(
     res$headers$`Content-Disposition`,
-    'attachment; filename="MWI_\\d+-\\d+_summary_report.html"')
+    'attachment; filename="MWI_summary-report_\\d+-\\d+.html"')
   expect_equal(res$headers$`Content-Length`,
                file.size(system_file("output", "malawi_summary_report.html")))
   ## Plumber uses an empty string to represent an empty body


### PR DESCRIPTION
UNAIDS requested we shorten the names, agreed these changes with Jeff. This will:
* Change order to `<area_level>_<file_type>_<date>-<time>`
* Remove seconds from `<time>`
* Change `<file_type>` name to one of `naomi-output`, `coarse-output` or `summary-report`

I've deployed this on staging and checked it is working