### PR TITLE
Use R6 constructor in rrq 0.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 0.1.38
+Version: 0.1.39
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",
@@ -25,7 +25,7 @@ Imports:
     porcelain (>= 0.1.0),
     R6,
     redux,
-    rrq (>= 0.4.3),
+    rrq (>= 0.5.0),
     specio (>= 0.1.4),
     storr,
     traduire (>= 0.0.5),
@@ -41,4 +41,4 @@ Suggests:
     testthat (>= 2.1.0),
     withr
 Remotes:
-    mrc-ide/rrq
+    mrc-ide/rrq@mrc-2338

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,4 +41,4 @@ Suggests:
     testthat (>= 2.1.0),
     withr
 Remotes:
-    mrc-ide/rrq@mrc-2338
+    mrc-ide/rrq

--- a/R/queue.R
+++ b/R/queue.R
@@ -21,7 +21,7 @@ Queue <- R6::R6Class(
 
       message(t_("QUEUE_STARTING"))
       queue_id <- hintr_queue_id(queue_id)
-      self$queue <- rrq::rrq_controller(queue_id, con)
+      self$queue <- rrq::rrq_controller$new(queue_id, con)
       self$queue$worker_config_save("localhost", heartbeat_period = 10,
                                     queue = c(QUEUE_CALIBRATE, QUEUE_RUN))
       self$queue$worker_config_save("calibrate_only", heartbeat_period = 10,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN install_packages --repo=https://mrc-ide.github.io/drat \
 COPY docker/bin /usr/local/bin/
 
 RUN install_remote \
-        mrc-ide/rrq \
+        mrc-ide/rrq@mrc-2338 \
         reside-ic/traduire \
         ropensci/jsonvalidate
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN install_packages --repo=https://mrc-ide.github.io/drat \
 COPY docker/bin /usr/local/bin/
 
 RUN install_remote \
-        mrc-ide/rrq@mrc-2338 \
+        mrc-ide/rrq \
         reside-ic/traduire \
         ropensci/jsonvalidate
 

--- a/docker/bin/hintr_stop_workers
+++ b/docker/bin/hintr_stop_workers
@@ -1,3 +1,3 @@
 #!/usr/bin/env Rscript
-rrq <- rrq::rrq_controller("hintr", redux::hiredis())
+rrq <- rrq::rrq_controller$new("hintr", redux::hiredis())
 rrq$message_send("STOP")

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -650,7 +650,7 @@ test_that("crashed worker can be detected", {
   id <- response_from_json(r)$data$id
 
   Sys.sleep(2)
-  obj <- rrq::rrq_controller(server$queue_id)
+  obj <- rrq::rrq_controller$new(server$queue_id)
   expect_equal(obj$task_status(id), setNames("RUNNING", id))
 
   ## There's quite a chore here to try and identify the actual running


### PR DESCRIPTION
Update to use the new `rrq_controller$new(...)` constructor, rather than the `rrq_controller(...)` helper, removed in rrq 0.5.0 (https://github.com/mrc-ide/rrq/pull/53)

Update branch pins before merge.