### PR TITLE
Run codecov in paralell with tests

### DIFF
--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -6,17 +6,22 @@ steps:
 
   - label: ":hammer: Unit tests"
     command: docker/test_check
+    key: "unit tests"
 
   - label: ":hammer_and_pick: Integration tests"
     command: docker/test_integration
+    key: "integration tests"
 
   - label: ":docker: Docker connection test"
     command: docker/test_connection
-
-  - wait
-
-  - label: ":shipit: Push images"
-    command: docker/push
+    key: "connection tests"
 
   - label: ":codecov: Codecov"
     command: docker/coverage
+
+  - label: ":shipit: Push images"
+    command: docker/push
+    depends_on:
+      - "unit tests"
+      - "integration tests"
+      - "connection tests"

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -6,15 +6,15 @@ steps:
 
   - label: ":hammer: Unit tests"
     command: docker/test_check
-    key: "unit tests"
+    key: "unit-tests"
 
   - label: ":hammer_and_pick: Integration tests"
     command: docker/test_integration
-    key: "integration tests"
+    key: "integration-tests"
 
   - label: ":docker: Docker connection test"
     command: docker/test_connection
-    key: "connection tests"
+    key: "connection-tests"
 
   - label: ":codecov: Codecov"
     command: docker/coverage
@@ -22,6 +22,6 @@ steps:
   - label: ":shipit: Push images"
     command: docker/push
     depends_on:
-      - "unit tests"
-      - "integration tests"
-      - "connection tests"
+      - "unit-tests"
+      - "integration-tests"
+      - "connection-tests"


### PR DESCRIPTION
Have watched the tests running and confirmed that this is doing what we want, i.e. running code cov in parallel with all tests but not blocking the docker image push