### PR TITLE
Add test for generating input time series plot when no vls data present

### DIFF
--- a/tests/testthat/test-endpoints-chart-data.R
+++ b/tests/testthat/test-endpoints-chart-data.R
@@ -81,6 +81,23 @@ test_that("endpoint_input_time_series_plot works with programme data", {
                c("plot_type", "area_level", "quarter"))
 })
 
+test_that("endpoint_input_time_series_plot works without vls indicators", {
+  endpoint <- endpoint_input_time_series_plot()
+  input <- input_time_series_request(
+    file.path("testdata", "programme_no_vls.csv"),
+    "programme",
+    file.path("testdata", "malawi.geojson"))
+  res <- endpoint$run("programme", input)
+  expect_equal(res$status_code, 200)
+  body <- jsonlite::fromJSON(res$body)
+  expect_equal(body$status, "success")
+  expect_null(body$errors)
+  expect_equal(names(body$data), c("data", "metadata"))
+  expect_true(nrow(body$data$data) > 100)
+  expect_equal(names(body$data$metadata$defaults$selected_filter_options),
+               c("plot_type", "area_level", "quarter"))
+})
+
 test_that("endpoint_input_time_series_plot works with anc data", {
   endpoint <- endpoint_input_time_series_plot()
   input <- input_time_series_request(


### PR DESCRIPTION
This was failing previously but has been fixed in Naomi. This should fix the build problems you were having this morning. The problem was we merged the #310 in which the input time series was assuming that the data would have new VLS columns. The test data in hint doesn't have those new columns but the columns are optional so it should work with or without them. 