### PR TITLE
recode vls_tested and vls_suppressed to vl_tested_12mos and vl_suppressed_12mos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.0.9
+Version: 1.0.10
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.0.10
+
+* Recode `vls_tested` and `vls_suppressed` to `vl_tested_12mos` and `vl_suppressed_12mos`. Affects tests only.
+
 # hintr 1.0.9
 
 * Back `/calibrate/plot/<id>` endpoint with real data

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -120,12 +120,12 @@ test_that("possible filters are returned for data", {
   expect_equal(response$filters$indicators[[2]]$id, scalar("art_new"))
   expect_equal(response$filters$indicators[[2]]$label,
                scalar("ART new"))
-  expect_equal(response$filters$indicators[[3]]$id, scalar("vls_tested"))
+  expect_equal(response$filters$indicators[[3]]$id, scalar("vl_tested_12mos"))
   expect_equal(response$filters$indicators[[3]]$label,
-               scalar("VLS tested"))
-  expect_equal(response$filters$indicators[[4]]$id, scalar("vls_suppressed"))
+               scalar("VL tested"))
+  expect_equal(response$filters$indicators[[4]]$id, scalar("vl_suppressed_12mos"))
   expect_equal(response$filters$indicators[[4]]$label,
-               scalar("VLS tests suppressed"))
+               scalar("VL tests suppressed"))
 
 
   input <- validate_programme_survey_input(

--- a/tests/testthat/test-filters.R
+++ b/tests/testthat/test-filters.R
@@ -216,10 +216,10 @@ test_that("can get indicator filters for programme data", {
   expect_equal(filters[[1]]$label, scalar("ART number (attending)"))
   expect_equal(filters[[2]]$id, scalar("art_new"))
   expect_equal(filters[[2]]$label, scalar("ART new"))
-  expect_equal(filters[[3]]$id, scalar("vls_tested"))
-  expect_equal(filters[[3]]$label, scalar("VLS tested"))
-  expect_equal(filters[[4]]$id, scalar("vls_suppressed"))
-  expect_equal(filters[[4]]$label, scalar("VLS tests suppressed"))
+  expect_equal(filters[[3]]$id, scalar("vl_tested_12mos"))
+  expect_equal(filters[[3]]$label, scalar("VL tested"))
+  expect_equal(filters[[4]]$id, scalar("vl_suppressed_12mos"))
+  expect_equal(filters[[4]]$label, scalar("VL tests suppressed"))
 })
 
 test_that("can get indicator filters for anc data", {

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -24,10 +24,10 @@ test_that("can build metadata response", {
                scalar("ART number (attending)"))
   expect_equal(programme_indicators[[2]]$indicator, scalar("art_new"))
   expect_equal(programme_indicators[[2]]$name, scalar("ART new"))
-  expect_equal(programme_indicators[[3]]$indicator, scalar("vls_tested"))
-  expect_equal(programme_indicators[[3]]$name, scalar("VLS tested"))
-  expect_equal(programme_indicators[[4]]$indicator, scalar("vls_suppressed"))
-  expect_equal(programme_indicators[[4]]$name, scalar("VLS tests suppressed"))
+  expect_equal(programme_indicators[[3]]$indicator, scalar("vl_tested_12mos"))
+  expect_equal(programme_indicators[[3]]$name, scalar("VL tested"))
+  expect_equal(programme_indicators[[4]]$indicator, scalar("vl_suppressed_12mos"))
+  expect_equal(programme_indicators[[4]]$name, scalar("VL tests suppressed"))
 })
 
 test_that("error thrown when metadata contains conflicting information", {

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -112,11 +112,11 @@ test_that("do_validate_programme validates programme file", {
                scalar("ART number (attending)"))
   expect_equal(data$filters$indicators[[2]]$id, scalar("art_new"))
   expect_equal(data$filters$indicators[[2]]$label, scalar("ART new"))
-  expect_equal(data$filters$indicators[[3]]$id, scalar("vls_tested"))
-  expect_equal(data$filters$indicators[[3]]$label, scalar("VLS tested"))
-  expect_equal(data$filters$indicators[[4]]$id, scalar("vls_suppressed"))
+  expect_equal(data$filters$indicators[[3]]$id, scalar("vl_tested_12mos"))
+  expect_equal(data$filters$indicators[[3]]$label, scalar("VL tested"))
+  expect_equal(data$filters$indicators[[4]]$id, scalar("vl_suppressed_12mos"))
   expect_equal(data$filters$indicators[[4]]$label,
-               scalar("VLS tests suppressed"))
+               scalar("VL tests suppressed"))
 })
 
 test_that("do_validate_anc validates ANC file and gets data for plotting", {

--- a/tests/testthat/testdata/programme.csv
+++ b/tests/testthat/testdata/programme.csv
@@ -1,4 +1,4 @@
-area_id,area_name,sex,age_group,year,calendar_quarter,art_current,art_new,vls_tested,vls_suppressed
+area_id,area_name,sex,age_group,year,calendar_quarter,art_current,art_new,vl_tested_12mos,vl_suppressed_12mos
 MWI_4_1_demo,Chitipa,both,Y000_014,2011,CY2011Q4,127,9,,
 MWI_4_1_demo,Chitipa,both,Y015_999,2011,CY2011Q4,1989,144,,
 MWI_4_1_demo,Chitipa,both,Y000_014,2012,CY2012Q4,160,8,,


### PR DESCRIPTION
As far as I could see, this only affects test data and tests in hintr, no actual code changes? 

I suspect that corresponding Naomi PR needs to be merged before tests will pass: https://github.com/mrc-ide/naomi/pull/263

I can't recall if there was an update that I need to do to specify a branch pin for Naomi. 