### PR TITLE
mrc-2775 avoid duplicate names for schemas

### DIFF
--- a/inst/schema/PlottingMetadataResponse.schema.json
+++ b/inst/schema/PlottingMetadataResponse.schema.json
@@ -1,30 +1,49 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
-    "choropleth_metadata": {
-      "type": "array",
-      "items": { "$ref": "ChoroplethIndicatorMetadata.schema.json" }
-    },
     "metadata": {
       "type": "object",
       "properties": {
         "choropleth": {
           "type": "object",
           "properties": {
-            "indicators": { "$ref": "#/definitions/choropleth_metadata" }
-          }
+            "indicators": {
+              "type": "array",
+              "items": {
+                "$ref": "ChoroplethIndicatorMetadata.schema.json"
+              }
+            }
+          },
+          "required": [
+            "indicators"
+          ]
         }
-      }
+      },
+      "required": [
+        "choropleth"
+      ]
     }
   },
-
   "type": "object",
   "properties": {
-    "survey": { "$ref": "#/definitions/metadata" },
-    "anc": { "$ref": "#/definitions/metadata" },
-    "programme": { "$ref": "#/definitions/metadata" },
-    "output": { "$ref": "#/definitions/metadata" }
+    "survey": {
+      "$ref": "#/definitions/metadata"
+    },
+    "anc": {
+      "$ref": "#/definitions/metadata"
+    },
+    "programme": {
+      "$ref": "#/definitions/metadata"
+    },
+    "output": {
+      "$ref": "#/definitions/metadata"
+    }
   },
   "additionalProperties": false,
-  "required": ["survey", "anc", "programme", "output"]
+  "required": [
+    "survey",
+    "anc",
+    "programme",
+    "output"
+  ]
 }


### PR DESCRIPTION
This just re-writes the plotting metadata schema so that we don't end up with duplicate types in the generated typescript (both `choropleth_metadata` and `ChoroplethMetadata.schema.json` will result in conflicting types called `ChoroplethMetadata`.) It also marks all properties as required.