### PR TITLE
Relax validation rules to check for unique area levels per year, instead of in all data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.0.14
+Version: 1.0.15
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.0.15
+
+* Update programme & ANC validation to ensure only 1 area level per year is uploaded
+
 # hintr 1.0.13
 
 * Add validation error to programme/ART data to ensure only 1 area level is uploaded

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -118,10 +118,9 @@ do_validate_programme <- function(programme, shape) {
     colnames(data),
     c("area_id", "calendar_quarter", "sex", "age_group", "art_current"))
   shape_regions <- read_regions(shape, "shape")
-  programme_regions <- read_regions(programme, "programme")
-  assert_consistent_regions(shape_regions$area_id, programme_regions,
+  assert_consistent_regions(shape_regions$area_id, unique(data$area_id),
                             "programme")
-  assert_single_level(shape_regions, programme_regions)
+  assert_single_level_per_year(shape_regions, data)
   assert_unique_combinations(
     data, c("area_id", "calendar_quarter", "sex", "age_group"))
   assert_expected_values(data, "sex", c("male", "female", "both"))
@@ -157,10 +156,8 @@ do_validate_anc <- function(anc, shape) {
     c("area_id", "age_group", "year", "anc_clients",
       "anc_known_pos", "anc_already_art", "anc_tested", "anc_tested_pos"))
   shape_regions <- read_regions(shape, "shape")
-  anc_regions <- read_regions(anc, "anc")
-  assert_consistent_regions(shape_regions$area_id, anc_regions,
-                            "ANC")
-  assert_single_level(shape_regions, anc_regions)
+  assert_consistent_regions(shape_regions$area_id, unique(data$area_id), "ANC")
+  assert_single_level_per_year(shape_regions, data)
   assert_unique_combinations(data, c("area_id", "age_group", "year"))
   assert_expected_values(data, "age_group", "Y015_049")
   assert_year_column(data)

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -84,5 +84,6 @@
     "QUARTER_2": "Quarter 2",
     "QUARTER_3": "Quarter 3",
     "QUARTER_4": "Quarter 4",
-    "VALIDATION_MULTIPLE_LEVELS": "Data can only be for regions at a single area level, uploaded data at area levels {{levels}}"
+    "VALIDATION_MULTIPLE_LEVELS_DETAIL": "year {{year}} has area levels {{levels}}",
+    "VALIDATION_MULTIPLE_LEVELS": "Data can only be for regions at a single area level per year. In uploaded data {{detail}}."
 }

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -85,5 +85,6 @@
     "QUARTER_2": "trimestre 2",
     "QUARTER_3": "trimestre 3",
     "QUARTER_4": "trimestre 4",
-    "VALIDATION_MULTIPLE_LEVELS": "Les données ne peuvent concerner que des régions au niveau d'une seule zone, les données téléchargées au niveau des zones {{levels}}"
+    "VALIDATION_MULTIPLE_LEVELS_DETAIL": "l'année {{year}} a des niveaux de zone {{levels}}",
+    "VALIDATION_MULTIPLE_LEVELS": "Les données ne peuvent concerner que les régions à un seul niveau de zone par an. Dans les données téléchargées {{detail}}"
 }

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -84,5 +84,6 @@
     "QUARTER_2": "trimestre 2",
     "QUARTER_3": "trimestre 3",
     "QUARTER_4": "trimestre 4",
-    "VALIDATION_MULTIPLE_LEVELS": "Os dados só podem ser para regiões a um único nível de área, dados carregados a nível de área {{levels}}"
+    "VALIDATION_MULTIPLE_LEVELS_DETAIL": "ano {{year}} tem níveis de área {{levels}}",
+    "VALIDATION_MULTIPLE_LEVELS": "Os dados só podem ser relativos a regiões a um único nível de área por ano. Em dados carregados {{detail}}"
 }

--- a/tests/testthat/test-validation-asserts.R
+++ b/tests/testthat/test-validation-asserts.R
@@ -314,7 +314,7 @@ test_that("can assert data has to have 1 area level", {
   data$area_id[1] <- "MWI_2_1_demo"
   data$area_id[3] <- "MWI_2_1_demo"
   expect_error(assert_single_level_per_year(shape_regions, data),
-               paste0("Data can only be for regions at a single area level",
-                      "per year. In uploaded data year 2011 has area levels",
-                      "2, 4, year 2021 has area levels 2, 4."))
+               paste0("Data can only be for regions at a single area level ",
+                      "per year. In uploaded data year 2011 has area levels ",
+                      "2, 4, year 2012 has area levels 2, 4."))
 })

--- a/tests/testthat/test-validation-asserts.R
+++ b/tests/testthat/test-validation-asserts.R
@@ -308,11 +308,13 @@ test_that("can check for non NA values", {
 })
 
 test_that("can assert data has to have 1 area level", {
-  data <- read_regions(list(path = "testdata/programme.csv"), "programme")
+  data <- read_csv("testdata/programme.csv")
   shape_regions <- read_geojson_data(list(path = "testdata/malawi.geojson"))
-  expect_true(assert_single_level(shape_regions, data))
-  data[1] <- "MWI_2_1_demo"
-  expect_error(assert_single_level(shape_regions, data),
-               paste0("Data can only be for regions at a single area ",
-                      "level, uploaded data at area levels 2, 4"))
+  expect_true(assert_single_level_per_year(shape_regions, data))
+  data$area_id[1] <- "MWI_2_1_demo"
+  data$area_id[3] <- "MWI_2_1_demo"
+  expect_error(assert_single_level_per_year(shape_regions, data),
+               paste0("Data can only be for regions at a single area level",
+                      "per year. In uploaded data year 2011 has area levels",
+                      "2, 4, year 2021 has area levels 2, 4."))
 })


### PR DESCRIPTION
Will unblock Mozambique issue 39

Oli has reported that Mozambique uses ART data at multiple area levels. So we should allow this. We're changing our validation rule from rejecting ART data with multiple area levels to rejecting ART with multiple area levels per year.