### PR TITLE
mrc-2844: Update docker cleanup to remove correct container

### DIFF
--- a/docker/coverage
+++ b/docker/coverage
@@ -12,7 +12,7 @@ NAME_NETWORK=hintr_network
 function cleanup {
     echo "Cleaning up"
     docker kill $NAME_REDIS > /dev/null || true
-    docker kill hintr_tests > /dev/null || true
+    docker kill $NAME_HINTR_TESTS > /dev/null || true
     docker network rm $NAME_NETWORK > /dev/null || true
 }
 

--- a/docker/teamcity
+++ b/docker/teamcity
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -e
-HERE=$(dirname $0)
-$HERE/build
-$HERE/test
-#$HERE/push

--- a/docker/test_check
+++ b/docker/test_check
@@ -12,7 +12,7 @@ NAME_NETWORK=hintr_network
 function cleanup {
     echo "Cleaning up"
     docker kill $NAME_REDIS > /dev/null || true
-    docker kill hintr_tests > /dev/null || true
+    docker kill $NAME_HINTR_TESTS > /dev/null || true
     docker network rm $NAME_NETWORK > /dev/null || true
 }
 

--- a/docker/test_connection
+++ b/docker/test_connection
@@ -15,7 +15,7 @@ function cleanup {
     echo "Cleaning up"
     docker kill $NAME_REDIS > /dev/null || true
     docker kill $NAME_SERVER > /dev/null || true
-    docker kill hintr_tests > /dev/null || true
+    docker kill $NAME_HINTR_TESTS > /dev/null || true
     docker network rm $NAME_NETWORK > /dev/null || true
     docker volume rm $NAME_VOLUME > /dev/null || true
 }

--- a/docker/test_integration
+++ b/docker/test_integration
@@ -15,7 +15,7 @@ function cleanup {
     echo "Cleaning up"
     docker kill $NAME_REDIS > /dev/null || true
     docker kill $NAME_SERVER > /dev/null || true
-    docker kill hintr_tests > /dev/null || true
+    docker kill $NAME_HINTR_TESTS > /dev/null || true
     docker network rm $NAME_NETWORK > /dev/null || true
     docker volume rm $NAME_VOLUME > /dev/null || true
 }


### PR DESCRIPTION
This fixes issue I was seeing where if we cancelled a hintr build then it would leave docker containers and network around meaning subsequent builds on the same agent would fail. This was just because the cleanup was attempting to remove container with incorrect name. See https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2844#focus=Comments-97-15263.0-0 for details

Also removed old teamcity script