### PR TITLE
mrc-3171: Include input files in download_debug when called with calibrate or output download ids

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.0.30
+Version: 1.0.31
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.0.31
+
+* Include input files when download_debug called with id from a calibrate run or output generation
+
 # hintr 1.0.29
 
 * Return warnings from input time series aggregation

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -347,21 +347,38 @@ download_model_debug <- function(queue) {
   function(id) {
     tryCatch({
       data <- queue$queue$task_data(id)
-      files <- unique(unlist(lapply(data$objects$data, function(x) {
-        if (!is.null(x)) {
-          x$path
+      browser()
+      func <- as.list(data$expr)[[1]]
+      if (func == "hintr:::run_model") {
+        files <- unique(unlist(lapply(data$objects$data, function(x) {
+          if (!is.null(x)) {
+            x$path
+          }
+        }), FALSE, FALSE))
+        data$objects$data <- lapply(data$objects$data, function(x) {
+          if (!is.null(x)) {
+            list(path = basename(x$path), hash = x$hash, filename = x$filename)
+          }
+        })
+      } else {
+        ## Calibrate, file download requests have format of "hintr_output"
+        ## object from naomi. They have files at plot_data_path
+        ## and model_output_path
+        files <- data$objects$model_output$model_output_path
+        data$objects$model_output$model_output_path <- basename(
+          data$objects$model_output$model_output_path)
+        if (!is.null(data$objects$model_output$plot_data_path)) {
+          ## This file only exists after calibrate has been run
+          files <- c(files, data$objects$model_output$plot_data_path)
+          data$objects$model_output$plot_data_path <- basename(
+            data$objects$model_output$plot_data_path)
         }
-      }), FALSE, FALSE))
+      }
       tmp <- tempfile()
       path <- file.path(tmp, id)
       dir.create(path, FALSE, TRUE)
 
       data$sessionInfo <- utils::sessionInfo()
-      data$objects$data <- lapply(data$objects$data, function(x) {
-        if (!is.null(x)) {
-          list(path = basename(x$path), hash = x$hash, filename = x$filename)
-        }
-      })
 
       path_files <- file.path(path, "files")
       dir.create(path_files)

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -347,7 +347,6 @@ download_model_debug <- function(queue) {
   function(id) {
     tryCatch({
       data <- queue$queue$task_data(id)
-      browser()
       func <- as.list(data$expr)[[1]]
       if (func == "hintr:::run_model") {
         files <- unique(unlist(lapply(data$objects$data, function(x) {

--- a/tests/testthat/test-debug.R
+++ b/tests/testthat/test-debug.R
@@ -6,3 +6,126 @@ test_that("download_debug prevents overwriting", {
     download_debug(id, dest = tmp),
     "Path 'abc' already exists at destination")
 })
+
+test_that("Debug endpoint returns debug information", {
+  test_redis_available()
+  test_mock_model_available()
+
+  ## Start the model running
+  path <- setup_submit_payload()
+  queue <- test_queue(workers = 1)
+  model_submit <- submit_model(queue)
+  response <- model_submit(readLines(path))
+  expect_true("id" %in% names(response))
+  id <- response$id
+
+  model_debug <- download_model_debug(queue)
+  bin <- model_debug(id)
+  tmp <- tempfile()
+  dest <- tempfile()
+  writeBin(as.vector(bin), tmp)
+  zip::unzip(tmp, exdir = dest)
+  expect_equal(scalar(dir(dest)), id)
+  expect_setequal(
+    dir(file.path(dest, id)),
+    c("data.rds", "files"))
+  info <- readRDS(file.path(dest, id, "data.rds"))
+  ## Smoke test options are passed through
+  expect_true(length(info$objects$options) > 25)
+  expect_true(list(area_scope = "MWI") %in% info$objects$options)
+  expect_is(info$sessionInfo, "sessionInfo")
+  expect_equal(names(info$objects$data),
+               c("pjnz", "shape", "population", "survey", "programme", "anc"))
+  expect_equal(names(info$objects$data$pjnz), c("path", "hash", "filename"))
+  expect_setequal(
+    dir(file.path(dest, id, "files")),
+    c("anc.csv", "malawi.geojson", "Malawi2019.PJNZ", "population.csv",
+      "programme.csv", "survey.csv"))
+})
+
+test_that("Debug endpoint returns debug information for calibrate", {
+  test_mock_model_available()
+  q <- test_queue_result()
+
+  submit <- endpoint_model_calibrate_submit(q$queue)
+  path <- setup_calibrate_payload()
+  submit_response <- submit$run(q$model_run_id, readLines(path))
+  id <- submit_response$data$id
+
+  expect_equal(submit_response$status_code, 200)
+  expect_true(!is.null(id))
+
+  ## Wait for complete status
+  out <- q$queue$queue$task_wait(id)
+  status <- endpoint_model_calibrate_status(q$queue)
+  status_response <- status$run(id)
+  expect_equal(status_response$data$status, scalar("COMPLETE"))
+
+  model_debug <- download_model_debug(q$queue)
+  bin <- model_debug(id)
+  tmp <- tempfile()
+  dest <- tempfile()
+  writeBin(as.vector(bin), tmp)
+  zip::unzip(tmp, exdir = dest)
+  expect_equal(scalar(dir(dest)), id)
+  expect_setequal(
+    dir(file.path(dest, id)),
+    c("data.rds", "files"))
+  info <- readRDS(file.path(dest, id, "data.rds"))
+
+  expect_is(info$objects$model_output, "hintr_output")
+  expect_true(length(info$objects$calibration_options) > 5)
+  expect_is(info$sessionInfo, "sessionInfo")
+  expect_equal(info$objects$model_output$model_output_path,
+               dir(file.path(dest, id, "files")))
+  expect_null(info$objects$model_output$plot_data_path)
+})
+
+test_that("Debug endpoint returns debug information for download", {
+  test_mock_model_available()
+  q <- test_queue_result()
+
+  submit <- endpoint_download_submit(q$queue)
+  submit_response <- submit$run(q$calibrate_id, "spectrum")
+  id <- submit_response$data$id
+
+  expect_equal(submit_response$status_code, 200)
+  expect_true(!is.null(id))
+
+  ## Wait for complete status
+  out <- q$queue$queue$task_wait(id)
+  status <- endpoint_model_calibrate_status(q$queue)
+  status_response <- status$run(id)
+  expect_equal(status_response$data$status, scalar("COMPLETE"))
+
+  model_debug <- download_model_debug(q$queue)
+  bin <- model_debug(id)
+  tmp <- tempfile()
+  dest <- tempfile()
+  writeBin(as.vector(bin), tmp)
+  zip::unzip(tmp, exdir = dest)
+  expect_equal(scalar(dir(dest)), id)
+  expect_setequal(
+    dir(file.path(dest, id)),
+    c("data.rds", "files"))
+  info <- readRDS(file.path(dest, id, "data.rds"))
+
+  expect_is(info$objects$model_output, "hintr_output")
+  expect_equal(info$objects$type, "spectrum")
+  expect_is(info$sessionInfo, "sessionInfo")
+  files <- c(info$objects$model_output$model_output_path,
+             info$objects$model_output$plot_data_path)
+  expect_equal(files, dir(file.path(dest, id, "files")))
+})
+
+test_that("Debug endpoint errors on nonexistant id", {
+  test_redis_available()
+  queue <- test_queue()
+  model_debug <- download_model_debug(queue)
+
+  error <- expect_error(model_debug("1234"))
+  expect_equal(error$data[[1]]$error, scalar("INVALID_TASK"))
+  expect_equal(error$data[[1]]$detail,
+               scalar("Task '1234' not found"))
+  expect_equal(error$status_code, 400)
+})

--- a/tests/testthat/test-debug.R
+++ b/tests/testthat/test-debug.R
@@ -115,7 +115,7 @@ test_that("Debug endpoint returns debug information for download", {
   expect_is(info$sessionInfo, "sessionInfo")
   files <- c(info$objects$model_output$model_output_path,
              info$objects$model_output$plot_data_path)
-  expect_equal(files, dir(file.path(dest, id, "files")))
+  expect_setequal(files, dir(file.path(dest, id, "files")))
 })
 
 test_that("Debug endpoint errors on nonexistant id", {

--- a/tests/testthat/test-endpoints-model.R
+++ b/tests/testthat/test-endpoints-model.R
@@ -317,54 +317,6 @@ test_that("failed cancel sends reasonable message", {
   expect_equal(error$status_code, 400)
 })
 
-test_that("Debug endpoint returns debug information", {
-  test_redis_available()
-  test_mock_model_available()
-
-  ## Start the model running
-  path <- setup_submit_payload()
-  queue <- test_queue(workers = 1)
-  model_submit <- submit_model(queue)
-  response <- model_submit(readLines(path))
-  expect_true("id" %in% names(response))
-  id <- response$id
-
-  model_debug <- download_model_debug(queue)
-  bin <- model_debug(id)
-  tmp <- tempfile()
-  dest <- tempfile()
-  writeBin(as.vector(bin), tmp)
-  zip::unzip(tmp, exdir = dest)
-  expect_equal(scalar(dir(dest)), id)
-  expect_setequal(
-    dir(file.path(dest, id)),
-    c("data.rds", "files"))
-  info <- readRDS(file.path(dest, id, "data.rds"))
-  ## Smoke test options are passed through
-  expect_true(length(info$objects$options) > 25)
-  expect_true(list(area_scope = "MWI") %in% info$objects$options)
-  expect_is(info$sessionInfo, "sessionInfo")
-  expect_equal(names(info$objects$data),
-               c("pjnz", "shape", "population", "survey", "programme", "anc"))
-  expect_equal(names(info$objects$data$pjnz), c("path", "hash", "filename"))
-  expect_setequal(
-    dir(file.path(dest, id, "files")),
-    c("anc.csv", "malawi.geojson", "Malawi2019.PJNZ", "population.csv",
-      "programme.csv", "survey.csv"))
-})
-
-test_that("Debug endpoint errors on nonexistant id", {
-  test_redis_available()
-  queue <- test_queue()
-  model_debug <- download_model_debug(queue)
-
-  error <- expect_error(model_debug("1234"))
-  expect_equal(error$data[[1]]$error, scalar("INVALID_TASK"))
-  expect_equal(error$data[[1]]$detail,
-               scalar("Task '1234' not found"))
-  expect_equal(error$status_code, 400)
-})
-
 test_that("getting result returns empty warnings with old run", {
   test_redis_available()
   test_mock_model_available()


### PR DESCRIPTION
At the moment `download_debug` will only return any `files` if called with an ID from `submit/model` endpoint as the code is specific to the format of that response object. This PR expands the functionality to handle the response format from a calibration ID or a download generation ID.

This means that when they debug a calibration failure it will include the `model_output` from the corresponding model run.

Ideally we would also include the corresponding model fit ID but that is a bit fiddly to get out so including that is something we can do in another ticket.