### PR TITLE
mrc-3072: Add new download type for comparison report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     ids,
     jsonlite (>= 1.2.2),
     lgr,
-    naomi (>= 2.6.24,
+    naomi (>= 2.6.24),
     porcelain (>= 0.1.8),
     R6,
     redux,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.0.30
+Version: 1.0.31
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     ids,
     jsonlite (>= 1.2.2),
     lgr,
-    naomi (>= 2.6.21),
+    naomi (>= 2.6.23),
     porcelain (>= 0.1.8),
     R6,
     redux,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.0.31
+
+* Add new download type "comparison" to return input to output comparison report
+
 # hintr 1.0.29
 
 * Return warnings from input time series aggregation

--- a/R/downloads.R
+++ b/R/downloads.R
@@ -13,7 +13,7 @@ download <- function(model_output, type, path_results, language = NULL) {
                  spectrum = naomi::hintr_prepare_spectrum_download,
                  coarse_output = naomi::hintr_prepare_coarse_age_group_download,
                  summary = naomi::hintr_prepare_summary_report_download,
-                 comparison = naomi::hintr_prepare_summary_report_download,
+                 comparison = naomi::hintr_prepare_comparison_report_download,
                  hintr_error(t_("INVALID_DOWNLOAD_TYPE", list(type = type)),
                              "INVALID_DOWNLOAD_TYPE"))
   file_ext <- switch(type,

--- a/R/downloads.R
+++ b/R/downloads.R
@@ -13,12 +13,14 @@ download <- function(model_output, type, path_results, language = NULL) {
                  spectrum = naomi::hintr_prepare_spectrum_download,
                  coarse_output = naomi::hintr_prepare_coarse_age_group_download,
                  summary = naomi::hintr_prepare_summary_report_download,
+                 comparison = naomi::hintr_prepare_summary_report_download,
                  hintr_error(t_("INVALID_DOWNLOAD_TYPE", list(type = type)),
                              "INVALID_DOWNLOAD_TYPE"))
   file_ext <- switch(type,
                      spectrum = ".zip",
                      coarse_output = ".zip",
                      summary = ".html",
+                     comparison = ".html",
                      hintr_error(t_("INVALID_DOWNLOAD_TYPE", list(type = type)),
                                  "INVALID_DOWNLOAD_TYPE"))
   path_results <- normalizePath(path_results, mustWork = TRUE)

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -315,11 +315,13 @@ download_result <- function(queue) {
       filename <- switch(res$metadata$type,
                          spectrum = "naomi-output",
                          coarse_output = "coarse-output",
-                         summary = "summary-report")
+                         summary = "summary-report",
+                         comparison = "comparison-report")
       ext <- switch(res$metadata$type,
-                         spectrum = ".zip",
-                         coarse_output = ".zip",
-                         summary = ".html")
+                    spectrum = ".zip",
+                    coarse_output = ".zip",
+                    summary = ".html",
+                    comparison = ".html")
       bytes <- readBin(res$path, "raw", n = file.size(res$path))
       bytes <- porcelain::porcelain_add_headers(bytes, list(
         "Content-Disposition" = build_content_disp_header(res$metadata$areas,

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone --single-branch --branch mrc-3072-naomi https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone --single-branch --branch mrc-3072-naomi https://github.com/mrc-ide/naomi
+git clone https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/tests/testthat/test-endpoints-download.R
+++ b/tests/testthat/test-endpoints-download.R
@@ -379,3 +379,83 @@ test_that("trying to get download with invalid result returns error", {
                scalar("Failed to generate metadata, output format is invalid"))
   expect_equal(out$status_code, 400)
 })
+
+
+test_that("summary report download returns bytes", {
+  test_mock_model_available()
+  q <- test_queue_result()
+
+  ## Submit download request
+  submit <- endpoint_download_submit(q$queue)
+  submit_response <- submit$run(q$calibrate_id, "summary")
+
+  expect_equal(submit_response$status_code, 200)
+  expect_true(!is.null(submit_response$data$id))
+
+  ## Status
+  out <- q$queue$queue$task_wait(submit_response$data$id)
+  status <- endpoint_download_status(q$queue)
+  status_response <- status$run(submit_response$data$id)
+
+  expect_equal(status_response$status_code, 200)
+  expect_equal(status_response$data$id, submit_response$data$id)
+  expect_true(status_response$data$done)
+  expect_equal(status_response$data$status, scalar("COMPLETE"))
+  expect_true(status_response$data$success)
+  expect_equal(status_response$data$queue, scalar(0))
+  expect_length(status_response$data$progress, 1)
+
+  ## Get result
+  result <- endpoint_download_result(q$queue)
+  response <- result$run(status_response$data$id)
+  expect_equal(response$status_code, 200)
+  expect_match(
+    response$headers$`Content-Disposition`,
+    'attachment; filename="MWI_summary-report_\\d+-\\d+.html"')
+  size <- length(response$data)
+  ## There is some data in the report
+  expect_true(size > 10000)
+  expect_equal(response$headers$`Content-Length`, size)
+})
+
+test_that("api can call summary report download", {
+  test_redis_available()
+  test_mock_model_available()
+  q <- test_queue_result()
+  api <- api_build(q$queue)
+
+  ## Submit download request
+  submit <- api$request("GET", paste0("/download/submit/summary/",
+                                      q$calibrate_id))
+  submit_body <- jsonlite::fromJSON(submit$body)
+  expect_equal(submit$status, 200)
+  expect_true(!is.null(submit_body$data$id))
+
+  ## Status
+  out <- q$queue$queue$task_wait(submit_body$data$id)
+  status <- api$request("GET",
+                        paste0("/download/status/", submit_body$data$id))
+
+  expect_equal(status$status, 200)
+  status_body <- jsonlite::fromJSON(status$body)
+  expect_equal(status_body$data$id, submit_body$data$id)
+  expect_true(status_body$data$done)
+  expect_equal(status_body$data$status, "COMPLETE")
+  expect_true(status_body$data$success)
+  expect_equal(status_body$data$queue, 0)
+  expect_length(status_body$data$progress, 1)
+
+  ## Get result
+  res <- api$request("GET", paste0("/download/result/", submit_body$data$id))
+
+  expect_equal(res$status, 200)
+  expect_equal(res$headers$`Content-Type`, "application/octet-stream")
+  expect_match(
+    res$headers$`Content-Disposition`,
+    'attachment; filename="MWI_summary-report_\\d+-\\d+.html"')
+  ## Size of bytes is close to expected
+  size <- length(res$body)
+  ## There is some data in the report
+  expect_true(size > 10000)
+  expect_equal(res$headers$`Content-Length`, size)
+})

--- a/tests/testthat/test-endpoints-download.R
+++ b/tests/testthat/test-endpoints-download.R
@@ -380,14 +380,13 @@ test_that("trying to get download with invalid result returns error", {
   expect_equal(out$status_code, 400)
 })
 
-
-test_that("summary report download returns bytes", {
+test_that("comparison report download returns bytes", {
   test_mock_model_available()
   q <- test_queue_result()
 
   ## Submit download request
   submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "summary")
+  submit_response <- submit$run(q$calibrate_id, "comparison")
 
   expect_equal(submit_response$status_code, 200)
   expect_true(!is.null(submit_response$data$id))
@@ -411,21 +410,21 @@ test_that("summary report download returns bytes", {
   expect_equal(response$status_code, 200)
   expect_match(
     response$headers$`Content-Disposition`,
-    'attachment; filename="MWI_summary-report_\\d+-\\d+.html"')
+    'attachment; filename="MWI_comparison-report_\\d+-\\d+.html"')
   size <- length(response$data)
   ## There is some data in the report
   expect_true(size > 10000)
   expect_equal(response$headers$`Content-Length`, size)
 })
 
-test_that("api can call summary report download", {
+test_that("api can call comparison report download", {
   test_redis_available()
   test_mock_model_available()
   q <- test_queue_result()
   api <- api_build(q$queue)
 
   ## Submit download request
-  submit <- api$request("GET", paste0("/download/submit/summary/",
+  submit <- api$request("GET", paste0("/download/submit/comparison/",
                                       q$calibrate_id))
   submit_body <- jsonlite::fromJSON(submit$body)
   expect_equal(submit$status, 200)
@@ -452,7 +451,7 @@ test_that("api can call summary report download", {
   expect_equal(res$headers$`Content-Type`, "application/octet-stream")
   expect_match(
     res$headers$`Content-Disposition`,
-    'attachment; filename="MWI_summary-report_\\d+-\\d+.html"')
+    'attachment; filename="MWI_comparison-report_\\d+-\\d+.html"')
   ## Size of bytes is close to expected
   size <- length(res$body)
   ## There is some data in the report


### PR DESCRIPTION
At the moment this just returns the same as summary report, when Rachel has time to address https://github.com/mrc-ide/naomi-board/issues/2 we can update this to return the comparison report.
