### PR TITLE
Turn off input warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.0.31
+Version: 1.0.32
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.0.32
+
+* Temporarily stop warning generation from ANC & ART uploads as it is taking a long time (> 18s for Nigeria) which is causing time out issues in hint.
+
 # hintr 1.0.31
 
 * Add new download type "comparison" to return input to output comparison report

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -135,8 +135,6 @@ do_validate_programme <- function(programme, shape, pjnz, strict = TRUE) {
   data$art_current <- as.numeric(data$art_current)
   assert_column_positive_numeric(data, "art_current")
   assert_calendar_quarter_column(data)
-  naomi_valid <- naomi::hintr_validate_art(programme$path, shape$path,
-                                           pjnz$path)
   list(data = data,
        filters = list("age" = get_age_filters(data),
                       "calendar_quarter" = get_quarter_filters(data),
@@ -180,7 +178,6 @@ do_validate_anc <- function(anc, shape, pjnz, strict = TRUE) {
   if (strict) {
     assert_anc_client_numbers(data)
   }
-  naomi_valid <- naomi::hintr_validate_anc(anc$path, shape$path, pjnz$path)
   data <- naomi::calculate_prevalence_art_coverage(data)
   list(data = data,
        filters = list("year" = get_year_filters(data),

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -139,7 +139,7 @@ do_validate_programme <- function(programme, shape, pjnz, strict = TRUE) {
        filters = list("age" = get_age_filters(data),
                       "calendar_quarter" = get_quarter_filters(data),
                       "indicators" = get_indicator_filters(data, "programme")),
-       warnings = naomi_valid$warnings)
+       warnings = list())
 }
 
 #' Validate ANC data file.
@@ -182,7 +182,7 @@ do_validate_anc <- function(anc, shape, pjnz, strict = TRUE) {
   list(data = data,
        filters = list("year" = get_year_filters(data),
                       "indicators" = get_indicator_filters(data, "anc")),
-       warnings = naomi_valid$warnings)
+       warnings = list())
 }
 
 #' Validate survey data file.

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -89,7 +89,7 @@ test_that("validate programme", {
   expect_length(response$data$filters$age, 2)
   expect_length(response$data$filters$calendar_quarter, 8)
   expect_length(response$data$filters$indicators, 4)
-  expect_length(response$data$warnings, 1)
+  expect_length(response$data$warnings, 0)
 })
 
 test_that("validate ANC", {
@@ -111,7 +111,7 @@ test_that("validate ANC", {
   expect_equal(names(response$data$filters), c("year", "indicators"))
   expect_length(response$data$filters$year, 8)
   expect_length(response$data$filters$indicators, 2)
-  expect_length(response$data$warnings, 2)
+  expect_length(response$data$warnings, 0)
 })
 
 test_that("validate survey", {

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -250,7 +250,7 @@ test_that("endpoint_validate_survey_programme works with programme data", {
   ## Sanity check that data has been returned
   expect_true(nrow(body$data$data) >= 200)
   expect_type(body$data$data[, "art_current"], "integer")
-  expect_equal(nrow(body$data$warnings), 0)
+  expect_length(body$data$warnings, 0)
 })
 
 test_that("endpoint_validate_survey_programme anc", {
@@ -286,7 +286,7 @@ test_that("endpoint_validate_survey_programme works with anc data", {
   expect_true(nrow(body$data$data) >= 200)
   expect_type(body$data$data[, "anc_prevalence"], "double")
   expect_type(body$data$data[, "anc_art_coverage"], "double")
-  expect_equal(nrow(body$data$warnings), 0)
+  expect_length(body$data$warnings, 0)
 })
 
 test_that("endpoint_validate_survey_programme survey", {
@@ -364,5 +364,5 @@ test_that("anc data can be validated can be run with relaxed validation", {
   expect_true(nrow(body$data$data) >= 200)
   expect_type(body$data$data[, "anc_prevalence"], "double")
   expect_type(body$data$data[, "anc_art_coverage"], "double")
-  expect_equal(nrow(body$data$warnings), 0)
+  expect_length(body$data$warnings, 0)
 })

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -14,7 +14,7 @@ test_that("endpoint_validate_survey_programme supports programme file", {
   ## Sanity check that data has been returned
   expect_true(nrow(response$data) >= 200)
   expect_type(response$data[, "art_current"], "double")
-  expect_length(response$warnings, 1)
+  expect_length(response$warnings, 0)
 })
 
 test_that("endpoint_validate_survey_programme returns error on invalid programme data", {
@@ -47,7 +47,7 @@ test_that("endpoint_validate_survey_programme supports ANC file", {
   expect_true(nrow(response$data) >= 200)
   expect_type(response$data[, "anc_prevalence"], "double")
   expect_type(response$data[, "anc_art_coverage"], "double")
-  expect_length(response$warnings, 2)
+  expect_length(response$warnings, 0)
 })
 
 test_that("endpoint_validate_survey_programme returns error on invalid ANC data", {
@@ -230,7 +230,7 @@ test_that("endpoint_validate_survey_programme programme", {
   ## Sanity check that data has been returned
   expect_true(nrow(response$data$data) >= 200)
   expect_type(response$data$data[, "art_current"], "double")
-  expect_length(response$data$warnings, 1)
+  expect_length(response$data$warnings, 0)
 })
 
 test_that("endpoint_validate_survey_programme works with programme data", {
@@ -250,7 +250,7 @@ test_that("endpoint_validate_survey_programme works with programme data", {
   ## Sanity check that data has been returned
   expect_true(nrow(body$data$data) >= 200)
   expect_type(body$data$data[, "art_current"], "integer")
-  expect_equal(nrow(body$data$warnings), 1)
+  expect_equal(nrow(body$data$warnings), 0)
 })
 
 test_that("endpoint_validate_survey_programme anc", {
@@ -266,7 +266,7 @@ test_that("endpoint_validate_survey_programme anc", {
   expect_true(nrow(response$data$data) >= 200)
   expect_type(response$data$data[, "anc_prevalence"], "double")
   expect_type(response$data$data[, "anc_art_coverage"], "double")
-  expect_length(response$data$warnings, 2)
+  expect_length(response$data$warnings, 0)
 })
 
 test_that("endpoint_validate_survey_programme works with anc data", {
@@ -286,7 +286,7 @@ test_that("endpoint_validate_survey_programme works with anc data", {
   expect_true(nrow(body$data$data) >= 200)
   expect_type(body$data$data[, "anc_prevalence"], "double")
   expect_type(body$data$data[, "anc_art_coverage"], "double")
-  expect_equal(nrow(body$data$warnings), 2)
+  expect_equal(nrow(body$data$warnings), 0)
 })
 
 test_that("endpoint_validate_survey_programme survey", {
@@ -364,5 +364,5 @@ test_that("anc data can be validated can be run with relaxed validation", {
   expect_true(nrow(body$data$data) >= 200)
   expect_type(body$data$data[, "anc_prevalence"], "double")
   expect_type(body$data$data[, "anc_art_coverage"], "double")
-  expect_equal(nrow(body$data$warnings), 2)
+  expect_equal(nrow(body$data$warnings), 0)
 })

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -119,8 +119,7 @@ test_that("do_validate_programme validates programme file", {
   expect_equal(data$filters$indicators[[4]]$label,
                scalar("VL tests suppressed"))
 
-  expect_length(data$warnings, 1)
-  expect_equal(data$warnings[[1]]$locations, "review_inputs")
+  expect_length(data$warnings, 0)
 })
 
 test_that("do_validate_anc validates ANC file and gets data for plotting", {
@@ -144,9 +143,7 @@ test_that("do_validate_anc validates ANC file and gets data for plotting", {
   expect_equal(data$filters$indicators[[2]]$id, scalar("anc_art_coverage"))
   expect_equal(data$filters$indicators[[2]]$label, scalar("ANC prior ART coverage"))
 
-  expect_length(data$warnings, 2)
-  expect_equal(data$warnings[[1]]$locations, "review_inputs")
-  expect_equal(data$warnings[[2]]$locations, "review_inputs")
+  expect_length(data$warnings, 0)
 })
 
 test_that("do_validate_anc can include anc_hiv_status column", {


### PR DESCRIPTION
These are taking ages and causing front end requests to the hintr API to timeout as it takes > 18s to run the validation for Nigeria