### PR TITLE
Switch download submit to a POST endpoint

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -311,7 +311,7 @@ endpoint_download_submit <- function(queue) {
                                                 schema_root())
   response <- porcelain::porcelain_returning_json(
     "DownloadSubmitResponse.schema", schema_root())
-  porcelain::porcelain_endpoint$new("GET",
+  porcelain::porcelain_endpoint$new("POST",
                                     "/download/submit/<type>/<id>",
                                     download_submit(queue),
                                     input,

--- a/inst/schema/ProjectState.schema.json
+++ b/inst/schema/ProjectState.schema.json
@@ -18,14 +18,6 @@
       },
       "additionalProperties": false,
       "required": [ "options", "id" ]
-    },
-    "async_run": {
-      "type": "object",
-      "properties": {
-        "id": { "type": "string" }
-      },
-      "additionalProperties": false,
-      "required": [ "id" ]
     }
   },
   "type": "object",
@@ -45,10 +37,6 @@
     },
     "model_fit": { "$ref": "#/definitions/async_run_options" },
     "calibrate": { "$ref": "#/definitions/async_run_options" },
-    "model_output": { "$ref": "#/definitions/async_run" },
-    "coarse_output": { "$ref": "#/definitions/async_run" },
-    "summary_report": { "$ref": "#/definitions/async_run" },
-    "comparison_report": { "$ref": "#/definitions/async_run" },
     "version": { "$ref": "VersionInfo.schema.json" }
   },
   "additionalProperties": false,
@@ -56,10 +44,6 @@
     "datasets",
     "model_fit",
     "calibrate",
-    "model_output",
-    "coarse_output",
-    "summary_report",
-    "comparison_report",
     "version"
   ]
 }

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -567,7 +567,7 @@ test_that("download streams bytes", {
   })
 
   ## Start the download
-  r <- server$request("GET",
+  r <- server$request("POST",
                       paste0("/download/submit/spectrum/", calibrate_id))
   response <- response_from_json(r)
   expect_equal(httr::status_code(r), 200)

--- a/tests/testthat/payload/spectrum_download_state_payload.json
+++ b/tests/testthat/payload/spectrum_download_state_payload.json
@@ -76,17 +76,5 @@
     },
     "id": "6e457f5a9f0413708624b7b0384e5fd0"
   },
-  "model_output": {
-    "id": "123"
-  },
-  "coarse_output": {
-    "id": "456"
-  },
-  "summary_report": {
-    "id": "789"
-  },
-  "comparison_report": {
-    "id": "1011"
-  },
   "version": <version_info>
 }

--- a/tests/testthat/test-endpoints-download.R
+++ b/tests/testthat/test-endpoints-download.R
@@ -52,7 +52,7 @@ test_that("api can call spectrum download", {
   api <- api_build(q$queue)
 
   ## Submit download request
-  submit <- api$request("GET",
+  submit <- api$request("POST",
                         paste0("/download/submit/spectrum/", q$calibrate_id))
   submit_body <- jsonlite::fromJSON(submit$body)
   expect_equal(submit$status, 200)
@@ -138,7 +138,7 @@ test_that("api can call coarse_output download", {
   api <- api_build(q$queue)
 
   ## Submit download request
-  submit <- api$request("GET", paste0("/download/submit/coarse-output/",
+  submit <- api$request("POST", paste0("/download/submit/coarse-output/",
                                       q$calibrate_id))
   submit_body <- jsonlite::fromJSON(submit$body)
   expect_equal(submit$status, 200)
@@ -217,7 +217,7 @@ test_that("api can call summary report download", {
   api <- api_build(q$queue)
 
   ## Submit download request
-  submit <- api$request("GET", paste0("/download/submit/summary/",
+  submit <- api$request("POST", paste0("/download/submit/summary/",
                                       q$calibrate_id))
   submit_body <- jsonlite::fromJSON(submit$body)
   expect_equal(submit$status, 200)
@@ -426,7 +426,7 @@ test_that("api can call comparison report download", {
   api <- api_build(q$queue)
 
   ## Submit download request
-  submit <- api$request("GET", paste0("/download/submit/comparison/",
+  submit <- api$request("POST", paste0("/download/submit/comparison/",
                                       q$calibrate_id))
   submit_body <- jsonlite::fromJSON(submit$body)
   expect_equal(submit$status, 200)
@@ -526,7 +526,7 @@ test_that("api: spectrum download can include notes", {
 
   ## Submit download request
   path <- setup_download_request_payload(include_state = FALSE)
-  submit <- api$request("GET",
+  submit <- api$request("POST",
                         paste0("/download/submit/spectrum/", q$calibrate_id),
                         body = readLines(path))
   submit_body <- jsonlite::fromJSON(submit$body)
@@ -655,7 +655,7 @@ test_that("api: spectrum download can include project state", {
 
   ## Submit download request
   path <- setup_download_request_payload(include_notes = FALSE)
-  submit <- api$request("GET",
+  submit <- api$request("POST",
                         paste0("/download/submit/spectrum/", q$calibrate_id),
                         body = readLines(path))
   submit_body <- jsonlite::fromJSON(submit$body)
@@ -696,7 +696,7 @@ test_that("api: spectrum download can include notes and state", {
 
   ## Submit download request
   path <- setup_download_request_payload()
-  submit <- api$request("GET",
+  submit <- api$request("POST",
                         paste0("/download/submit/spectrum/", q$calibrate_id),
                         body = readLines(path))
   submit_body <- jsonlite::fromJSON(submit$body)
@@ -764,7 +764,7 @@ test_that("api: programme and anc files are optional in spectrum download", {
   jsonlite::write_json(json, t, auto_unbox = TRUE)
 
   ## Submit download request
-  submit <- api$request("GET",
+  submit <- api$request("POST",
                         paste0("/download/submit/spectrum/", q$calibrate_id),
                         body = readLines(t))
   submit_body <- jsonlite::fromJSON(submit$body)


### PR DESCRIPTION
This endpoint should probably have been a `POST` from the start but now that it takes a json body it needs to be switched