### PR TITLE
Remove download from state

### DIFF
--- a/inst/schema/ProjectState.schema.json
+++ b/inst/schema/ProjectState.schema.json
@@ -18,14 +18,6 @@
       },
       "additionalProperties": false,
       "required": [ "options", "id" ]
-    },
-    "async_run": {
-      "type": "object",
-      "properties": {
-        "id": { "type": "string" }
-      },
-      "additionalProperties": false,
-      "required": [ "id" ]
     }
   },
   "type": "object",
@@ -45,10 +37,6 @@
     },
     "model_fit": { "$ref": "#/definitions/async_run_options" },
     "calibrate": { "$ref": "#/definitions/async_run_options" },
-    "model_output": { "$ref": "#/definitions/async_run" },
-    "coarse_output": { "$ref": "#/definitions/async_run" },
-    "summary_report": { "$ref": "#/definitions/async_run" },
-    "comparison_report": { "$ref": "#/definitions/async_run" },
     "version": { "$ref": "VersionInfo.schema.json" }
   },
   "additionalProperties": false,
@@ -56,10 +44,6 @@
     "datasets",
     "model_fit",
     "calibrate",
-    "model_output",
-    "coarse_output",
-    "summary_report",
-    "comparison_report",
     "version"
   ]
 }

--- a/tests/testthat/payload/spectrum_download_state_payload.json
+++ b/tests/testthat/payload/spectrum_download_state_payload.json
@@ -76,17 +76,5 @@
     },
     "id": "6e457f5a9f0413708624b7b0384e5fd0"
   },
-  "model_output": {
-    "id": "123"
-  },
-  "coarse_output": {
-    "id": "456"
-  },
-  "summary_report": {
-    "id": "789"
-  },
-  "comparison_report": {
-    "id": "1011"
-  },
   "version": <version_info>
 }


### PR DESCRIPTION
Builds on #385 

We don't necessarily know the download ids at the point of generation (and we definitely don't know the ID of the output zip download ID) see https://github.com/mrc-ide/hint/pull/708#pullrequestreview-1001523167