### PR TITLE
Run integration tests in a new environment with pkload env as parent

### DIFF
--- a/scripts/test_integration
+++ b/scripts/test_integration
@@ -1,4 +1,9 @@
 #!/usr/bin/env Rscript
+env <- pkgload::load_all(".")$env
+## Since pkgload 1.3.0 the namespace is now locked just before onLoad
+## hooks are run. testthat evaluates helper functions in passed env so
+## we need to create a new environment for testing
+test_env <- new.env(parent = env)
 testthat::test_file("tests/testthat/integration-server.R",
-                    env = pkgload::load_all(".")$env,
+                    env = test_env,
                     stop_on_failure = TRUE)


### PR DESCRIPTION
This PR will
* Fix integration test setup after pkgload 1.3.0 update see https://pkgload.r-lib.org/news/index.html

> The loaded namespace is now locked just before user onLoad hooks are run. This better reproduced the namespace sealing behaviour of regular loading.
The package environment environment is now locked as well before both the user and package onAttach hooks are run.