### PR TITLE
Fix test after plumber update

### DIFF
--- a/tests/testthat/test-endpoints-download.R
+++ b/tests/testthat/test-endpoints-download.R
@@ -93,7 +93,7 @@ test_that("api can call spectrum download", {
                'attachment; filename="MWI_naomi-output_\\d+-\\d+.zip"')
   expect_equal(head_res$headers$`Content-Length`, size)
   ## Plumber uses an empty string to represent an empty body
-  expect_equal(head_res$body, "")
+  expect_null(head_res$body)
 })
 
 test_that("coarse output download returns bytes", {


### PR DESCRIPTION
Not exactly sure what changed in the underlying package here, but this failed locally after I upgraded plumber package. I am guessing something with serialization in HEAD requests or of empty JSON has changed. Either way I think not important for us between api return NULL or an empty body so we can just update the test