### PR TITLE
mrc-3655: Replace rehydate with load in error message wording for clarity

### DIFF
--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -86,5 +86,5 @@
     "QUARTER_4": "Quarter 4",
     "VALIDATION_MULTIPLE_LEVELS_DETAIL": "year {{year}} has area levels {{levels}}",
     "VALIDATION_MULTIPLE_LEVELS": "Data can only be for regions at a single area level per year. In uploaded data {{detail}}.",
-    "FAILED_ZIP_REHYDRATE_SUBMIT": "Cannot rehydrate from zip file, archive missing required information. Please regenerate output zip and try again."
+    "FAILED_ZIP_REHYDRATE_SUBMIT": "Cannot load from this zip file, archive missing required information. Please regenerate output zip and try again."
 }

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -87,5 +87,5 @@
     "QUARTER_4": "trimestre 4",
     "VALIDATION_MULTIPLE_LEVELS_DETAIL": "l'année {{year}} a des niveaux de zone {{levels}}",
     "VALIDATION_MULTIPLE_LEVELS": "Les données ne peuvent concerner que les régions à un seul niveau de zone par an. Dans les données téléchargées {{detail}}",
-    "FAILED_ZIP_REHYDRATE_SUBMIT": "Impossible de réhydrater à partir du fichier zip, l'archive manque d'informations requises. Veuillez régénérer le zip de sortie et réessayer."
+    "FAILED_ZIP_REHYDRATE_SUBMIT": "Impossible de charger à partir de ce fichier zip, l'archive manque d'informations requises. Veuillez régénérer le zip de sortie et réessayer."
 }

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -86,5 +86,5 @@
     "QUARTER_4": "trimestre 4",
     "VALIDATION_MULTIPLE_LEVELS_DETAIL": "ano {{year}} tem níveis de área {{levels}}",
     "VALIDATION_MULTIPLE_LEVELS": "Os dados só podem ser relativos a regiões a um único nível de área por ano. Em dados carregados {{detail}}",
-    "FAILED_ZIP_REHYDRATE_SUBMIT": "Não é possível re-hidratar a partir de ficheiro zip, faltando informação necessária ao arquivo. Por favor, regenerar zip de saída e tentar novamente."
+    "FAILED_ZIP_REHYDRATE_SUBMIT": "Não é possível carregar a partir deste ficheiro zip, faltando informação necessária ao arquivo. Por favor, regenerar zip de saída e tentar novamente."
 }

--- a/tests/testthat/test-endpoints-rehydrate.R
+++ b/tests/testthat/test-endpoints-rehydrate.R
@@ -111,7 +111,7 @@ test_that("rehydrate returns useful error if cannot rehydrate from zip", {
   expect_equal(response$value$errors[[1]]$error,
                scalar("PROJECT_REHYDRATE_FAILED"))
   expect_equal(response$value$errors[[1]]$detail,
-               scalar(paste0("Cannot rehydrate from zip file, archive missing",
+               scalar(paste0("Cannot load from this zip file, archive missing",
                              " required information. Please regenerate output",
                              " zip and try again.")))
 })


### PR DESCRIPTION
UNAIDS were confused about "rehydrate" and we call it "load" elsewhere in the UI so rename it here to be consistent