### PR TITLE
Fix duplicate running of rehydrate and add lintr

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,7 @@
+linters: with_defaults(
+    object_length_linter = NULL,
+    object_name_linter = NULL,
+    object_usage_linter = NULL,
+    cyclocomp_linter = NULL
+    )
+exclusions: list("tests/testthat.R")

--- a/R/queue.R
+++ b/R/queue.R
@@ -14,7 +14,7 @@ Queue <- R6::R6Class(
                           prerun_dir = NULL,
                           timeout = Inf) {
       self$cleanup_on_exit <- cleanup_on_exit
-      self$results_dir = results_dir
+      self$results_dir <- results_dir
 
       message(t_("QUEUE_CONNECTING", list(redis = redux::redis_config()$url)))
       con <- redux::hiredis()

--- a/R/rehydrate.R
+++ b/R/rehydrate.R
@@ -24,7 +24,6 @@ rehydrate_submit <- function(queue) {
     tryCatch({
       input <- jsonlite::fromJSON(input)
       assert_file_exists(input$file$path)
-      queue$submit_rehydrate(input$file)
       list(id = scalar(queue$submit_rehydrate(input$file)))
     }, error = function(e) {
       hintr_error(e$message, "REHYDRATE_SUBMIT_FAILED")


### PR DESCRIPTION
This PR will add a lintr configuration and remove duplicated call to `queue$submit_rehydrate(input$file)`