### PR TITLE
Improve performance of get_model_options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Additional_repositories: https://mrc-ide.r-universe.dev 
 Imports:
+    data.table,
     digest,
     docopt,
     geojsonio (>= 0.8.0),
@@ -22,7 +23,7 @@ Imports:
     ids,
     jsonlite (>= 1.2.2),
     lgr,
-    naomi (>= 2.7.18),
+    naomi (>= 2.7.19),
     naomi.options,
     porcelain (>= 0.1.8),
     R6,

--- a/R/indicators.R
+++ b/R/indicators.R
@@ -5,13 +5,13 @@
 #' return the rows containing the specified indicator.
 #'
 #' @param data The input data type to filter.
+#' @param metadata The metadata from naomi.
 #' @param type The type of input data.
 #' @param indicator The indicator to filter on.
 #'
 #' @return The read data filtered for the indicator
 #' @keywords internal
-get_indicator_data <- function(file, type, indicator) {
-  metadata <- naomi::get_metadata()
+get_indicator_data <- function(data, metadata, type, indicator) {
   type_metadata <- metadata[
     metadata$data_type == type & metadata$indicator == indicator, ]
   if (nrow(type_metadata) != 1) {
@@ -19,7 +19,6 @@ get_indicator_data <- function(file, type, indicator) {
             list(nrow = nrow(type_metadata), type = type,
                  indicator = indicator)))
   }
-  data <- read_csv(file$path)
   if (!is.null(type_metadata$indicator_column) && !identical(type_metadata$indicator_column, "")) {
     ## Filter indicator column based on indicator value of data
     ret <- data[data[[type_metadata$indicator_column]] == type_metadata$indicator_value, ]

--- a/R/model_options.R
+++ b/R/model_options.R
@@ -32,7 +32,7 @@ do_endpoint_model_options <- function(shape, survey, programme, anc) {
     ## included in options
     most_recent_survey_qid <- naomi::calendar_quarter_to_quarter_id(
       most_recent_survey_quarter)
-    mr_qlist <- list(quarter_id_to_json_list(most_recent_survey_qid))
+    mr_qlist <- quarter_id_to_json_list(most_recent_survey_qid)
     time_options <- union_time_list(time_options, mr_qlist, decreasing = TRUE)
   } else {
     ## Use the most recent time option
@@ -134,7 +134,7 @@ quarter_id_to_json_list <- function(times) {
   format <- function(id, label) {
     list(id = scalar(id), label = scalar(label))
   }
-  Map(format, ids, labels)
+  Map(format, ids, labels, USE.NAMES = FALSE)
 }
 
 sort_time_json_list <- function(time_list, decreasing = TRUE) {

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -24,16 +24,12 @@ read_csv_regions <- function(csv_file) {
 }
 
 read_csv <- function(file, ...) {
-  header <- readLines(file, 1)
-  if (!grepl(",", header) && grepl(";", header)) {
-    read <- utils::read.csv2
-  } else {
-    read <- utils::read.csv
-  }
-
-  data <- read(file, ..., stringsAsFactors = FALSE)
-  na_or_empty_rows <- rowSums(is.na(data)) + rowSums(data == "", na.rm = TRUE)
-  data[na_or_empty_rows != ncol(data), ]
+  data <- data.table::fread(file, ...,
+                            blank.lines.skip = TRUE,
+                            data.table = FALSE,
+                            nThread = 1,
+                            na.strings = c("NA", ""))
+  data[rowSums(is.na(data)) != ncol(data), ]
 }
 
 read_pjnz_iso3 <- function(pjnz) {
@@ -56,6 +52,10 @@ read_geojson_iso3 <- function(shape) {
   json <- hintr_geojson_read(shape)
   ## At this point we have validated there is only data for 1 country so we can
   ## just take the first.
+  get_geojson_iso3(json)
+}
+
+get_geojson_iso3 <- function(json) {
   substr(json$features[[1]]$properties$area_id, 1, 3)
 }
 
@@ -71,4 +71,3 @@ read_country <- function(pjnz_path) {
   hiv_params <- specio::read_pjn_metadata(pjnz_path)
   hiv_params$country
 }
-

--- a/R/utils.R
+++ b/R/utils.R
@@ -136,3 +136,4 @@ format_notes <- function(notes) {
 file_exists <- function(file) {
   !is.null(file) && file.exists(file)
 }
+

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone --single-branch --branch vectorise-quarter https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone --single-branch --branch vectorise-quarter https://github.com/mrc-ide/naomi
+git clone https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/tests/testthat/test-indicators.R
+++ b/tests/testthat/test-indicators.R
@@ -1,33 +1,32 @@
 context("indicators")
 
 test_that("can get filtered data for indicator", {
-  survey <- file_object(file.path("testdata", "survey.csv"))
-  indicator_data <- get_indicator_data(survey, "survey", "art_coverage")
+  data <- read_csv(file.path("testdata", "survey.csv"))
+  metadata <- naomi::get_metadata()
+  indicator_data <- get_indicator_data(data, metadata, "survey", "art_coverage")
   expect_true(all(indicator_data$indicator == "art_coverage"))
   expect_equal(names(indicator_data),
                c("indicator", "survey_id", "survey_mid_calendar_quarter",
                  "area_id", "area_name", "res_type", "sex", "age_group",
                  "n_clusters", "n_observations", "n_eff_kish", "estimate",
                  "std_error", "ci_lower", "ci_upper"))
-  prevalence_data <- get_indicator_data(survey, "survey", "prevalence")
+  prevalence_data <- get_indicator_data(data, metadata, "survey", "prevalence")
   expect_true(all(prevalence_data$indicator == "prevalence"))
 
-  anc <- file_object(file.path("testdata", "anc.csv"))
-  anc_prevalence <- get_indicator_data(anc, "anc", "anc_prevalence")
+  anc <- read_csv(file.path("testdata", "anc.csv"))
+  anc_prevalence <- get_indicator_data(anc, metadata, "anc", "anc_prevalence")
   expect_equal(names(anc_prevalence),
                c("area_id", "area_name", "age_group", "year", "anc_clients",
                  "anc_known_pos", "anc_already_art", "anc_tested",
                  "anc_tested_pos", "anc_known_neg", "births_facility"))
-  anc_art <- get_indicator_data(anc, "anc", "anc_art_coverage")
+  anc_art <- get_indicator_data(anc, metadata, "anc", "anc_art_coverage")
   expect_equal(nrow(anc_art), nrow(anc_prevalence))
 
-  mock_metadata <- mockery::mock(data.frame(
+  mock_metadata <- data.frame(
     data_type = c("survey", "survey"),
     indicator = c("prevalence", "art_coverage"),
     stringsAsFactors = FALSE
-  ))
-  with_mock("naomi::get_metadata" = mock_metadata, {
-    expect_error(get_indicator_data(anc, "anc", "anc_prevalence"),
-                 "Found 0 rows in metadata for data type anc and indicator anc_prevalence. Should be exactly one.")
-  })
+  )
+  expect_error(get_indicator_data(anc, mock_metadata, "anc", "anc_prevalence"),
+               "Found 0 rows in metadata for data type anc and indicator anc_prevalence. Should be exactly one.")
 })

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -369,8 +369,9 @@ test_that("model options work when survey_mid_calendar_quarter missing", {
 })
 
 test_that("can get survey options & default for different indicators", {
-  survey <- file_object(file.path("testdata", "survey.csv"))
-  prev_options <- get_survey_options(survey, "prevalence")
+  data <- read_csv(file.path("testdata", "survey.csv"))
+  metadata <- naomi::get_metadata()
+  prev_options <- get_survey_options(data, metadata, "prevalence")
   expect_equal(prev_options$default, scalar("DEMO2016PHIA"))
   expect_equal(prev_options$options, list(
     list(
@@ -391,7 +392,7 @@ test_that("can get survey options & default for different indicators", {
     )
   ))
 
-  art_options <- get_survey_options(survey, "art_coverage")
+  art_options <- get_survey_options(data, metadata, "art_coverage")
   expect_equal(art_options$default, scalar("DEMO2016PHIA"))
   expect_equal(art_options$options, list(
     list(id = scalar("DEMO2016PHIA"),
@@ -399,7 +400,8 @@ test_that("can get survey options & default for different indicators", {
   ))
 
   mock_get_indicator_data <- mockery::mock(NULL)
-  recent_infected_options <- get_survey_options(survey, "recent_infected")
+  recent_infected_options <- get_survey_options(data, metadata,
+                                                "recent_infected")
   expect_equal(art_options$default, scalar("DEMO2016PHIA"))
   expect_equal(art_options$options, list(
     list(id = scalar("DEMO2016PHIA"),
@@ -408,9 +410,10 @@ test_that("can get survey options & default for different indicators", {
 })
 
 test_that("getting survey options for missing indicator returns empty values", {
-  survey <- file_object(file.path("testdata", "survey_prevalence_only.csv"))
+  data <- read_csv(file.path("testdata", "survey_prevalence_only.csv"))
+  metadata <- naomi::get_metadata()
   expect_equal(
-    get_survey_options(survey, "art_coverage"),
+    get_survey_options(data, metadata, "art_coverage"),
     list(
       options = NULL,
       default = scalar("")

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -330,8 +330,8 @@ test_that("integrating time options works", {
   quarter_ids1 <- naomi::calendar_quarter_to_quarter_id(ids1)
   quarter_ids2 <- naomi::calendar_quarter_to_quarter_id(ids2)
 
-  times1 <- lapply(quarter_ids1, quarter_id_to_json_list)
-  times2 <- lapply(quarter_ids2, quarter_id_to_json_list)
+  times1 <- quarter_id_to_json_list(quarter_ids1)
+  times2 <- quarter_id_to_json_list(quarter_ids2)
 
   times <- union_time_list(times1, times2)
 


### PR DESCRIPTION
This will speed up in a few ways
* Reduce duplicate reads (of shape file and geojson)
* Use vectorised version of naomi functions for getting labels (atm this is slow because each call to naomi translates some strings, now that translation is only done once)
* Use data.table to read the csv file, this much faster than read.csv

Running benchmarking locally before these changes on current Cameroon data from ADR we have
```
> microbenchmark::microbenchmark(model_options(input), times = 10)
Unit: seconds
                 expr     min       lq     mean   median       uq      max neval
 model_options(input) 2.14557 2.154384 2.249949 2.232277 2.351745 2.373982    1
```

After this we are getting

```
> microbenchmark::microbenchmark(model_options(input), times = 10)
Unit: milliseconds
                 expr      min       lq    mean   median      uq      max neval
 model_options(input) 376.0353 383.2105 406.114 385.1356 395.946 561.7291    10
```

Looking at the profile the timing is now
* reading geojson `hintr_geojson_read` ~ 120ms
* getting filters from this  `get_region_filters` ~ 50ms
* reading the survey data `read_csv` ~ 40ms
* reading anc data `naomi::read_anc_testing` ~ 20ms
* building the options json `naomi.options::get_controls_json` ~ 80ms

I think this will be a bit quicker live because we have caching of the geojson read.