### PR TITLE
Error immediately if comparison report cannot be generated

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.0.43
+Version: 1.0.44
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.0.44
+
+* Fail early if comparison report output cannot be generated
+
 # hintr 1.0.41
 
 * Add country specific default values to all model and calibration options

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -261,11 +261,11 @@ comparison_plot <- function(queue) {
   }
 }
 
-verify_result_available <- function(queue, id) {
+verify_result_available <- function(queue, id, version = NULL) {
   task_status <- queue$queue$task_status(id)
   if (task_status == "COMPLETE") {
     result <- queue$result(id)
-    naomi:::assert_model_output_version(result)
+    naomi:::assert_model_output_version(result, version = version)
   } else if (task_status == "ERROR") {
     result <- queue$result(id)
     trace <- c(sprintf("# %s", id), result$trace)
@@ -302,10 +302,14 @@ plotting_metadata <- function(iso3 = NULL) {
 
 download_submit <- function(queue) {
   function(id, type, input = NULL) {
-    verify_result_available(queue, id)
     ## API path should be - separated but we
     ## use _ for names in naomi
     type <- gsub("-", "_", type, fixed = TRUE)
+    version <- NULL
+    if (type == "comparison") {
+      version <- "2.7.16"
+    }
+    verify_result_available(queue, id, version)
     notes <- NULL
     state <- NULL
     if (!is.null(input)) {

--- a/tests/testthat/test-endpoints-download.R
+++ b/tests/testthat/test-endpoints-download.R
@@ -839,3 +839,17 @@ test_that("spectrum download is translated", {
   indicators <- read.csv(file.path(dest, INDICATORS_PATH))
   expect_true("Prévalence du VIH" %in% unique(indicators$indicator_label))
 })
+
+test_that("comparison report download errors for old model output", {
+  test_mock_model_available()
+  q <- test_queue_result(model = mock_model_v1.0.7,
+                         calibrate = mock_calibrate_v1.0.7)
+
+  ## Submit download request
+  submit <- endpoint_download_submit(q$queue)
+  submit_response <- submit$run(q$calibrate_id, "comparison")
+
+  expect_equal(submit_response$status_code, 500)
+  expect_equal(submit_response$value$errors[[1]]$detail, scalar(
+    "Model output out of date please re-run model and try again."))
+})


### PR DESCRIPTION
At the moment naomi checks what version of the model output it can generate the comparison report for. This means that  if they try to generate it for an old model output, the download starts and the error is thrown by naomi when running on the worker. So only surfaces when the result is then fetched from hint. We are not handling errors in hint from download result atm so if we error earlier when we try to submit it can bypass this problem. We do need to add this error handling to hint in the future but this should buy us some time before the workshop.