### PR TITLE
Revert "Error immediately if comparison report cannot be generated"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.0.44
+Version: 1.0.43
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,3 @@
-# hintr 1.0.44
-
-* Fail early if comparison report output cannot be generated
-
 # hintr 1.0.41
 
 * Add country specific default values to all model and calibration options

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -261,11 +261,11 @@ comparison_plot <- function(queue) {
   }
 }
 
-verify_result_available <- function(queue, id, version = NULL) {
+verify_result_available <- function(queue, id) {
   task_status <- queue$queue$task_status(id)
   if (task_status == "COMPLETE") {
     result <- queue$result(id)
-    naomi:::assert_model_output_version(result, version = version)
+    naomi:::assert_model_output_version(result)
   } else if (task_status == "ERROR") {
     result <- queue$result(id)
     trace <- c(sprintf("# %s", id), result$trace)
@@ -302,14 +302,10 @@ plotting_metadata <- function(iso3 = NULL) {
 
 download_submit <- function(queue) {
   function(id, type, input = NULL) {
+    verify_result_available(queue, id)
     ## API path should be - separated but we
     ## use _ for names in naomi
     type <- gsub("-", "_", type, fixed = TRUE)
-    version <- NULL
-    if (type == "comparison") {
-      version <- "2.7.16"
-    }
-    verify_result_available(queue, id, version)
     notes <- NULL
     state <- NULL
     if (!is.null(input)) {

--- a/tests/testthat/test-endpoints-download.R
+++ b/tests/testthat/test-endpoints-download.R
@@ -839,17 +839,3 @@ test_that("spectrum download is translated", {
   indicators <- read.csv(file.path(dest, INDICATORS_PATH))
   expect_true("Prévalence du VIH" %in% unique(indicators$indicator_label))
 })
-
-test_that("comparison report download errors for old model output", {
-  test_mock_model_available()
-  q <- test_queue_result(model = mock_model_v1.0.7,
-                         calibrate = mock_calibrate_v1.0.7)
-
-  ## Submit download request
-  submit <- endpoint_download_submit(q$queue)
-  submit_response <- submit$run(q$calibrate_id, "comparison")
-
-  expect_equal(submit_response$status_code, 500)
-  expect_equal(submit_response$value$errors[[1]]$detail, scalar(
-    "Model output out of date please re-run model and try again."))
-})


### PR DESCRIPTION
This reverts commit 8cd25a1e4f81e6248edcd25a5f88363a75e589de.

This is for testing hint error handling and should not be merged!