### PR TITLE
Add default selection data into comparison plot response

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.1.2
+
+* Add default selections for each indicator in comparison plot
+
 # hintr 1.1.1
 
 * Add fallback model and calibration options for unknown countries

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -248,13 +248,15 @@ comparison_plot <- function(queue) {
                    "calendar_quarter", "indicator", "source", "mean",
                    "lower", "upper")]
     filters <- get_comparison_plot_filters(data)
+    selections <- get_comparison_barchart_selections(data, filters)
     list(
       data = data,
       plottingMetadata = list(
         barchart = list(
           indicators = get_barchart_metadata(data, "comparison"),
           filters = filters,
-          defaults = get_comparison_barchart_defaults(data, filters)
+          defaults = selections[[1]],
+          selections = selections
         )
       )
     )

--- a/R/filters.R
+++ b/R/filters.R
@@ -240,7 +240,7 @@ get_comparison_barchart_selections <- function(output, filters) {
   all_sexes <- get_selected_mappings(filters, "sex")
   both <- get_selected_mappings(filters, "sex", "both")
   female <- get_selected_mappings(filters, "sex", "female")
-  first_quarter <- get_selected_mappings(filters, "quarter")[1]
+  survey_quarter <- get_selected_mappings(filters, "quarter")[2]
   source = get_selected_mappings(filters, "source")
   fifteen_to_49 <- get_selected_mappings(filters, "age", "Y015_049")
   list(
@@ -250,7 +250,7 @@ get_comparison_barchart_selections <- function(output, filters) {
       disaggregate_by_id = scalar("source"),
       selected_filter_options = list(
         area = area_default,
-        quarter = first_quarter,
+        quarter = survey_quarter,
         sex = both,
         age = five_year_age_groups,
         source = source
@@ -262,7 +262,7 @@ get_comparison_barchart_selections <- function(output, filters) {
       disaggregate_by_id = scalar("source"),
       selected_filter_options = list(
         area = area_default,
-        quarter = first_quarter,
+        quarter = survey_quarter,
         sex = both,
         age = five_year_age_groups,
         source = source
@@ -274,7 +274,7 @@ get_comparison_barchart_selections <- function(output, filters) {
       disaggregate_by_id = scalar("source"),
       selected_filter_options = list(
         area = area_default,
-        quarter = first_quarter,
+        quarter = survey_quarter,
         sex = all_sexes,
         age = get_selected_mappings(filters, "age", "Y015_999"),
         source = source
@@ -286,7 +286,7 @@ get_comparison_barchart_selections <- function(output, filters) {
       disaggregate_by_id = scalar("source"),
       selected_filter_options = list(
         area = area_default,
-        quarter = first_quarter,
+        quarter = survey_quarter,
         sex = female,
         age = fifteen_to_49,
         source = source
@@ -298,7 +298,7 @@ get_comparison_barchart_selections <- function(output, filters) {
       disaggregate_by_id = scalar("source"),
       selected_filter_options = list(
         area = area_default,
-        quarter = first_quarter,
+        quarter = survey_quarter,
         sex = female,
         age = fifteen_to_49,
         source = source

--- a/R/filters.R
+++ b/R/filters.R
@@ -234,17 +234,70 @@ get_calibrate_barchart_defaults <- function(filters) {
 }
 
 get_comparison_barchart_defaults <- function(output, filters) {
+  area_default <- get_area_level_filter_option(output)
   list(
-    indicator_id = scalar("prevalence"),
-    x_axis_id = scalar("age"),
-    disaggregate_by_id = scalar("source"),
-    selected_filter_options = list(
-      area = get_area_level_filter_option(output),
-      quarter = get_selected_mappings(filters, "quarter")[2],
-      sex = get_selected_mappings(filters, "sex")[1],
-      age = get_selected_mappings(filters, "age",
-                                  naomi::get_five_year_age_groups()),
-      source = get_selected_mappings(filters, "source")
+    list(
+      indicator_id = scalar("prevalence"),
+      x_axis_id = scalar("age"),
+      disaggregate_by_id = scalar("source"),
+      selected_filter_options = list(
+        area = area_default,
+        quarter = get_selected_mappings(filters, "quarter")[2],
+        sex = get_selected_mappings(filters, "sex")[1],
+        age = get_selected_mappings(filters, "age",
+                                    naomi::get_five_year_age_groups()),
+        source = get_selected_mappings(filters, "source")
+      )
+    ),
+    list(
+      indicator_id = scalar("art_coverage"),
+      x_axis_id = scalar("age"),
+      disaggregate_by_id = scalar("source"),
+      selected_filter_options = list(
+        area = area_default,
+        quarter = get_selected_mappings(filters, "quarter")[2],
+        sex = get_selected_mappings(filters, "sex")[1],
+        age = get_selected_mappings(filters, "age",
+                                    naomi::get_five_year_age_groups()),
+        source = get_selected_mappings(filters, "source")
+      )
+    ),
+    list(
+      indicator_id = scalar("art_current"),
+      x_axis_id = scalar("age"),
+      disaggregate_by_id = scalar("source"),
+      selected_filter_options = list(
+        area = area_default,
+        quarter = get_selected_mappings(filters, "quarter")[2],
+        sex = get_selected_mappings(filters, "sex")[1],
+        age = get_selected_mappings(filters, "age",
+                                    naomi::get_five_year_age_groups()),
+        source = get_selected_mappings(filters, "source")
+      )
+    ),
+    list(
+      indicator_id = scalar("anc_prevalence_age_matched"),
+      x_axis_id = scalar("age"),
+      disaggregate_by_id = scalar("source"),
+      selected_filter_options = list(
+        area = area_default,
+        quarter = get_selected_mappings(filters, "quarter")[2],
+        sex = get_selected_mappings(filters, "sex", "female"),
+        age = get_selected_mappings(filters, "age", "Y015_049"),
+        source = get_selected_mappings(filters, "source")
+      )
+    ),
+    list(
+      indicator_id = scalar("anc_art_coverage_age_matched"),
+      x_axis_id = scalar("age"),
+      disaggregate_by_id = scalar("source"),
+      selected_filter_options = list(
+        area =area_default,
+        quarter = get_selected_mappings(filters, "quarter")[2],
+        sex = get_selected_mappings(filters, "sex", "female"),
+        age = get_selected_mappings(filters, "age", "Y015_049"),
+        source = get_selected_mappings(filters, "source")
+      )
     )
   )
 }

--- a/R/filters.R
+++ b/R/filters.R
@@ -235,6 +235,14 @@ get_calibrate_barchart_defaults <- function(filters) {
 
 get_comparison_barchart_selections <- function(output, filters) {
   area_default <- get_area_level_filter_option(output)
+  five_year_age_groups <- get_selected_mappings(
+    filters, "age",naomi::get_five_year_age_groups())
+  all_sexes <- get_selected_mappings(filters, "sex")
+  both <- get_selected_mappings(filters, "sex", "both")
+  female <- get_selected_mappings(filters, "sex", "female")
+  first_quarter <- get_selected_mappings(filters, "quarter")[1]
+  source = get_selected_mappings(filters, "source")
+  fifteen_to_49 <- get_selected_mappings(filters, "age", "Y015_049")
   list(
     list(
       indicator_id = scalar("prevalence"),
@@ -242,11 +250,10 @@ get_comparison_barchart_selections <- function(output, filters) {
       disaggregate_by_id = scalar("source"),
       selected_filter_options = list(
         area = area_default,
-        quarter = get_selected_mappings(filters, "quarter")[2],
-        sex = get_selected_mappings(filters, "sex")[1],
-        age = get_selected_mappings(filters, "age",
-                                    naomi::get_five_year_age_groups()),
-        source = get_selected_mappings(filters, "source")
+        quarter = first_quarter,
+        sex = both,
+        age = five_year_age_groups,
+        source = source
       )
     ),
     list(
@@ -255,48 +262,46 @@ get_comparison_barchart_selections <- function(output, filters) {
       disaggregate_by_id = scalar("source"),
       selected_filter_options = list(
         area = area_default,
-        quarter = get_selected_mappings(filters, "quarter")[2],
-        sex = get_selected_mappings(filters, "sex")[1],
-        age = get_selected_mappings(filters, "age",
-                                    naomi::get_five_year_age_groups()),
-        source = get_selected_mappings(filters, "source")
+        quarter = first_quarter,
+        sex = both,
+        age = five_year_age_groups,
+        source = source
       )
     ),
     list(
       indicator_id = scalar("art_current"),
-      x_axis_id = scalar("age"),
+      x_axis_id = scalar("sex"),
       disaggregate_by_id = scalar("source"),
       selected_filter_options = list(
         area = area_default,
-        quarter = get_selected_mappings(filters, "quarter")[2],
-        sex = get_selected_mappings(filters, "sex")[1],
-        age = get_selected_mappings(filters, "age",
-                                    naomi::get_five_year_age_groups()),
-        source = get_selected_mappings(filters, "source")
+        quarter = first_quarter,
+        sex = all_sexes,
+        age = get_selected_mappings(filters, "age", "Y015_999"),
+        source = source
       )
     ),
     list(
       indicator_id = scalar("anc_prevalence_age_matched"),
-      x_axis_id = scalar("age"),
+      x_axis_id = scalar("sex"),
       disaggregate_by_id = scalar("source"),
       selected_filter_options = list(
         area = area_default,
-        quarter = get_selected_mappings(filters, "quarter")[2],
-        sex = get_selected_mappings(filters, "sex", "female"),
-        age = get_selected_mappings(filters, "age", "Y015_049"),
-        source = get_selected_mappings(filters, "source")
+        quarter = first_quarter,
+        sex = female,
+        age = fifteen_to_49,
+        source = source
       )
     ),
     list(
       indicator_id = scalar("anc_art_coverage_age_matched"),
-      x_axis_id = scalar("age"),
+      x_axis_id = scalar("sex"),
       disaggregate_by_id = scalar("source"),
       selected_filter_options = list(
-        area =area_default,
-        quarter = get_selected_mappings(filters, "quarter")[2],
-        sex = get_selected_mappings(filters, "sex", "female"),
-        age = get_selected_mappings(filters, "age", "Y015_049"),
-        source = get_selected_mappings(filters, "source")
+        area = area_default,
+        quarter = first_quarter,
+        sex = female,
+        age = fifteen_to_49,
+        source = source
       )
     )
   )

--- a/R/filters.R
+++ b/R/filters.R
@@ -236,7 +236,7 @@ get_calibrate_barchart_defaults <- function(filters) {
 get_comparison_barchart_selections <- function(output, filters) {
   area_default <- get_area_level_filter_option(output)
   five_year_age_groups <- get_selected_mappings(
-    filters, "age",naomi::get_five_year_age_groups())
+    filters, "age", naomi::get_five_year_age_groups())
   all_sexes <- get_selected_mappings(filters, "sex")
   both <- get_selected_mappings(filters, "sex", "both")
   female <- get_selected_mappings(filters, "sex", "female")

--- a/R/filters.R
+++ b/R/filters.R
@@ -233,7 +233,7 @@ get_calibrate_barchart_defaults <- function(filters) {
   )
 }
 
-get_comparison_barchart_defaults <- function(output, filters) {
+get_comparison_barchart_selections <- function(output, filters) {
   area_default <- get_area_level_filter_option(output)
   list(
     list(

--- a/inst/schema/ComparisonBarchartMetadata.schema.json
+++ b/inst/schema/ComparisonBarchartMetadata.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties" : {
+    "indicators" : {
+      "type": "array",
+      "items": { "$ref": "BarchartIndicator.schema.json" }
+    },
+    "filters" : {
+      "type": "array",
+      "items": { "$ref": "Filter.schema.json" }
+    },
+    "defaults": {
+      "type": "array",
+      "items": { "$ref": "BarchartDefaults.schema.json" }
+    }
+  },
+  "additionalProperties": false,
+  "required": [ "indicators", "filters", "defaults" ]
+}

--- a/inst/schema/ComparisonBarchartMetadata.schema.json
+++ b/inst/schema/ComparisonBarchartMetadata.schema.json
@@ -10,11 +10,12 @@
       "type": "array",
       "items": { "$ref": "Filter.schema.json" }
     },
-    "defaults": {
+    "defaults": { "$ref": "BarchartDefaults.schema.json" },
+    "selections": {
       "type": "array",
       "items": { "$ref": "BarchartDefaults.schema.json" }
     }
   },
   "additionalProperties": false,
-  "required": [ "indicators", "filters", "defaults" ]
+  "required": [ "indicators", "filters", "defaults", "selections" ]
 }

--- a/inst/schema/ComparisonPlotResponse.schema.json
+++ b/inst/schema/ComparisonPlotResponse.schema.json
@@ -6,7 +6,7 @@
     "plottingMetadata": {
       "type": "object",
       "properties": {
-        "barchart": { "$ref": "BarchartMetadata.schema.json" }
+        "barchart": { "$ref": "ComparisonBarchartMetadata.schema.json" }
       },
       "additionalProperties": false,
       "required": [ "barchart" ]

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -1078,9 +1078,12 @@ test_that("can get comparison plot data", {
   expect_equal(filters[[4]], scalar("age_group"))
   expect_equal(filters[[5]], scalar("source"))
 
-  expect_setequal(names(response_data$plottingMetadata$barchart$defaults),
-                  c("indicator_id", "x_axis_id", "disaggregate_by_id",
-                    "selected_filter_options"))
+  expect_true(length(response_data$plottingMetadata$barchart$defaults) >= 5)
+  for (default in response_data$plottingMetadata$barchart$defaults) {
+    expect_setequal(names(default),
+                    c("indicator_id", "x_axis_id", "disaggregate_by_id",
+                      "selected_filter_options"))
+  }
 })
 
 test_that("API can return comparison plotting data", {
@@ -1124,7 +1127,10 @@ test_that("API can return comparison plotting data", {
   expect_equal(filters[[4]], "age_group")
   expect_equal(filters[[5]], "source")
 
-  expect_setequal(names(response_data$plottingMetadata$barchart$defaults),
-                  c("indicator_id", "x_axis_id", "disaggregate_by_id",
-                    "selected_filter_options"))
+  expect_true(length(response_data$plottingMetadata$barchart$defaults) >= 5)
+  for (default in response_data$plottingMetadata$barchart$defaults) {
+    expect_setequal(names(default),
+                    c("indicator_id", "x_axis_id", "disaggregate_by_id",
+                      "selected_filter_options"))
+  }
 })

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -1061,7 +1061,7 @@ test_that("can get comparison plot data", {
   expect_true(nrow(response_data$data) > 0)
   expect_equal(names(response_data$plottingMetadata), "barchart")
   expect_setequal(names(response_data$plottingMetadata$barchart),
-                  c("indicators", "filters", "defaults"))
+                  c("indicators", "filters", "defaults", "selections"))
 
   expect_setequal(names(response_data$plottingMetadata$barchart$indicators),
                   c("indicator", "value_column", "error_low_column",
@@ -1078,9 +1078,13 @@ test_that("can get comparison plot data", {
   expect_equal(filters[[4]], scalar("age_group"))
   expect_equal(filters[[5]], scalar("source"))
 
-  expect_true(length(response_data$plottingMetadata$barchart$defaults) >= 5)
-  for (default in response_data$plottingMetadata$barchart$defaults) {
-    expect_setequal(names(default),
+  expect_setequal(names(response_data$plottingMetadata$barchart$defaults),
+                  c("indicator_id", "x_axis_id", "disaggregate_by_id",
+                    "selected_filter_options"))
+
+  expect_true(length(response_data$plottingMetadata$barchart$selections) >= 5)
+  for (selection in response_data$plottingMetadata$barchart$selections) {
+    expect_setequal(names(selection),
                     c("indicator_id", "x_axis_id", "disaggregate_by_id",
                       "selected_filter_options"))
   }
@@ -1108,7 +1112,7 @@ test_that("API can return comparison plotting data", {
   expect_true(nrow(data) > 0)
   expect_equal(names(response_data$plottingMetadata), "barchart")
   expect_setequal(names(response_data$plottingMetadata$barchart),
-                  c("indicators", "filters", "defaults"))
+                  c("indicators", "filters", "defaults", "selections"))
 
   barchart_indicators <- do.call(
     rbind, response_data$plottingMetadata$barchart$indicators)
@@ -1127,9 +1131,13 @@ test_that("API can return comparison plotting data", {
   expect_equal(filters[[4]], "age_group")
   expect_equal(filters[[5]], "source")
 
-  expect_true(length(response_data$plottingMetadata$barchart$defaults) >= 5)
-  for (default in response_data$plottingMetadata$barchart$defaults) {
-    expect_setequal(names(default),
+  expect_setequal(names(response_data$plottingMetadata$barchart$defaults),
+                  c("indicator_id", "x_axis_id", "disaggregate_by_id",
+                    "selected_filter_options"))
+
+  expect_true(length(response_data$plottingMetadata$barchart$selections) >= 5)
+  for (selection in response_data$plottingMetadata$barchart$selections) {
+    expect_setequal(names(selection),
                     c("indicator_id", "x_axis_id", "disaggregate_by_id",
                       "selected_filter_options"))
   }

--- a/tests/testthat/test-comparison.R
+++ b/tests/testthat/test-comparison.R
@@ -32,9 +32,12 @@ test_that("can get data for calibration plot", {
   expect_equal(filters[[4]], scalar("age_group"))
   expect_equal(filters[[5]], scalar("source"))
 
-  expect_setequal(names(res$plottingMetadata$barchart$defaults),
-                  c("indicator_id", "x_axis_id", "disaggregate_by_id",
-                    "selected_filter_options"))
+  expect_true(length(res$plottingMetadata$barchart$defaults) >= 5)
+  for (default in res$plottingMetadata$barchart$defaults) {
+    expect_setequal(names(default),
+                    c("indicator_id", "x_axis_id", "disaggregate_by_id",
+                      "selected_filter_options"))
+  }
 
   expect_false(any(is.na(res$data$mean)))
 })

--- a/tests/testthat/test-comparison.R
+++ b/tests/testthat/test-comparison.R
@@ -14,7 +14,7 @@ test_that("can get data for calibration plot", {
   expect_true(nrow(res$data) > 0)
   expect_equal(names(res$plottingMetadata), "barchart")
   expect_setequal(names(res$plottingMetadata$barchart),
-                  c("indicators", "filters", "defaults"))
+                  c("indicators", "filters", "defaults", "selections"))
 
   expect_setequal(names(res$plottingMetadata$barchart$indicators),
                   c("indicator", "value_column", "error_low_column",
@@ -32,9 +32,13 @@ test_that("can get data for calibration plot", {
   expect_equal(filters[[4]], scalar("age_group"))
   expect_equal(filters[[5]], scalar("source"))
 
-  expect_true(length(res$plottingMetadata$barchart$defaults) >= 5)
-  for (default in res$plottingMetadata$barchart$defaults) {
-    expect_setequal(names(default),
+  expect_setequal(names(res$plottingMetadata$barchart$defaults),
+                  c("indicator_id", "x_axis_id", "disaggregate_by_id",
+                    "selected_filter_options"))
+
+  expect_true(length(res$plottingMetadata$barchart$selections) >= 5)
+  for (selection in res$plottingMetadata$barchart$selections) {
+    expect_setequal(names(selection),
                     c("indicator_id", "x_axis_id", "disaggregate_by_id",
                       "selected_filter_options"))
   }


### PR DESCRIPTION
This will add placeholder multiple defaults for comparison plot, these will be used to switch the default filter selections shown when the user changes the indicator