### PR TITLE
Remove PJNZ file from survey and programme validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.0.44
+Version: 1.1.0
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.1.0
+
+* Remove PJNZ file from survey and programme data validation
+
 # hintr 1.0.44
 
 * Fail early if comparison report output cannot be generated

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -87,11 +87,9 @@ validate_survey_programme <- function(input, strict = TRUE) {
   tryCatch({
     shape <- file_object(input$shape)
     assert_file_exists(input$file$path)
-    pjnz <- file_object(input$pjnz)
-    assert_file_exists(pjnz$path)
     assert_file_exists(shape$path)
     input_response(
-      validate_func(input$file, shape, pjnz, strict), input$type, input$file)
+      validate_func(input$file, shape, strict), input$type, input$file)
   },
   error = function(e) {
     hintr_error(e$message, "INVALID_FILE")

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -115,7 +115,7 @@ do_validate_population <- function(population) {
 #'
 #' @return An error if invalid.
 #' @keywords internal
-do_validate_programme <- function(programme, shape, pjnz, strict = TRUE) {
+do_validate_programme <- function(programme, shape, strict = TRUE) {
   assert_file_extension(programme, "csv")
   data <- read_csv(programme$path, header = TRUE)
   assert_single_country(data, "programme")
@@ -159,7 +159,7 @@ do_validate_programme <- function(programme, shape, pjnz, strict = TRUE) {
 #'
 #' @return An error if invalid.
 #' @keywords internal
-do_validate_anc <- function(anc, shape, pjnz, strict = TRUE) {
+do_validate_anc <- function(anc, shape, strict = TRUE) {
   assert_file_extension(anc, "csv")
   data <- as.data.frame(naomi::read_anc_testing(anc$path))
   assert_single_country(data, "anc")
@@ -203,7 +203,7 @@ do_validate_anc <- function(anc, shape, pjnz, strict = TRUE) {
 #'
 #' @return An error if invalid.
 #' @keywords internal
-do_validate_survey <- function(survey, shape, pjnz, strict = TRUE) {
+do_validate_survey <- function(survey, shape, strict = TRUE) {
   assert_file_extension(survey, "csv")
   data <- read_csv(survey$path, header = TRUE)
   assert_single_country(data, "survey")

--- a/inst/schema/ValidateSurveyAndProgrammeRequest.schema.json
+++ b/inst/schema/ValidateSurveyAndProgrammeRequest.schema.json
@@ -4,14 +4,12 @@
   "properties": {
     "type" : { "$ref": "InputType.schema.json" },
     "file" : { "$ref": "SessionFile.schema.json" },
-    "shape": { "$ref": "FilePath.schema.json" },
-    "pjnz": { "$ref": "FilePath.schema.json" }
+    "shape": { "$ref": "FilePath.schema.json" }
   },
   "additionalProperties": false,
   "required": [
     "type",
     "file",
-    "shape",
-    "pjnz"
+    "shape"
   ]
 }

--- a/tests/testthat/helper-endpoint.R
+++ b/tests/testthat/helper-endpoint.R
@@ -56,8 +56,7 @@ validate_baseline_all_input <- function(pjnz, shape, population) {
   )
 }
 
-validate_programme_survey_input <- function(file_path, type, shape,
-                                            pjnz) {
+validate_programme_survey_input <- function(file_path, type, shape) {
   sprintf(
     '{"type": "%s",
       "file": {
@@ -66,9 +65,8 @@ validate_programme_survey_input <- function(file_path, type, shape,
         "filename": "original",
         "fromADR": false
       },
-      "shape": "%s",
-      "pjnz": "%s"
-    }', type, file_path, shape, pjnz)
+      "shape": "%s"
+    }', type, file_path, shape)
 }
 
 input_time_series_request <- function(file_path, type, shape_path) {

--- a/tests/testthat/payload/validate_anc_payload.json
+++ b/tests/testthat/payload/validate_anc_payload.json
@@ -6,6 +6,5 @@
     "filename": "original.csv",
     "fromADR": false
   },
-  "shape": "testdata/malawi.geojson",
-  "pjnz": "testdata/Malawi2019.PJNZ"
+  "shape": "testdata/malawi.geojson"
 }

--- a/tests/testthat/payload/validate_programme_payload.json
+++ b/tests/testthat/payload/validate_programme_payload.json
@@ -6,6 +6,5 @@
     "hash": "12345",
     "fromADR": false
   },
-  "shape": "testdata/malawi.geojson",
-  "pjnz": "testdata/Malawi2019.PJNZ"
+  "shape": "testdata/malawi.geojson"
 }

--- a/tests/testthat/payload/validate_survey_payload.json
+++ b/tests/testthat/payload/validate_survey_payload.json
@@ -6,6 +6,5 @@
     "hash": "12345",
     "fromADR": false
   },
-  "shape": "testdata/malawi.geojson",
-  "pjnz": "testdata/Malawi2019.PJNZ"
+  "shape": "testdata/malawi.geojson"
 }

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -4,8 +4,7 @@ test_that("endpoint_validate_survey_programme supports programme file", {
   input <- validate_programme_survey_input(
     file.path("testdata", "programme.csv"),
     "programme",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   response <- validate_survey_programme(input)
 
   expect_equal(response$filename, scalar("original"))
@@ -21,8 +20,7 @@ test_that("endpoint_validate_survey_programme returns error on invalid programme
   input <- validate_programme_survey_input(
     file.path("testdata", "malformed_programme.csv"),
     "programme",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   error <- expect_error(validate_survey_programme(input))
 
   expect_equal(error$data[[1]]$error, scalar("INVALID_FILE"))
@@ -36,8 +34,7 @@ test_that("endpoint_validate_survey_programme supports ANC file", {
   input <- validate_programme_survey_input(
     file.path("testdata", "anc.csv"),
     "anc",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   response <- validate_survey_programme(input)
 
   expect_equal(response$filename, scalar("original"))
@@ -54,8 +51,7 @@ test_that("endpoint_validate_survey_programme returns error on invalid ANC data"
   input <- validate_programme_survey_input(
     file.path("testdata", "malformed_anc.csv"),
     "anc",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   error <- expect_error(validate_survey_programme(input))
 
   expect_equal(error$data[[1]]$error, scalar("INVALID_FILE"))
@@ -71,8 +67,7 @@ test_that("endpoint_validate_survey_programme supports survey file", {
   input <- validate_programme_survey_input(
     file.path("testdata", "survey.csv"),
     "survey",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   response <- validate_survey_programme(input)
 
   expect_equal(response$filename, scalar("original"))
@@ -88,8 +83,7 @@ test_that("endpoint_validate_survey_programme returns error on invalid survey da
   input <- validate_programme_survey_input(
     file.path("testdata", "malformed_survey.csv"),
     "survey",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   error <- expect_error(validate_survey_programme(input))
 
   expect_equal(error$data[[1]]$error, scalar("INVALID_FILE"))
@@ -103,8 +97,7 @@ test_that("possible filters are returned for data", {
   input <- validate_programme_survey_input(
     file.path("testdata", "programme.csv"),
     "programme",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   response <- validate_survey_programme(input)
 
   expect_equal(names(response$filters), c("age", "calendar_quarter", "indicators"))
@@ -141,8 +134,7 @@ test_that("possible filters are returned for data", {
   input <- validate_programme_survey_input(
     file.path("testdata", "anc.csv"),
     "anc",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   response <- validate_survey_programme(input)
 
   expect_equal(names(response$filters), c("year", "indicators"))
@@ -159,8 +151,7 @@ test_that("possible filters are returned for data", {
   input <- validate_programme_survey_input(
     file.path("testdata", "survey.csv"),
     "survey",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   response <- validate_survey_programme(input)
 
   expect_equal(names(response$filters), c("age", "surveys", "indicators"))
@@ -202,8 +193,7 @@ test_that("filters not returned if indicator missing from input data", {
   input <- validate_programme_survey_input(
     file.path("testdata", "programme_no_vls.csv"),
     "programme",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   response <- validate_survey_programme(input)
 
   expect_equal(names(response$filters),
@@ -333,8 +323,7 @@ test_that("anc data can be validated can be run with relaxed validation", {
   input <- validate_programme_survey_input(
     t,
     "anc",
-    file.path("testdata", "malawi.geojson"),
-    file.path("testdata", "Malawi2019.PJNZ"))
+    file.path("testdata", "malawi.geojson"))
   queue <- test_queue(workers = 0)
   api <- api_build(queue)
 

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -89,8 +89,7 @@ test_that("empty rows are ignored in validation", {
 test_that("do_validate_programme validates programme file", {
   programme <- file_object(file.path("testdata", "programme.csv"))
   shape <- file_object(file.path("testdata", "malawi.geojson"))
-  pjnz <- file_object(file.path("testdata", "Malawi2019.PJNZ"))
-  data <- do_validate_programme(programme, shape, pjnz)
+  data <- do_validate_programme(programme, shape)
   ## Some arbitrary test that the data has actually been returned
   expect_true(nrow(data$data) > 200)
   expect_type(data$data$art_current, "double")
@@ -125,8 +124,7 @@ test_that("do_validate_programme validates programme file", {
 test_that("do_validate_anc validates ANC file and gets data for plotting", {
   anc <- file_object(file.path("testdata", "anc.csv"))
   shape <- file_object(file.path("testdata", "malawi.geojson"))
-  pjnz <- file_object(file.path("testdata", "Malawi2019.PJNZ"))
-  data <- do_validate_anc(anc, shape, pjnz)
+  data <- do_validate_anc(anc, shape)
 
   expect_true(nrow(data$data) > 200)
   expect_type(data$data$area_id, "character")
@@ -153,8 +151,7 @@ test_that("do_validate_anc can include anc_hiv_status column", {
   write.csv(anc, t)
   anc_file <- file_object(t)
   shape <- file_object(file.path("testdata", "malawi.geojson"))
-  pjnz <- file_object(file.path("testdata", "Malawi2019.PJNZ"))
-  data <- do_validate_anc(anc_file, shape, pjnz)
+  data <- do_validate_anc(anc_file, shape)
 
   expect_true(nrow(data$data) > 200)
   expect_type(data$data$area_id, "character")
@@ -179,8 +176,7 @@ test_that("do_validate_anc adds default anc_known_neg column", {
   t <- tempfile(fileext = ".csv")
   write.csv(x, t, row.names = FALSE)
   shape <- file_object(file.path("testdata", "malawi.geojson"))
-  pjnz <- file_object(file.path("testdata", "Malawi2019.PJNZ"))
-  data <- do_validate_anc(file_object(t), shape, pjnz)
+  data <- do_validate_anc(file_object(t), shape)
 
   expect_true(nrow(data$data) > 200)
   expect_type(data$data$area_id, "character")
@@ -191,8 +187,7 @@ test_that("do_validate_anc adds default anc_known_neg column", {
 test_that("do_validate_survey validates survey file", {
   survey <- file_object(file.path("testdata", "survey.csv"))
   shape <- file_object(file.path("testdata", "malawi.geojson"))
-  pjnz <- file_object(file.path("testdata", "Malawi2019.PJNZ"))
-  data <- do_validate_survey(survey, shape, pjnz)
+  data <- do_validate_survey(survey, shape)
   ## Some arbitrary test that the data has actually been returned
   expect_true(nrow(data$data) > 20000)
   expect_type(data$data$estimate, "double")
@@ -231,24 +226,21 @@ test_that("do_validate_survey validates survey file", {
 test_that("do_validate_programme returns useful error from shapefile comparison", {
   programme <- file_object(file.path("testdata", "programme.csv"))
   shape <- file_object(file.path("testdata", "malawi_missing_regions.geojson"))
-  pjnz <- file_object(file.path("testdata", "Malawi2019.PJNZ"))
-  expect_error(do_validate_programme(programme, shape, pjnz),
+  expect_error(do_validate_programme(programme, shape),
     "Regions aren't consistent programme file contains 32 regions missing from shape file including:\n\\w+")
 })
 
 test_that("do_validate_anc returns useful error from shapefile comparison", {
   anc <- file_object(file.path("testdata", "anc.csv"))
   shape <- file_object(file.path("testdata", "malawi_missing_regions.geojson"))
-  pjnz <- file_object(file.path("testdata", "Malawi2019.PJNZ"))
-  expect_error(do_validate_anc(anc, shape, pjnz),
+  expect_error(do_validate_anc(anc, shape),
     "Regions aren't consistent ANC file contains 32 regions missing from shape file including:\n\\w+")
 })
 
 test_that("do_validate_survey returns useful error from shapefile comparison", {
   survey <- file_object(file.path("testdata", "survey.csv"))
   shape <- file_object(file.path("testdata", "malawi_missing_regions.geojson"))
-  pjnz <- file_object(file.path("testdata", "Malawi2019.PJNZ"))
-  expect_error(do_validate_survey(survey, shape, pjnz),
+  expect_error(do_validate_survey(survey, shape),
     "Regions aren't consistent survey file contains 68 regions missing from shape file including:\n\\w+")
 })
 


### PR DESCRIPTION
This PR will
* Remove PJNZ file from `/validate/survey-and-programme` endpoint. This file hasn't been used to validate survey, ANC or ART data for a while so we can remove it.

After this I expect that we can remove the file requirement from data exploration on PJNZ file.

**Note**: Will need to have a corresponding hint PR before this can be merged