### PR TITLE
mrc-3675: Add ability to rehydrate endpoint to restore from data zip

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.1.2
+Version: 1.1.3
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",
@@ -23,7 +23,7 @@ Imports:
     ids,
     jsonlite (>= 1.2.2),
     lgr,
-    naomi (>= 2.8.5),
+    naomi (>= 2.8.9),
     naomi.options (>= 1.0.0),
     porcelain (>= 0.1.8),
     R6,

--- a/R/api.R
+++ b/R/api.R
@@ -60,9 +60,9 @@ api_postserialize <- function(data, req, res, value) {
 #' @export
 api <- function(queue_id = NULL, workers = 2,
                 results_dir = tempdir(), prerun_dir = NULL,
-                log_level = "info") {
+                uploads_dir = NULL, log_level = "info") {
   queue <- Queue$new(queue_id, workers, results_dir = results_dir,
-                     prerun_dir = prerun_dir)
+                     prerun_dir = prerun_dir, uploads_dir = uploads_dir)
   queue$queue$worker_delete_exited()
   logger <- porcelain::porcelain_logger(log_level)
   api_build(queue, logger = logger)

--- a/R/main.R
+++ b/R/main.R
@@ -6,7 +6,8 @@ Options:
 --workers=N         Number of workers to spawn [default: 2]
 --port=PORT         Port to use [default: 8888]
 --results-dir=PATH  Directory to store model results in
---prerun-dir=PATH   Directory to find prerun results in"
+--prerun-dir=PATH   Directory to find prerun results in
+--uploads-dir=PATH  Directory to find uploaded files in"
 
   validate_path <- function(path) {
     if (is.null(path)) {
@@ -20,13 +21,15 @@ Options:
        queue_id = dat$queue_id,
        workers = as.integer(dat$workers),
        results_dir = validate_path(dat[["results_dir"]]),
-       prerun_dir = validate_path(dat[["prerun_dir"]]))
+       prerun_dir = validate_path(dat[["prerun_dir"]]),
+       uploads_dir = validate_path(dat[["uploads_dir"]]))
 }
 
 main_api <- function(args = commandArgs(TRUE)) {
   # nocov start
   dat <- main_api_args(args)
-  api <- api(dat$queue_id, dat$workers, dat$results_dir, dat$prerun_dir)
+  api <- api(dat$queue_id, dat$workers, dat$results_dir,
+             dat$prerun_dir, dat$uploads_dir)
   api$run(host = "0.0.0.0", port = dat$port)
   # nocov end
 }

--- a/R/queue.R
+++ b/R/queue.R
@@ -7,11 +7,13 @@ Queue <- R6::R6Class(
     queue = NULL,
     results_dir = NULL,
     prerun_dir = NULL,
+    uploads_dir = NULL,
 
     initialize = function(queue_id = NULL, workers = 2,
                           cleanup_on_exit = workers > 0,
                           results_dir = tempdir(),
                           prerun_dir = NULL,
+                          uploads_dir = NULL,
                           timeout = Inf) {
       self$cleanup_on_exit <- cleanup_on_exit
       self$results_dir <- results_dir
@@ -33,6 +35,7 @@ Queue <- R6::R6Class(
       set_cache(queue_id)
 
       self$prerun_dir <- prerun_dir
+      self$uploads_dir <- uploads_dir
     },
 
     start = function(workers, timeout) {
@@ -82,8 +85,10 @@ Queue <- R6::R6Class(
     },
 
     submit_rehydrate_files = function(hintr_output, fit_id, calibrate_id) {
+      uploads_dir <- self$uploads_dir
       self$submit(quote(hintr:::rehydrate_from_files(hintr_output, fit_id,
-                                                     calibrate_id)),
+                                                     calibrate_id,
+                                                     uploads_dir)),
                   queue = QUEUE_CALIBRATE)
     },
 

--- a/R/queue.R
+++ b/R/queue.R
@@ -77,7 +77,8 @@ Queue <- R6::R6Class(
     },
 
     submit_rehydrate = function(output_zip) {
-      self$submit(quote(hintr:::rehydrate(output_zip)), queue = QUEUE_CALIBRATE)
+      self$submit(quote(hintr:::rehydrate(output_zip, self$results_dir)),
+                  queue = QUEUE_CALIBRATE)
     },
 
     status = function(id) {

--- a/R/queue.R
+++ b/R/queue.R
@@ -76,8 +76,14 @@ Queue <- R6::R6Class(
         queue = QUEUE_CALIBRATE)
     },
 
-    submit_rehydrate = function(output_zip) {
-      self$submit(quote(hintr:::rehydrate(output_zip, self$results_dir)),
+    submit_rehydrate_state = function(output_zip) {
+      self$submit(quote(hintr:::rehydrate_from_state(output_zip)),
+                  queue = QUEUE_CALIBRATE)
+    },
+
+    submit_rehydrate_files = function(hintr_output, fit_id, calibrate_id) {
+      self$submit(quote(hintr:::rehydrate_from_files(hintr_output, fit_id,
+                                                     calibrate_id)),
                   queue = QUEUE_CALIBRATE)
     },
 

--- a/R/rehydrate.R
+++ b/R/rehydrate.R
@@ -87,13 +87,19 @@ rehydrate_inputs <- function(output, uploads_dir) {
               list(filename = filename,
                    hash = row$md5sum)))
     }
+    ## web app expects path like as uploads/file_name.csv
+    ## if leading / is included then it takes "uploads" as the filename and
+    ## errors
+    if (substring(path, 1, 1) == "/") {
+      path <- substring(path, 2)
+    }
     list(
       path = scalar(path),
       filename = scalar(filename)
     )
   })
   files <- inputs$role
-  ## Map from names used by Naomi to names used by interface
+  ## Map from names used by Naomi to names used by web interface
   files[files == "art_number"] <- "programme"
   files[files == "anc_testing"] <- "anc"
   names(rehydrated) <- files

--- a/R/rehydrate.R
+++ b/R/rehydrate.R
@@ -1,10 +1,41 @@
-rehydrate <- function(output_zip, results_dir) {
-  files <- zip::zip_list(output_zip$path)
-  if (PROJECT_STATE_PATH %in% files$filename) {
-    state <- rehydrate_from_state(output_zip)
-  } else {
-    state <- rehydrate_from_files(output_zip, results_dir)
+rehydrate_submit <- function(queue) {
+  function(input) {
+    tryCatch({
+      input <- jsonlite::fromJSON(input)
+      assert_file_exists(input$file$path)
+      files <- zip::zip_list(input$file$path)
+      if (PROJECT_STATE_PATH %in% files$filename) {
+        id <- queue$submit_rehydrate_state(input$file)
+      } else if ("hintr_output.rds" %in% files$filename) {
+        ## This is not ideal that we do this sync but if we want to save
+        ## outputs into output dir on disk then we need to create the result
+        ## The worker cannot do this as it cannot connect to queue
+        ## to run a new fit
+        t <- tempfile()
+        dir.create(t)
+        hintr_output <- naomi::read_rehydrate_zip(input$file$path, t)
+        hintr_output <- rehydrate_save_output(queue$results_dir, hintr_output)
+        fit_id <- rehydrate_create_result(queue, hintr_output)
+        calibrate_id <- rehydrate_create_result(queue, hintr_output)
+        queue$queue$task_wait(fit_id, timeout = 3)
+        queue$queue$task_wait(calibrate_id, timeout = 3)
+        id <- queue$submit_rehydrate_files(hintr_output, fit_id, calibrate_id)
+      } else {
+        stop(t_("FAILED_ZIP_REHYDRATE_SUBMIT"))
+      }
+      list(id = scalar(id))
+    }, error = function(e) {
+      hintr_error(e$message, "REHYDRATE_SUBMIT_FAILED")
+    })
   }
+}
+
+rehydrate_from_state <- function(output_zip) {
+  con <- unz(output_zip$path, PROJECT_STATE_PATH)
+  on.exit(close(con))
+  state <- paste0(readLines(con), collapse = "\n")
+  state <- json_verbatim(state)
+  files <- zip::zip_list(output_zip$path)
   notes <- NULL
   if (NOTES_PATH %in% files$filename) {
     notes_con <- unz(output_zip$path, NOTES_PATH)
@@ -17,36 +48,90 @@ rehydrate <- function(output_zip, results_dir) {
   )
 }
 
-rehydrate_from_state <- function(output_zip) {
-  con <- unz(output_zip$path, PROJECT_STATE_PATH)
-  on.exit(close(con))
-  state <- paste0(readLines(con), collapse = "\n")
-  json_verbatim(state)
-}
+rehydrate_from_files <- function(hintr_output, fit_id, calibrate_id) {
+  output <- naomi::read_hintr_output(hintr_output$model_output_path)
 
-rehydrate_from_files <- function(output_zip, results_dir) {
-  inputs <- rehydrate_input()
-  fit <- rehydrate_fit()
-  calibrate <- rehydrate_calibrate()
-  version <- rehydrate_version()
-  list(
+  inputs <- rehydrate_inputs(output)
+  fit <- rehydrate_fit(fit_id, output)
+  calibrate <- rehydrate_calibrate(calibrate_id, output)
+  version <- rehydrate_version(hintr_output$version)
+  state <- list(
     datasets = inputs,
     model_fit = fit,
     calibrate = calibrate,
     version = version
   )
+  ## Note no notes in output zip, could add this as an enhancement
+  notes <- ""
+  list(
+    notes = scalar(notes),
+    state = state
+  )
 }
 
-rehydrate_submit <- function(queue) {
-  function(input) {
-    tryCatch({
-      input <- jsonlite::fromJSON(input)
-      assert_file_exists(input$file$path)
-      list(id = scalar(queue$submit_rehydrate(input$file)))
-    }, error = function(e) {
-      hintr_error(e$message, "REHYDRATE_SUBMIT_FAILED")
-    })
-  }
+rehydrate_inputs <- function(output) {
+  ## Build the inputs JSON to look like the format used by the web app
+  ## This is a bit hacky but we are limited atm because the output zip
+  ## does not include input files yet
+  ## This will error in the web app if the input files are not found
+  ## but is a bit delicate, next step will be to either include inputs
+  ## in the zip and save them uploads dir or reconstruct them from outputs
+  inputs <-  read_csv(output$info$inputs.csv)
+  rehydrated <- lapply(seq_len(nrow(inputs)), function(row_no) {
+    row <- inputs[row_no, ]
+    list(
+      path = scalar(paste0(file.path("uploads", toupper(row$md5sum)),
+                           ".", tools::file_ext(row$filename))),
+      filename = scalar(row$filename)
+    )
+  })
+  files <- inputs$role
+  ## Map from names used by Naomi to names used by interface
+  files[files == "art_number"] <- "programme"
+  files[files == "anc_testing"] <- "anc"
+  names(rehydrated) <- files
+  rehydrated
+}
+
+rehydrate_fit <- function(fit_id, output) {
+  fit_options <- recursive_scalar(
+    yaml::read_yaml(text = output$info$options.yml))
+  list(
+    options = fit_options,
+    id = scalar(fit_id)
+  )
+}
+
+rehydrate_calibrate <- function(calibrate_id, output) {
+  calibration_options <- recursive_scalar(
+    yaml::read_yaml(text = output$info$calibration_options.yml))
+  list(
+    options = calibration_options,
+    id = scalar(calibrate_id)
+  )
+}
+
+rehydrate_save_output <- function(results_dir, hintr_output) {
+  path_results <- normalizePath(results_dir, mustWork = TRUE)
+  model_output_path <- tempfile("model_output", tmpdir = path_results,
+                                fileext = ".qs")
+  plot_data_path <- tempfile("plot_data", tmpdir = path_results,
+                             fileext = ".qs")
+  file.copy(hintr_output$model_output_path, model_output_path)
+  file.copy(hintr_output$plot_data_path, plot_data_path)
+  hintr_output$model_output_path <- model_output_path
+  hintr_output$plot_data_path <- plot_data_path
+  hintr_output
+}
+
+rehydrate_create_result <- function(queue, hintr_output) {
+  queue$submit(quote(identity(hintr_output)))
+}
+
+rehydrate_version <- function(naomi_version) {
+  version <- cfg$version_info
+  version$naomi <- scalar(as.character(naomi_version))
+  version
 }
 
 rehydrate_result <- function(queue) {

--- a/docker/build
+++ b/docker/build
@@ -29,7 +29,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone --single-branch --branch=rehydrate https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -86,5 +86,6 @@
     "QUARTER_4": "Quarter 4",
     "VALIDATION_MULTIPLE_LEVELS_DETAIL": "year {{year}} has area levels {{levels}}",
     "VALIDATION_MULTIPLE_LEVELS": "Data can only be for regions at a single area level per year. In uploaded data {{detail}}.",
-    "FAILED_ZIP_REHYDRATE_SUBMIT": "Cannot load from this zip file, archive missing required information. Please regenerate output zip and try again."
+    "FAILED_ZIP_REHYDRATE_SUBMIT": "Cannot load from this zip file, archive missing required information. Please regenerate output zip and try again.",
+    "REHYDRATE_INPUT_MISSING": "Cannot load from this zip file, input file '{{filename}}' with hash '{{hash}}' is missing."
 }

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -249,7 +249,7 @@ setup_project_state_json <- function(version = NULL) {
   path
 }
 
-setup_reydrate_payload <- function(
+setup_rehydrate_payload <- function(
     path = system.file("output", "malawi_spectrum_download.zip",
                        package = "hintr")) {
   c('{"file":{',

--- a/tests/testthat/helper-queue.R
+++ b/tests/testthat/helper-queue.R
@@ -50,8 +50,10 @@ create_blocking_worker <- function(queue_id, worker_name = NULL) {
 }
 
 test_queue_result <- function(model = mock_model, calibrate = mock_calibrate,
-                              clone_output = TRUE, workers = 1) {
-  queue <- Queue$new(workers = workers, timeout = 300)
+                              clone_output = TRUE, workers = 1,
+                              uploads_dir = NULL) {
+  queue <- Queue$new(workers = workers, timeout = 300,
+                     uploads_dir = uploads_dir)
   withr::defer_parent({
     message("cleaning up workers")
     queue$cleanup()
@@ -85,6 +87,25 @@ test_queue_result <- function(model = mock_model, calibrate = mock_calibrate,
     queue = queue,
     model_run_id = model_run_id,
     calibrate_id = calibrate_id
+  )
+}
+
+build_test_rehydrate <- function(calibrate_output = mock_calibrate) {
+  rehydrate_zip <- naomi::save_rehydrate_zip(calibrate_output,
+                                             hash_filenames = FALSE)
+
+  ## Copy input files into place
+  t <- tempfile()
+  dir.create(t)
+  data <- c("testdata/Malawi2019.PJNZ", "testdata/population.csv",
+            "testdata/malawi.geojson", "testdata/programme.csv",
+            "testdata/anc.csv", "testdata/survey.csv")
+  # dest_names <- paste0(toupper(tools::md5sum(data)), ".", tools::file_ext(data))
+  file.copy(data, t)
+
+  list(
+    uploads_dir = t,
+    rehydrate_zip = rehydrate_zip
   )
 }
 

--- a/tests/testthat/helper-queue.R
+++ b/tests/testthat/helper-queue.R
@@ -50,8 +50,8 @@ create_blocking_worker <- function(queue_id, worker_name = NULL) {
 }
 
 test_queue_result <- function(model = mock_model, calibrate = mock_calibrate,
-                              clone_output = TRUE) {
-  queue <- Queue$new(workers = 1, timeout = 300)
+                              clone_output = TRUE, workers = 1) {
+  queue <- Queue$new(workers = workers, timeout = 300)
   withr::defer_parent({
     message("cleaning up workers")
     queue$cleanup()

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -831,7 +831,7 @@ test_that("input time series can return plot data for anc", {
 })
 
 test_that("rehydrate", {
-  payload <- setup_reydrate_payload()
+  payload <- setup_rehydrate_payload()
 
   r <- server$request("POST",
                       "/rehydrate/submit",

--- a/tests/testthat/test-endpoints-rehydrate.R
+++ b/tests/testthat/test-endpoints-rehydrate.R
@@ -154,7 +154,8 @@ test_that("rehydrate from files works", {
     c("pjnz", "population", "shape", "survey", "programme", "anc"))
   for (data in state$datasets) {
     expect_setequal(names(data), c("path", "filename"))
-    expect_match(data$path, paste0(rehydrate$uploads_dir, "/\\w+"))
+    expect_match(data$path,
+                 paste0(substring(rehydrate$uploads_dir, 2), "/\\w+"))
   }
 
   ## Model fit
@@ -223,7 +224,8 @@ test_that("rehydrate endpoint from data returns json", {
     c("pjnz", "population", "shape", "survey", "programme", "anc"))
   for (data in state$datasets) {
     expect_setequal(names(data), c("path", "filename"))
-    expect_match(data$path, paste0(rehydrate$uploads_dir, "/\\w+"))
+    expect_match(data$path,
+                 paste0(substring(rehydrate$uploads_dir, 2), "/\\w+"))
   }
 
   ## Model fit
@@ -294,7 +296,8 @@ test_that("api can rehydrate", {
     c("pjnz", "population", "shape", "survey", "programme", "anc"))
   for (data in state$datasets) {
     expect_setequal(names(data), c("path", "filename"))
-    expect_match(data$path, paste0(rehydrate$uploads_dir, "/\\w+"))
+    expect_match(data$path,
+                 paste0(substring(rehydrate$uploads_dir, 2), "/\\w+"))
   }
 
   ## Model fit

--- a/tests/testthat/test-endpoints-rehydrate.R
+++ b/tests/testthat/test-endpoints-rehydrate.R
@@ -1,7 +1,7 @@
 test_that("rehydrate returns json", {
-  payload <- setup_reydrate_payload()
+  payload <- setup_rehydrate_payload()
   input <- jsonlite::fromJSON(payload)
-  out <- rehydrate(input$file)
+  out <- rehydrate_from_state(input$file)
 
   state <- jsonlite::fromJSON(out$state)
   expect_setequal(names(state),
@@ -18,7 +18,7 @@ test_that("rehydrate endpoint returns json", {
   q <- test_queue_result()
 
   ## Submit rehydrate request
-  payload <- setup_reydrate_payload()
+  payload <- setup_rehydrate_payload()
   submit <- endpoint_rehydrate_submit(q$queue)
   submit_response <- submit$run(payload)
 
@@ -51,14 +51,14 @@ test_that("rehydrate endpoint returns json", {
   expect_match(response$data$notes, "These are my project notes")
 })
 
-test_that("api can call spectrum download", {
+test_that("api can rehydrate", {
   test_redis_available()
   test_mock_model_available()
   q <- test_queue_result()
   api <- api_build(q$queue)
 
   ## Submit rehydrate request
-  payload <- setup_reydrate_payload()
+  payload <- setup_rehydrate_payload()
   submit <- api$request("POST", "/rehydrate/submit", body = payload)
   expect_equal(submit$status, 200)
   submit_body <- jsonlite::fromJSON(submit$body)
@@ -98,43 +98,21 @@ test_that("rehydrate returns useful error if cannot rehydrate from zip", {
   q <- test_queue_result()
 
   ## Submit rehydrate request which will error
-  payload <- setup_reydrate_payload("testdata/Malawi2019.PJNZ")
+  payload <- setup_rehydrate_payload("testdata/Malawi2019.PJNZ")
   submit <- endpoint_rehydrate_submit(q$queue)
   submit_response <- submit$run(payload)
-  expect_equal(submit_response$status_code, 200)
-
-  ## Get result
-  out <- q$queue$queue$task_wait(submit_response$data$id)
-  result <- endpoint_rehydrate_result(q$queue)
-  response <- result$run(submit_response$data$id)
-  expect_equal(response$status_code, 400)
-  expect_equal(response$value$errors[[1]]$error,
-               scalar("PROJECT_REHYDRATE_FAILED"))
-  expect_equal(response$value$errors[[1]]$detail,
+  expect_equal(submit_response$status_code, 400)
+  expect_equal(submit_response$value$errors[[1]]$error,
+               scalar("REHYDRATE_SUBMIT_FAILED"))
+  expect_equal(submit_response$value$errors[[1]]$detail,
                scalar(paste0("Cannot load from this zip file, archive missing",
                              " required information. Please regenerate output",
                              " zip and try again.")))
 })
 
-test_that("rehydrate returns useful error when submission fails", {
-  test_mock_model_available()
-  q <- test_queue_result()
-
-  payload <- setup_reydrate_payload("missing/file.zip")
-  submit <- endpoint_rehydrate_submit(q$queue)
-  response <- submit$run(payload)
-
-  expect_equal(response$status_code, 400)
-  expect_equal(response$value$errors[[1]]$error,
-               scalar("REHYDRATE_SUBMIT_FAILED"))
-  expect_equal(response$value$errors[[1]]$detail,
-               scalar(paste0("File at path missing/file.zip does not exist. ",
-                             "Create it, or fix the path.")))
-})
-
 test_that("trying to rehydrate with no notes does not error", {
   ## Setup payload and remove notes.txt from zip
-  payload <- setup_reydrate_payload()
+  payload <- setup_rehydrate_payload()
   input <- jsonlite::fromJSON(payload)
   t <- tempfile()
   dir.create(t, FALSE, TRUE)
@@ -144,7 +122,7 @@ test_that("trying to rehydrate with no notes does not error", {
   zip::zip(zip_without_notes, list.files(t), root = t)
   input$file$path <- zip_without_notes
 
-  out <- rehydrate(input$file)
+  out <- rehydrate_from_state(input$file)
 
   state <- jsonlite::fromJSON(out$state)
   expect_setequal(names(state),
@@ -154,4 +132,185 @@ test_that("trying to rehydrate with no notes does not error", {
     c("pjnz", "population", "shape", "survey", "programme", "anc"))
 
   expect_null(out$notes)
+})
+
+test_that("rehydrate from files works", {
+  test_mock_model_available()
+  q <- test_queue_result()
+
+  hintr_output <- q$queue$result(q$calibrate_id)
+  output <- rehydrate_from_files(hintr_output,
+                                 q$model_run_id,
+                                 q$calibrate_id)
+
+  expect_equal(output$notes, scalar(""))
+  state <- output$state
+
+  ## Input data
+  expect_setequal(
+    names(state$datasets),
+    c("pjnz", "population", "shape", "survey", "programme", "anc"))
+  for (data in state$datasets) {
+    expect_setequal(names(data), c("path", "filename"))
+    expect_match(data$path, "uploads/[A-Z0-9]+.[A-Za-z]+")
+  }
+
+  ## Model fit
+  expect_equal(state$model_fit$options$area_scope, scalar("MWI"))
+  expect_equal(state$model_fit$options$survey_prevalence,
+               list(scalar("DEMO2016PHIA"), scalar("DEMO2015DHS")))
+  fit <- q$queue$result(state$model_fit$id)
+  expect_s3_class(fit, "hintr_output")
+  expect_true(file.exists(fit$model_output_path))
+
+  ## Calibration
+  expect_equal(state$calibrate$options$spectrum_plhiv_calibration_level,
+               scalar("none"))
+  calibrate <- q$queue$result(state$calibrate$id)
+  expect_s3_class(calibrate, "hintr_output")
+  expect_true(file.exists(calibrate$plot_data_path))
+  expect_true(file.exists(calibrate$model_output_path))
+
+  ## Version
+  expect_setequal(names(state$version),
+                  c("hintr", "naomi", "rrq", "traduire"))
+})
+
+test_that("rehydrate endpoint from data returns json", {
+  test_mock_model_available()
+  q <- test_queue_result(workers = 1)
+
+  ## Submit rehydrate request
+  payload <- setup_rehydrate_payload(
+    file.path("testdata", "malawi_rehydrate.zip"))
+  submit <- endpoint_rehydrate_submit(q$queue)
+  submit_response <- submit$run(payload)
+
+  expect_equal(submit_response$status_code, 200)
+  expect_true(!is.null(submit_response$data$id))
+
+  ## Status
+  out <- q$queue$queue$task_wait(submit_response$data$id)
+  status <- endpoint_rehydrate_status(q$queue)
+  status_response <- status$run(submit_response$data$id)
+
+  expect_equal(status_response$status_code, 200)
+  expect_equal(status_response$data$id, submit_response$data$id)
+  expect_true(status_response$data$done)
+  expect_equal(status_response$data$status, scalar("COMPLETE"))
+  expect_true(status_response$data$success)
+  expect_equal(status_response$data$queue, scalar(0))
+  expect_length(status_response$data$progress, 0)
+
+  ## Get result
+  result <- endpoint_rehydrate_result(q$queue)
+  response <- result$run(status_response$data$id)
+
+  expect_equal(response$data$notes, scalar(""))
+
+  state <- response$data$state
+
+  expect_equal(response$status_code, 200)
+  expect_setequal(names(state),
+                  c("datasets", "model_fit", "calibrate", "version"))
+
+  ## Input data
+  expect_setequal(
+    names(state$datasets),
+    c("pjnz", "population", "shape", "survey", "programme", "anc"))
+  for (data in state$datasets) {
+    expect_setequal(names(data), c("path", "filename"))
+    expect_match(data$path, "uploads/[A-Z0-9]{32}.[a-z]+")
+  }
+
+  ## Model fit
+  expect_equal(state$model_fit$options$area_scope, scalar("MWI"))
+  expect_equal(state$model_fit$options$survey_prevalence,
+               list(scalar("DEMO2016PHIA"), scalar("DEMO2015DHS")))
+  fit <- q$queue$result(state$model_fit$id)
+  expect_s3_class(fit, "hintr_output")
+  expect_true(file.exists(fit$plot_data_path))
+  expect_true(file.exists(fit$model_output_path))
+
+  ## Calibration
+  expect_equal(state$calibrate$options$spectrum_plhiv_calibration_level,
+               scalar("subnational"))
+  calibrate <- q$queue$result(state$calibrate$id)
+  expect_s3_class(calibrate, "hintr_output")
+  expect_true(file.exists(calibrate$plot_data_path))
+  expect_true(file.exists(calibrate$model_output_path))
+
+  ## Version
+  expect_setequal(names(state$version),
+                  c("hintr", "naomi", "rrq", "traduire"))
+})
+
+test_that("api can rehydrate", {
+  test_redis_available()
+  test_mock_model_available()
+  q <- test_queue_result()
+  api <- api_build(q$queue)
+
+  ## Submit rehydrate request
+  payload <- setup_rehydrate_payload(
+    file.path("testdata", "malawi_rehydrate.zip"))
+  submit <- api$request("POST", "/rehydrate/submit", body = payload)
+  expect_equal(submit$status, 200)
+  submit_body <- jsonlite::fromJSON(submit$body)
+  expect_true(!is.null(submit_body$data$id))
+
+  ## Status
+  out <- q$queue$queue$task_wait(submit_body$data$id)
+  status <- api$request("GET",
+                        paste0("/rehydrate/status/", submit_body$data$id))
+
+  expect_equal(status$status, 200)
+  status_body <- jsonlite::fromJSON(status$body)
+  expect_equal(status_body$data$id, submit_body$data$id)
+  expect_true(status_body$data$done)
+  expect_equal(status_body$data$status, "COMPLETE")
+  expect_true(status_body$data$success)
+  expect_equal(status_body$data$queue, 0)
+  expect_length(status_body$data$progress, 0)
+
+  ## Get result
+  response <- api$request("GET",
+                          paste0("/rehydrate/result/", submit_body$data$id))
+  expect_equal(response$status, 200)
+  res <- jsonlite::fromJSON(response$body)
+  expect_equal(res$status, "success")
+  expect_length(res$errors, 0)
+  state <- res$data$state
+  expect_setequal(names(res$data$state),
+                  c("datasets", "model_fit", "calibrate", "version"))
+
+  ## Input data
+  expect_setequal(
+    names(state$datasets),
+    c("pjnz", "population", "shape", "survey", "programme", "anc"))
+  for (data in state$datasets) {
+    expect_setequal(names(data), c("path", "filename"))
+    expect_match(data$path, "uploads/[A-Z0-9]{32}.[a-z]+")
+  }
+
+  ## Model fit
+  expect_equal(state$model_fit$options$area_scope, "MWI")
+  expect_equal(state$model_fit$options$survey_prevalence,
+               c("DEMO2016PHIA", "DEMO2015DHS"))
+  fit <- q$queue$result(state$model_fit$id)
+  expect_s3_class(fit, "hintr_output")
+  expect_true(file.exists(fit$plot_data_path))
+  expect_true(file.exists(fit$model_output_path))
+
+  ## Calibration
+  expect_equal(state$calibrate$options$spectrum_plhiv_calibration_level,
+               "subnational")
+  calibrate <- q$queue$result(state$calibrate$id)
+  expect_s3_class(calibrate, "hintr_output")
+  expect_true(file.exists(calibrate$plot_data_path))
+  expect_true(file.exists(calibrate$model_output_path))
+
+  ## Version
+  expect_setequal(names(state$version),
+                  c("hintr", "naomi", "rrq", "traduire"))
 })

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -9,9 +9,9 @@ test_that("main_api_args", {
   expect_true(file.exists(default$prerun_dir))
   expect_equal(
     main_api_args(c("--workers=0", "--port", "80", "--results-dir=out",
-                    "--prerun-dir=pr", "hintr")),
+                    "--prerun-dir=pr", "--uploads-dir=up", "hintr")),
     list(port = 80, queue_id = "hintr", workers = 0, results_dir = "out",
-         prerun_dir = "pr"))
+         prerun_dir = "pr", uploads_dir = "up"))
 })
 
 test_that("main_worker_args", {


### PR DESCRIPTION
This PR will
* Enable users to upload a calibration output generated from the naomi package (i.e. regenerate from the files without using the project state)

Note there will be some limitations to this feature in the first instance
* If input files don't exist there will be errors
* This uses the calibrate output to reconstruct the model fit output and calibrate output. This could cause an issue if they recalibrate the model fit as this output is really calibration output. Not clear if this will cause a problem.


The way this can be used is, from naomi package

```
data <- list(shape = "~/projects/hintr/tests/testthat/testdata/malawi.geojson",
             pjnz = "~/projects/hintr/tests/testthat/testdata/Malawi2019.PJNZ",
             art_number = "~/projects/hintr/tests/testthat/testdata/programme.csv",
             population = "~/projects/hintr/tests/testthat/testdata/population.csv",
             survey = "~/projects/hintr/tests/testthat/testdata/survey.csv",
             anc_testing = "~/projects/hintr/tests/testthat/testdata/anc.csv")
options <- list(
    area_scope = "MWI",
    area_level = 4,
    calendar_quarter_t1 = "CY2016Q1",
    calendar_quarter_t2 = "CY2018Q3",
    calendar_quarter_t3 = "CY2019Q2",
    survey_prevalence = c("DEMO2016PHIA", "DEMO2015DHS"),
    survey_art_coverage = "DEMO2016PHIA",
    survey_recently_infected = "DEMO2016PHIA",
    include_art_t1 = "true",
    include_art_t2 = "true",
    anc_clients_year2 = 2018,
    anc_clients_year2_num_months = "9",
    anc_prevalence_year1 = 2016,
    anc_prevalence_year2 = 2018,
    anc_art_coverage_year1 = 2016,
    anc_art_coverage_year2 = 2018,
    spectrum_population_calibration = "none",
    spectrum_plhiv_calibration_level = "none",
    spectrum_plhiv_calibration_strat = "sex_age_coarse",
    spectrum_artnum_calibration_level = "none",
    spectrum_artnum_calibration_strat = "sex_age_coarse",
    spectrum_infections_calibration_level = "none",
    spectrum_infections_calibration_strat = "sex_age_coarse",
    spectrum_aware_calibration_level = "none",
    spectrum_aware_calibration_strat = "sex_age_coarse",
    calibrate_method = "logistic",
    artattend_log_gamma_offset = -4,
    artattend = "false",
    output_aware_plhiv = "true",
    rng_seed = 17,
    no_of_samples = 500,
    max_iter = 250)
output <- hintr_run_model(data, options)

calibration_options <- list(
  spectrum_plhiv_calibration_level = "subnational",
  spectrum_plhiv_calibration_strat = "sex_age_group",
  spectrum_artnum_calibration_level = "subnational",
  spectrum_artnum_calibration_strat = "sex_age_coarse",
  spectrum_aware_calibration_level = "national",
  spectrum_aware_calibration_strat = "age_coarse",
  spectrum_infections_calibration_level = "none",
  spectrum_infections_calibration_strat = "age_coarse",
  calibrate_method = "logistic"
)
calibrate_output <- hintr_calibrate(output, calibration_options)

rehydrate <- save_rehydrate_zip(calibrate_output, path = "~/Downloads/malawi_rehydrate.zip")
```

Then take output at path `~/Downloads/malawi_rehydrate.zip` and upload it into the app using "File -> Load model outputs"

Things to look at as iterations of this
* Do we need plot data too or can this be reconstructed from calibration output?
* Can we put the dummy results into place async instead of doing it synchronously?
* Can we not error if inputs are missing? Either recreate inputs from the outputs if possible, or handle not needing inputs in the front end?