### PR TITLE
mrc-3884: API startup can get handle on uploads directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.1.4
+Version: 1.1.5
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/R/api.R
+++ b/R/api.R
@@ -60,9 +60,9 @@ api_postserialize <- function(data, req, res, value) {
 #' @export
 api <- function(queue_id = NULL, workers = 2,
                 results_dir = tempdir(), prerun_dir = NULL,
-                log_level = "info") {
+                uploads_dir = NULL, log_level = "info") {
   queue <- Queue$new(queue_id, workers, results_dir = results_dir,
-                     prerun_dir = prerun_dir)
+                     prerun_dir = prerun_dir, uploads_dir = uploads_dir)
   queue$queue$worker_delete_exited()
   logger <- porcelain::porcelain_logger(log_level)
   api_build(queue, logger = logger)

--- a/R/main.R
+++ b/R/main.R
@@ -6,7 +6,8 @@ Options:
 --workers=N         Number of workers to spawn [default: 2]
 --port=PORT         Port to use [default: 8888]
 --results-dir=PATH  Directory to store model results in
---prerun-dir=PATH   Directory to find prerun results in"
+--prerun-dir=PATH   Directory to find prerun results in
+--uploads-dir=PATH  Directory to find uploaded fiels in"
 
   validate_path <- function(path) {
     if (is.null(path)) {
@@ -20,13 +21,15 @@ Options:
        queue_id = dat$queue_id,
        workers = as.integer(dat$workers),
        results_dir = validate_path(dat[["results_dir"]]),
-       prerun_dir = validate_path(dat[["prerun_dir"]]))
+       prerun_dir = validate_path(dat[["prerun_dir"]]),
+       uploads_dir = validate_path(dat[["uploads_dir"]]))
 }
 
 main_api <- function(args = commandArgs(TRUE)) {
   # nocov start
   dat <- main_api_args(args)
-  api <- api(dat$queue_id, dat$workers, dat$results_dir, dat$prerun_dir)
+  api <- api(dat$queue_id, dat$workers, dat$results_dir, dat$prerun_dir,
+             dat$uploads_dir)
   api$run(host = "0.0.0.0", port = dat$port)
   # nocov end
 }

--- a/R/queue.R
+++ b/R/queue.R
@@ -7,11 +7,13 @@ Queue <- R6::R6Class(
     queue = NULL,
     results_dir = NULL,
     prerun_dir = NULL,
+    uploads_dir = NULL,
 
     initialize = function(queue_id = NULL, workers = 2,
                           cleanup_on_exit = workers > 0,
                           results_dir = tempdir(),
                           prerun_dir = NULL,
+                          uploads_dir = NULL,
                           timeout = Inf) {
       self$cleanup_on_exit <- cleanup_on_exit
       self$results_dir <- results_dir
@@ -33,6 +35,7 @@ Queue <- R6::R6Class(
       set_cache(queue_id)
 
       self$prerun_dir <- prerun_dir
+      self$uploads_dir <- uploads_dir
     },
 
     start = function(workers, timeout) {

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -9,9 +9,9 @@ test_that("main_api_args", {
   expect_true(file.exists(default$prerun_dir))
   expect_equal(
     main_api_args(c("--workers=0", "--port", "80", "--results-dir=out",
-                    "--prerun-dir=pr", "hintr")),
+                    "--prerun-dir=pr", "--uploads-dir=up", "hintr")),
     list(port = 80, queue_id = "hintr", workers = 0, results_dir = "out",
-         prerun_dir = "pr"))
+         prerun_dir = "pr", uploads_dir = "up"))
 })
 
 test_that("main_worker_args", {

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -175,3 +175,7 @@ test_that("calibrate gets run before model running", {
                c("COMPLETE", "ERROR"))
 })
 
+test_that("queue has handle on uploads dir", {
+  queue <- Queue$new(workers = 0, uploads_dir = tempdir())
+  expect_equal(queue$uploads_dir, tempdir())
+})


### PR DESCRIPTION
This goes with https://github.com/mrc-ide/hint-deploy/pull/67 (where hint-deploy will fail until this is built on master)

This will enable us to add endpoints which check input files exist and upload them when they don't