### PR TITLE
Allow resource URL to be an explicit null in SessionFile for backwards compatibility

### DIFF
--- a/inst/schema/SessionFile.schema.json
+++ b/inst/schema/SessionFile.schema.json
@@ -6,7 +6,7 @@
     "hash" : { "type": "string" },
     "filename" : { "type": "string" },
     "fromADR":  { "type": "boolean" },
-    "resource_url": { "type": "string" }
+    "resource_url": { "type": [ "string", "null" ] }
   },
   "additionalProperties": false,
   "required": ["filename", "hash", "path"]

--- a/tests/testthat/payload/model_submit_payload.json
+++ b/tests/testthat/payload/model_submit_payload.json
@@ -4,37 +4,43 @@
       "path": "testdata/Malawi2019.PJNZ",
       "filename": "Malawi2019.PJNZ",
       "hash": "12345",
-      "fromADR": false
+      "fromADR": false,
+      "resource_url": null
     },
     "shape": {
       "path": "testdata/malawi.geojson",
       "filename": "malawi.geojson",
       "hash": "12345",
-      "fromADR": false
+      "fromADR": false,
+      "resource_url": null
     },
     "population": {
       "path": "testdata/population.csv",
       "filename": "population.csv",
       "hash": "12345",
-      "fromADR": false
+      "fromADR": false,
+      "resource_url": null
     },
     "survey": {
       "path": "testdata/survey.csv",
       "filename": "survey.csv",
       "hash": "12345",
-      "fromADR": false
+      "fromADR": false,
+      "resource_url": null
     },
     "programme": {
       "path": "testdata/programme.csv",
       "filename": "programme.csv",
       "hash": "12345",
-      "fromADR": false
+      "fromADR": false,
+      "resource_url": null
     },
     "anc": {
       "path": "testdata/anc.csv",
       "filename": "anc.csv",
       "hash": "12345",
-      "fromADR": false
+      "fromADR": false,
+      "resource_url": null
     }
   },
   "options": {


### PR DESCRIPTION
This PR will
* Allow `resource_url` in SessionFile schema to be null for backwards compatibility

Needed for https://github.com/mrc-ide/hint/pull/808/files