### PR TITLE
Unskip previously flaky test

### DIFF
--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -106,7 +106,6 @@ test_that("validate_baseline supports shape files", {
 })
 
 test_that("endpoint_validate_baseline returns human readable error", {
-  testthat::skip("Flaky test - see mrc-3892")
   input <- validate_baseline_input(file.path("testdata", "uganda.geojson"),
                                    "shape")
   error <- expect_error(validate_baseline(input))

--- a/tests/testthat/test-endpoints-validate-input.R
+++ b/tests/testthat/test-endpoints-validate-input.R
@@ -106,6 +106,7 @@ test_that("validate_baseline supports shape files", {
 })
 
 test_that("endpoint_validate_baseline returns human readable error", {
+  gc()
   input <- validate_baseline_input(file.path("testdata", "uganda.geojson"),
                                    "shape")
   error <- expect_error(validate_baseline(input))


### PR DESCRIPTION
I'm guessing this is failing because of some issue with test ordering, not very clear what that might be though. This seems to be working reliably when running a garbage collect