### PR TITLE
Error early if data.table raises a warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.1.12
+Version: 1.1.13
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # hintr 1.1.13
 
-* Validate that ANC programme data must contain a "year" column
+* Error early if reading data generates a warning, we cannot proceed with only a partial read of the data
 
 # hintr 1.1.10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.1.13
+
+* Validate that ANC programme data must contain a "year" column
+
 # hintr 1.1.10
 
 * Update fallback anc year to 2022

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -24,11 +24,15 @@ read_csv_regions <- function(csv_file) {
 }
 
 read_csv <- function(file, ...) {
-  data <- data.table::fread(file, ...,
-                            blank.lines.skip = TRUE,
-                            data.table = FALSE,
-                            nThread = 1,
-                            na.strings = c("NA", ""))
+  ## Make fread error early if any warning thrown e.g. because of
+  ## partially read data
+  data <- withr::with_options(list(warn = 3),
+    data.table::fread(file, ...,
+                      blank.lines.skip = TRUE,
+                      data.table = FALSE,
+                      nThread = 1,
+                      na.strings = c("NA", ""))
+  )
   data[rowSums(is.na(data)) != ncol(data), ]
 }
 

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -125,7 +125,7 @@ do_validate_programme <- function(programme, shape, strict = TRUE) {
   assert_single_country(data, "programme")
   assert_column_names(
     colnames(data),
-    c("area_id", "calendar_quarter", "sex", "year", "age_group", "art_current"))
+    c("area_id", "calendar_quarter", "sex", "age_group", "art_current"))
   shape_regions <- read_regions(shape, "shape")
   assert_consistent_regions(shape_regions$area_id, unique(data$area_id),
                             "programme")

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -125,7 +125,7 @@ do_validate_programme <- function(programme, shape, strict = TRUE) {
   assert_single_country(data, "programme")
   assert_column_names(
     colnames(data),
-    c("area_id", "calendar_quarter", "sex", "age_group", "art_current"))
+    c("area_id", "calendar_quarter", "sex", "year", "age_group", "art_current"))
   shape_regions <- read_regions(shape, "shape")
   assert_consistent_regions(shape_regions$area_id, unique(data$area_id),
                             "programme")

--- a/tests/testthat/test-endpoints-validate-survey-and-programme.R
+++ b/tests/testthat/test-endpoints-validate-survey-and-programme.R
@@ -24,7 +24,7 @@ test_that("endpoint_validate_survey_programme returns error on invalid programme
   expect_equal(error$data[[1]]$error, scalar("INVALID_FILE"))
   expect_equal(
     error$data[[1]]$detail,
-    scalar("Data missing 2 columns calendar_quarter, year."))
+    scalar("Data missing column calendar_quarter."))
   expect_equal(error$status_code, 400)
 })
 
@@ -356,4 +356,12 @@ test_that("anc data can be validated can be run with relaxed validation", {
   expect_type(body$data$data[, "anc_prevalence"], "double")
   expect_type(body$data$data[, "anc_art_coverage"], "double")
   expect_length(body$data$warnings, 0)
+})
+
+test_that("file read errors early if file only partially read", {
+  t <- tempfile(fileext = ".csv")
+  writeLines("file,header\nrow1,value1\nrow2\none,two", t)
+
+  expect_error(do_validate_programme(file_object(t), NULL),
+               "Stopped early on line 3")
 })


### PR DESCRIPTION
We had an issue from Congo where the input time series was returning unuseful errors like

![Screenshot_20230403_121927](https://user-images.githubusercontent.com/39248272/229494832-43496e46-dbdd-4157-bb67-ec43c6c96ea4.png)

This is because the way naomi reads data an error is thrown if one of the rows has fewer columns than the others. However in hintr data.table::fread just returns a warning in this case. This PR raises fread warnings to errors as if there are issues reading the data that could cause further harder to debug downstream problems.

See issue report https://teams.microsoft.com/l/message/19:80b58baae16d4f42920e07bffcfcd2a6@thread.tacv2/1680513167567?tenantId=2b897507-ee8c-4575-830b-4f8267c3d307&groupId=c8a90f50-631c-433e-9927-8aa39ae571fc&parentMessageId=1680513167567&teamName=Naomi%20Support%20-%20WP&channelName=General&createdTime=1680513167567&allowXTenantAccess=false
