### PR TITLE
Add new endpoints for returning calibration result and metadata separately

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.1.14
+Version: 1.1.15
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# hintr 1.1.15
+
+* Add two new endpoints in preparation for web backend accessing the result data on disk directly
+   * `/calibrate/result/metadata/<id>` to return the metadata and warnings from the `/calibrate/result/<id>` endpoint
+   * `/calibrate/result/data/<id>` for returning only the data from the `/calibrate/result/<id>` endpoint
+
 # hintr 1.1.13
 
 * Error early if reading data generates a warning, we cannot proceed with only a partial read of the data

--- a/R/api.R
+++ b/R/api.R
@@ -16,6 +16,8 @@ api_build <- function(queue, validate = FALSE, logger = NULL) {
   api$handle(endpoint_model_calibrate_submit(queue))
   api$handle(endpoint_model_calibrate_status(queue))
   api$handle(endpoint_model_calibrate_result(queue))
+  api$handle(endpoint_model_calibrate_metadata(queue))
+  api$handle(endpoint_model_calibrate_data(queue))
   api$handle(endpoint_model_calibrate_plot(queue))
   api$handle(endpoint_comparison_plot(queue))
   api$handle(endpoint_plotting_metadata_iso3())
@@ -283,6 +285,24 @@ endpoint_model_calibrate_result <- function(queue) {
   porcelain::porcelain_endpoint$new("GET",
                                     "/calibrate/result/<id>",
                                     calibrate_result(queue),
+                                    returning = response)
+}
+
+endpoint_model_calibrate_metadata <- function(queue) {
+  response <- porcelain::porcelain_returning_json(
+    "CalibrateMetadataResponse.schema", schema_root())
+  porcelain::porcelain_endpoint$new("GET",
+                                    "/calibrate/result/metadata/<id>",
+                                    calibrate_metadata(queue),
+                                    returning = response)
+}
+
+endpoint_model_calibrate_data <- function(queue) {
+  response <- porcelain::porcelain_returning_json(
+    "CalibrateDataResponse.schema", schema_root())
+  porcelain::porcelain_endpoint$new("GET",
+                                    "/calibrate/result/data/<id>",
+                                    calibrate_data(queue),
                                     returning = response)
 }
 

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -219,6 +219,32 @@ calibrate_result <- function(queue) {
   }
 }
 
+calibrate_metadata <- function(queue) {
+  function(id) {
+    verify_result_available(queue, id)
+    result <- queue$result(id)
+    output <- naomi::read_hintr_output(result$plot_data_path)
+    metadata <- build_output_metadata(output)
+    warnings <- list()
+    if (!is.null(result$warnings)) {
+      warnings <- warnings_scalar(result$warnings)
+    }
+    list(
+      plottingMetadata = metadata,
+      warnings = warnings
+    )
+  }
+}
+
+calibrate_data <- function(queue) {
+  function(id) {
+    verify_result_available(queue, id)
+    result <- queue$result(id)
+    output <- naomi::read_hintr_output(result$plot_data_path)
+    list(data = select_data(output))
+  }
+}
+
 calibrate_plot <- function(queue) {
   function(id) {
     verify_result_available(queue, id)

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -83,8 +83,19 @@ select_data <- function(data) {
 
 process_result <- function(model_output) {
   output <- naomi::read_hintr_output(model_output$plot_data_path)
+  metadata <- build_output_metadata(output)
+  warnings <- list()
+  if (!is.null(model_output$warnings)) {
+    warnings <- warnings_scalar(model_output$warnings)
+  }
+  list(data = select_data(output),
+       plottingMetadata = metadata,
+       warnings = warnings)
+}
+
+build_output_metadata <- function(output) {
   output_filters <- get_model_output_filters(output)
-  metadata <- list(
+  list(
     barchart = list(
       indicators = get_barchart_metadata(output),
       filters = output_filters,
@@ -95,13 +106,6 @@ process_result <- function(model_output) {
       filters = output_filters
     )
   )
-  warnings <- list()
-  if (!is.null(model_output$warnings)) {
-    warnings <- warnings_scalar(model_output$warnings)
-  }
-  list(data = select_data(output),
-       plottingMetadata = metadata,
-       warnings = warnings)
 }
 
 use_mock_model <- function() {

--- a/inst/schema/CalibrateDataResponse.schema.json
+++ b/inst/schema/CalibrateDataResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "data": { "$ref": "ModelResultData.schema.json" },
+  },
+  "required": [ "data" ]
+}

--- a/inst/schema/CalibrateDataResponse.schema.json
+++ b/inst/schema/CalibrateDataResponse.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
-    "data": { "$ref": "ModelResultData.schema.json" },
+    "data": { "$ref": "ModelResultData.schema.json" }
   },
   "required": [ "data" ]
 }

--- a/inst/schema/CalibrateMetadataResponse.schema.json
+++ b/inst/schema/CalibrateMetadataResponse.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "plottingMetadata": {
+      "type": "object",
+      "properties": {
+        "barchart": { "$ref": "BarchartMetadata.schema.json" },
+        "choropleth": { "$ref": "ChoroplethMetadata.schema.json" }
+      },
+      "additionalProperties": false,
+      "required": [ "barchart", "choropleth" ]
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "$ref": "Warning.schema.json"  }
+    }
+  },
+  "required": ["plottingMetadata", "warnings" ]
+}

--- a/tests/testthat/test-02-api.R
+++ b/tests/testthat/test-02-api.R
@@ -879,6 +879,20 @@ test_that("model calibrate can be queued and result returned", {
   expect_true(nrow(response$data$data) > 84042)
   expect_equal(names(response$data$plottingMetadata),
                c("barchart", "choropleth"))
+
+  ## Get metadata
+  metadata <- endpoint_model_calibrate_metadata(q$queue)
+  metadata_response <- metadata$run(status_response$data$id)
+  expect_equal(metadata_response$data$plottingMetadata,
+               response$data$plottingMetadata)
+  expect_equal(metadata_response$data$warnings,
+               response$data$warnings)
+
+  ## Get data
+  data <- endpoint_model_calibrate_data(q$queue)
+  data_response <- data$run(status_response$data$id)
+  expect_equal(data_response$data$data,
+               response$data$data)
 })
 
 test_that("api can call endpoint_model_calibrate", {
@@ -926,6 +940,24 @@ test_that("api can call endpoint_model_calibrate", {
   expect_true(nrow(result_body$data$data) > 84042)
   expect_equal(names(result_body$data$plottingMetadata),
                c("barchart", "choropleth"))
+
+  ## Get metadata
+  metadata_res <- api$request("GET", paste0("/calibrate/result/metadata/",
+                                            status_body$data$id))
+  expect_equal(metadata_res$status, 200)
+  metadata_body <- jsonlite::fromJSON(metadata_res$body)
+  expect_equal(metadata_body$data$plottingMetadata,
+               result_body$data$plottingMetadata)
+  expect_equal(metadata_body$data$warnings,
+               result_body$data$warnings)
+
+  ## Get data
+  data_res <- api$request("GET", paste0("/calibrate/result/data/",
+                                        status_body$data$id))
+  expect_equal(data_res$status, 200)
+  data_body <- jsonlite::fromJSON(data_res$body)
+  expect_equal(data_body$data$data,
+               result_body$data$data)
 })
 
 test_that("model calibrate result includes warnings", {


### PR DESCRIPTION
This PR will add 2 new endpoints
* `/calibrate/result/metadata/<id>` to return the metadata and warnings from the `/calibrate/result/<id>` endpoint
* `/calibrate/result/data/<id>` to return only the data from the `/calibrate/result/<id>` endpoint

This is the first step in heading towards smaller data payloads. We want to get hint working when metadata is fetched separately from the data itself. Note this PR doesn't remove existing endpoint, we can do that now or later.
