### PR TITLE
mrc-4508: Save plot data as a duckdb database

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     ids,
     jsonlite (>= 1.2.2),
     lgr,
-    naomi (>= 2.9.10),
+    naomi (>= 2.9.11),
     naomi.options (>= 1.1.0),
     porcelain (>= 0.1.8),
     qs,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.1.15
+Version: 1.1.16
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.1.16
+
+* Add a new endpoint `/calibrate/result/path/<id>` which will return the path to the calibration plot data output which can be read by web backend
+
 # hintr 1.1.15
 
 * Add two new endpoints in preparation for web backend accessing the result data on disk directly

--- a/R/api.R
+++ b/R/api.R
@@ -18,6 +18,7 @@ api_build <- function(queue, validate = FALSE, logger = NULL) {
   api$handle(endpoint_model_calibrate_result(queue))
   api$handle(endpoint_model_calibrate_metadata(queue))
   api$handle(endpoint_model_calibrate_data(queue))
+  api$handle(endpoint_model_calibrate_result_path(queue))
   api$handle(endpoint_model_calibrate_plot(queue))
   api$handle(endpoint_comparison_plot(queue))
   api$handle(endpoint_plotting_metadata_iso3())
@@ -303,6 +304,15 @@ endpoint_model_calibrate_data <- function(queue) {
   porcelain::porcelain_endpoint$new("GET",
                                     "/calibrate/result/data/<id>",
                                     calibrate_data(queue),
+                                    returning = response)
+}
+
+endpoint_model_calibrate_result_path <- function(queue) {
+  response <- porcelain::porcelain_returning_json(
+    "CalibrateResultPathResponse.schema", schema_root())
+  porcelain::porcelain_endpoint$new("GET",
+                                    "/calibrate/result/path/<id>",
+                                    calibrate_result_path(queue),
                                     returning = response)
 }
 

--- a/R/calibrate.R
+++ b/R/calibrate.R
@@ -12,7 +12,7 @@ run_calibrate <- function(model_output, calibration_options, path_results,
 
   path_results <- normalizePath(path_results, mustWork = TRUE)
   plot_data_path <- tempfile("plot_data", tmpdir = path_results,
-                             fileext = ".qs")
+                             fileext = ".duckdb")
   model_output_path <- tempfile("model_output", tmpdir = path_results,
                                 fileext = ".qs")
 

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -230,7 +230,6 @@ calibrate_metadata <- function(queue) {
       warnings <- warnings_scalar(result$warnings)
     }
     list(
-      path = scalar(result$plot_data_path),
       plottingMetadata = metadata,
       warnings = warnings
     )
@@ -243,6 +242,16 @@ calibrate_data <- function(queue) {
     result <- queue$result(id)
     output <- naomi::read_hintr_output(result$plot_data_path)
     list(data = select_data(output))
+  }
+}
+
+calibrate_result_path <- function(queue) {
+  function(id) {
+    verify_result_available(queue, id)
+    result <- queue$result(id)
+    list(
+      path = scalar(result$plot_data_path)
+    )
   }
 }
 

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -230,6 +230,7 @@ calibrate_metadata <- function(queue) {
       warnings <- warnings_scalar(result$warnings)
     }
     list(
+      path = scalar(result$plot_data_path),
       plottingMetadata = metadata,
       warnings = warnings
     )

--- a/docker/build
+++ b/docker/build
@@ -28,7 +28,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi
+git clone https://github.com/mrc-ide/naomi@mrc-4555
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/docker/build
+++ b/docker/build
@@ -28,7 +28,7 @@ ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 EOF
 
 rm -rf naomi
-git clone https://github.com/mrc-ide/naomi@mrc-4555
+git clone --single-branch --branch mrc-4555 https://github.com/mrc-ide/naomi
 if [ -z $NAOMI_SHA ]; then
     git -C $PACKAGE_ROOT/naomi checkout $NAOMI_SHA
 fi

--- a/inst/schema/CalibrateMetadataResponse.schema.json
+++ b/inst/schema/CalibrateMetadataResponse.schema.json
@@ -2,6 +2,9 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
+    "path": {
+      "type": "string"
+    },
     "plottingMetadata": {
       "type": "object",
       "properties": {
@@ -16,5 +19,5 @@
       "items": { "$ref": "Warning.schema.json"  }
     }
   },
-  "required": ["plottingMetadata", "warnings" ]
+  "required": [ "path", "plottingMetadata", "warnings" ]
 }

--- a/inst/schema/CalibrateMetadataResponse.schema.json
+++ b/inst/schema/CalibrateMetadataResponse.schema.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
-    "path": {
-      "type": "string"
-    },
     "plottingMetadata": {
       "type": "object",
       "properties": {
@@ -19,5 +16,5 @@
       "items": { "$ref": "Warning.schema.json"  }
     }
   },
-  "required": [ "path", "plottingMetadata", "warnings" ]
+  "required": [ "plottingMetadata", "warnings" ]
 }

--- a/inst/schema/CalibrateResultPathResponse.schema.json
+++ b/inst/schema/CalibrateResultPathResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" }
+  },
+  "required": [ "path" ]
+}

--- a/scripts/build_test_data
+++ b/scripts/build_test_data
@@ -1,7 +1,7 @@
 #!/usr/bin/env Rscript
 
 paths <- list(model_output_path = "inst/output/malawi_model_output.qs",
-              calibrate_plot_path = "inst/output/malawi_calibrate_plot_data.qs",
+              calibrate_plot_path = "inst/output/malawi_calibrate_plot_data.duckdb",
               calibrate_output_path = "inst/output/malawi_calibrate_output.qs",
               spectrum_path = "inst/output/malawi_spectrum_download.zip",
               coarse_output_path = "inst/output/malawi_coarse_output_download.zip",

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -127,7 +127,7 @@ clone_model_output <- function(output) {
   file.copy(output$model_output_path, model_output_path)
   plot_data_path <- NULL
   if (!is.null(output$plot_data_path)) {
-    plot_data_path <- tempfile(fileext = ".qs")
+    plot_data_path <- tempfile(fileext = ".duckdb")
     file.copy(output$plot_data_path, plot_data_path)
   }
   out <- list(model_output_path = model_output_path,

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -19,7 +19,7 @@ class(mock_model) <- "hintr_output"
 
 mock_calibrate <- list(
   plot_data_path =
-    system.file("output", "malawi_calibrate_plot_data.qs", package = "hintr"),
+    system.file("output", "malawi_calibrate_plot_data.duckdb", package = "hintr"),
   model_output_path =
     system.file("output", "malawi_calibrate_output.qs", package = "hintr"),
   version = utils::packageVersion("naomi"),
@@ -80,7 +80,7 @@ test_mock_model_available <- function() {
 ## hintr version 0.1.39 to 1.0.7 and naomi version 2.4.3 to 2.5.6
 mock_calibrate_v1.0.7 <- list(
   plot_data_path =
-    system.file("output", "malawi_calibrate_plot_data.qs", package = "hintr"),
+    system.file("output", "malawi_calibrate_plot_data.duckdb", package = "hintr"),
   model_output_path =
     system.file("output", "malawi_calibrate_output.qs", package = "hintr"),
   version = "2.5.6"

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -316,7 +316,8 @@ test_that("real model can be run & calibrated by API", {
   response <- response_from_json(r)
   expect_equal(response$status, "success")
   expect_equal(response$errors, NULL)
-  expect_equal(names(response$data), c("data", "plottingMetadata", "warnings"))
+  expect_equal(names(response$data),
+               c("data", "plottingMetadata", "warnings"))
   expect_equal(names(response$data$data[[1]]),
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator", "mode", "mean", "lower", "upper"))

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -316,14 +316,21 @@ test_that("real model can be run & calibrated by API", {
   response <- response_from_json(r)
   expect_equal(response$status, "success")
   expect_equal(response$errors, NULL)
-  expect_equal(names(response$data),
-               c("data", "plottingMetadata", "warnings"))
+  expect_equal(names(response$data), c("data", "plottingMetadata", "warnings"))
   expect_equal(names(response$data$data[[1]]),
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator", "mode", "mean", "lower", "upper"))
   expect_true(length(response$data$data) > 84042)
   expect_equal(names(response$data$plottingMetadata),
                c("barchart", "choropleth"))
+
+  ## Get path to result
+  r <- test_server$request("GET", paste0("/calibrate/result/path/",
+                                         calibrate_id))
+  response <- response_from_json(r)
+  expect_equal(response$status, "success")
+  expect_equal(names(response$data), "path")
+  expect_true(file.exists(response$data$path))
 })
 
 test_that("plotting metadata is exposed", {

--- a/tests/testthat/test-02-api.R
+++ b/tests/testthat/test-02-api.R
@@ -872,8 +872,7 @@ test_that("model calibrate can be queued and result returned", {
   response <- result$run(status_response$data$id)
 
   expect_equal(response$status_code, 200)
-  expect_equal(names(response$data),
-               c("data", "plottingMetadata", "warnings"))
+  expect_equal(names(response$data), c("data", "plottingMetadata", "warnings"))
   expect_equal(colnames(response$data$data),
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator", "mode", "mean", "lower", "upper"))
@@ -884,8 +883,6 @@ test_that("model calibrate can be queued and result returned", {
   ## Get metadata
   metadata <- endpoint_model_calibrate_metadata(q$queue)
   metadata_response <- metadata$run(status_response$data$id)
-  expect_equal(metadata$response$data$path,
-               response$data$path)
   expect_equal(metadata_response$data$plottingMetadata,
                response$data$plottingMetadata)
   expect_equal(metadata_response$data$warnings,
@@ -896,6 +893,12 @@ test_that("model calibrate can be queued and result returned", {
   data_response <- data$run(status_response$data$id)
   expect_equal(data_response$data$data,
                response$data$data)
+
+  ## Get path to data
+  path <- endpoint_model_calibrate_result_path(q$queue)
+  path_response <- path$run(status_response$data$id)
+  expect_equal(path_response$status_code, 200)
+  expect_true(file.exists(path_response$data$path))
 })
 
 test_that("api can call endpoint_model_calibrate", {
@@ -961,6 +964,13 @@ test_that("api can call endpoint_model_calibrate", {
   data_body <- jsonlite::fromJSON(data_res$body)
   expect_equal(data_body$data$data,
                result_body$data$data)
+
+  ## Get path to data
+  path_res <- api$request("GET", paste0("/calibrate/result/path/",
+                                        status_body$data$id))
+  expect_equal(path_res$status, 200)
+  path_body <- jsonlite::fromJSON(path_res$body)
+  expect_true(file.exists(path_body$data$path))
 })
 
 test_that("model calibrate result includes warnings", {

--- a/tests/testthat/test-02-api.R
+++ b/tests/testthat/test-02-api.R
@@ -872,7 +872,8 @@ test_that("model calibrate can be queued and result returned", {
   response <- result$run(status_response$data$id)
 
   expect_equal(response$status_code, 200)
-  expect_equal(names(response$data), c("data", "plottingMetadata", "warnings"))
+  expect_equal(names(response$data),
+               c("data", "plottingMetadata", "warnings"))
   expect_equal(colnames(response$data$data),
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator", "mode", "mean", "lower", "upper"))
@@ -883,6 +884,8 @@ test_that("model calibrate can be queued and result returned", {
   ## Get metadata
   metadata <- endpoint_model_calibrate_metadata(q$queue)
   metadata_response <- metadata$run(status_response$data$id)
+  expect_equal(metadata$response$data$path,
+               response$data$path)
   expect_equal(metadata_response$data$plottingMetadata,
                response$data$plottingMetadata)
   expect_equal(metadata_response$data$warnings,


### PR DESCRIPTION
This PR will
* Save plot data output as a duckdb database (the bulk of the work for that is done in the Naomi PR https://github.com/mrc-ide/naomi/pull/405
* Add path to the metadata response to tell Kotlin backend where the file is available on disk. Might be some things we want to make a bit more robust here - this is going to be dependent on where the kotlin and hintr contains have the data mounted into the container. So is dependent on the docker setup, I think this is at the same path at the moment and maybe we can insist that it must be but feels a little fragile that we are relying on that.

Also do we want any additional metadata here? Kotlin will want to know how it can slice the data, which is information available in the filters but let me know if you need that be moved around or anything?

Couple of important things to note. In the duckdb database the plot data is stored in a table called `data` it is the only table in the database. In the database there are columns which are needed for building the metadata here (like the label columns) but are not used in plotting. If you filter them in the Kotlin side and just read the columns you need that should be fast (duck db stores data in columnar format). Currently for plotting the old endpoint returns columns `area_id`, `sex`, `age_group`, `calendar_quarter`, `indicator`, `mode`, `mean`, `lower` and `upper`