### PR TITLE
mrc-4673: Add tableMetadata to calibrate result metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.1.17
+Version: 1.1.18
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.1.18
+
+* Add `tableMetadata` into the `calibrate/result/<id>` and `calibrate/result/metadata/<id>` endpoints for controling how the new output table feature will look
+
 # hintr 1.1.17
 
 * Add a dummy download endpoint of type "agyw" for generating AGYW (adolescent girls and young women) tool

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -225,12 +225,14 @@ calibrate_metadata <- function(queue) {
     result <- queue$result(id)
     output <- naomi::read_hintr_output(result$plot_data_path)
     metadata <- build_output_metadata(output)
+    table_metadata <- build_output_table_metadata()
     warnings <- list()
     if (!is.null(result$warnings)) {
       warnings <- warnings_scalar(result$warnings)
     }
     list(
       plottingMetadata = metadata,
+      tableMetadata = table_metadata,
       warnings = warnings
     )
   }

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -224,8 +224,9 @@ calibrate_metadata <- function(queue) {
     verify_result_available(queue, id)
     result <- queue$result(id)
     output <- naomi::read_hintr_output(result$plot_data_path)
-    metadata <- build_output_metadata(output)
-    table_metadata <- build_output_table_metadata()
+    filters <- get_model_output_filters(output)
+    metadata <- build_output_metadata(output, filters)
+    table_metadata <- build_output_table_metadata(output, filters)
     warnings <- list()
     if (!is.null(result$warnings)) {
       warnings <- warnings_scalar(result$warnings)

--- a/R/filters.R
+++ b/R/filters.R
@@ -52,6 +52,16 @@ get_indicator_filters <- function(data, type) {
   get_filters(data, type)
 }
 
+get_area_level_filters <- function(data) {
+  levels <- unique(data$area_level)
+  lapply(levels, function(level) {
+    list(
+      id = scalar(as.character(level)),
+      label = scalar(data[data$area_level == level, "area_level_label"][1])
+    )
+  })
+}
+
 #' Read filters from wide format data
 #'
 #' Expect input data with headers like
@@ -203,13 +213,22 @@ get_comparison_plot_filters <- function(data) {
   )
 }
 
+get_area_level_filter <- function(data) {
+  list(
+    id = scalar("area_level"),
+    column_id = scalar("area_level"),
+    label = scalar(t_("OUTPUT_FILTER_AREA_LEVEL")),
+    options = get_area_level_filters(data)
+  )
+}
+
 get_barchart_defaults <- function(output, output_filters) {
   list(
     indicator_id = scalar("prevalence"),
     x_axis_id = scalar("age"),
     disaggregate_by_id = scalar("sex"),
     selected_filter_options = list(
-      area = get_area_level_filter_option(output),
+      area = get_area_id_filter_default(output),
       quarter = get_selected_mappings(output_filters, "quarter")[2],
       sex = get_selected_mappings(output_filters, "sex", c("female", "male")),
       age = get_selected_mappings(output_filters, "age",
@@ -234,7 +253,7 @@ get_calibrate_barchart_defaults <- function(filters) {
 }
 
 get_comparison_barchart_selections <- function(output, filters) {
-  area_default <- get_area_level_filter_option(output)
+  area_default <- get_area_id_filter_default(output)
   five_year_age_groups <- get_selected_mappings(
     filters, "age", naomi::get_five_year_age_groups())
   all_sexes <- get_selected_mappings(filters, "sex")
@@ -340,7 +359,7 @@ get_selected_mappings <- function(mappings, type, ids = NULL, key = "options") {
   selected
 }
 
-get_area_level_filter_option <- function(output) {
+get_area_id_filter_default <- function(output) {
   ## We expect the areas to be returned in order - return the first region
   ## level as the default
   option <- output[1, c("area_id", "area_name")]

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -83,8 +83,9 @@ select_data <- function(data) {
 
 process_result <- function(model_output) {
   output <- naomi::read_hintr_output(model_output$plot_data_path)
-  metadata <- build_output_metadata(output)
-  table_metadata <- build_output_table_metadata()
+  filters <- get_model_output_filters(output)
+  metadata <- build_output_metadata(output, filters)
+  table_metadata <- build_output_table_metadata(output, filters)
   warnings <- list()
   if (!is.null(model_output$warnings)) {
     warnings <- warnings_scalar(model_output$warnings)
@@ -95,41 +96,46 @@ process_result <- function(model_output) {
        warnings = warnings)
 }
 
-build_output_metadata <- function(output) {
-  output_filters <- get_model_output_filters(output)
+build_output_metadata <- function(output, filters) {
   list(
     barchart = list(
       indicators = get_barchart_metadata(output),
-      filters = output_filters,
-      defaults = get_barchart_defaults(output, output_filters)
+      filters = filters,
+      defaults = get_barchart_defaults(output, filters)
     ),
     choropleth = list(
       indicators = get_choropleth_metadata(output),
-      filters = output_filters
+      filters = filters
     )
   )
 }
 
-build_output_table_metadata <- function() {
-  list(
-    presets = list(
-      list(
-        id = "sex_by_area",
-        label = scalar(t_("TABLE_SEX_BY_AREA")),
-        column = scalar("sex"),
-        row = scalar("area_id")
-      ),
-      list(
-        id = "sex_by_5_year_age_group",
-        label = scalar(t_("TABLE_SEX_BY_5_YEAR_AGE_GROUP")),
-        column = scalar("sex"),
-        row = scalar("age_group"),
-        selected_filter_options = list(
-          age = naomi::get_five_year_age_groups()
-        )
+build_output_table_metadata <- function(output, filters) {
+  area_level_filter <- get_area_level_filter(output)
+  filter_ids <- vcapply(filters, "[[", "id")
+  sex_by_area_filters <- c(list(area_level_filter), filters[filter_ids != "area"])
+  sex_by_area <- list(
+    filters = sex_by_area_filters,
+    defaults = list(
+      id = scalar("sex_by_area"),
+      label = scalar(t_("TABLE_SEX_BY_AREA")),
+      column = scalar("sex"),
+      row = scalar("area_id")
+    )
+  )
+  sex_by_5_year_age_group <- list(
+    filters = filters,
+    defaults = list(
+      id = scalar("sex_by_5_year_age_group"),
+      label = scalar(t_("TABLE_SEX_BY_5_YEAR_AGE_GROUP")),
+      column = scalar("sex"),
+      row = scalar("age_group"),
+      selected_filter_options = list(
+        age = naomi::get_five_year_age_groups()
       )
     )
   )
+  list(presets = list(sex_by_area, sex_by_5_year_age_group))
 }
 
 

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -84,12 +84,14 @@ select_data <- function(data) {
 process_result <- function(model_output) {
   output <- naomi::read_hintr_output(model_output$plot_data_path)
   metadata <- build_output_metadata(output)
+  table_metadata <- build_output_table_metadata()
   warnings <- list()
   if (!is.null(model_output$warnings)) {
     warnings <- warnings_scalar(model_output$warnings)
   }
   list(data = select_data(output),
        plottingMetadata = metadata,
+       tableMetadata = table_metadata,
        warnings = warnings)
 }
 
@@ -107,6 +109,27 @@ build_output_metadata <- function(output) {
     )
   )
 }
+
+build_output_table_metadata <- function() {
+  list(
+    presets = list(
+      list(
+        label = scalar(t_("TABLE_SEX_BY_AREA")),
+        column = scalar("sex"),
+        row = scalar("area_id")
+      ),
+      list(
+        label = scalar(t_("TABLE_SEX_BY_5_YEAR_AGE_GROUP")),
+        column = scalar("sex"),
+        row = scalar("age"),
+        selected_filter_options = list(
+          age = naomi::get_five_year_age_groups()
+        )
+      )
+    )
+  )
+}
+
 
 use_mock_model <- function() {
   Sys.getenv("USE_MOCK_MODEL") == "true"

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -117,13 +117,13 @@ build_output_table_metadata <- function() {
         id = "sex_by_area",
         label = scalar(t_("TABLE_SEX_BY_AREA")),
         column = scalar("sex"),
-        row = scalar("area")
+        row = scalar("area_id")
       ),
       list(
         id = "sex_by_5_year_age_group",
         label = scalar(t_("TABLE_SEX_BY_5_YEAR_AGE_GROUP")),
         column = scalar("sex"),
-        row = scalar("age"),
+        row = scalar("age_group"),
         selected_filter_options = list(
           age = naomi::get_five_year_age_groups()
         )

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -114,11 +114,13 @@ build_output_table_metadata <- function() {
   list(
     presets = list(
       list(
+        id = "sex_by_area",
         label = scalar(t_("TABLE_SEX_BY_AREA")),
         column = scalar("sex"),
         row = scalar("area")
       ),
       list(
+        id = "sex_by_5_year_age_group",
         label = scalar(t_("TABLE_SEX_BY_5_YEAR_AGE_GROUP")),
         column = scalar("sex"),
         row = scalar("age"),

--- a/inst/schema/CalibrateMetadataResponse.schema.json
+++ b/inst/schema/CalibrateMetadataResponse.schema.json
@@ -11,10 +11,11 @@
       "additionalProperties": false,
       "required": [ "barchart", "choropleth" ]
     },
+    "tableMetadata": { "$ref": "TableMetadata.schema.json" },
     "warnings": {
       "type": "array",
       "items": { "$ref": "Warning.schema.json"  }
     }
   },
-  "required": [ "plottingMetadata", "warnings" ]
+  "required": [ "plottingMetadata", "tableMetadata", "warnings" ]
 }

--- a/inst/schema/CalibrateResultResponse.schema.json
+++ b/inst/schema/CalibrateResultResponse.schema.json
@@ -12,10 +12,11 @@
       "additionalProperties": false,
       "required": [ "barchart", "choropleth" ]
     },
+    "tableMetadata": { "$ref": "TableMetadata.schema.json" },
     "warnings": {
       "type": "array",
       "items": { "$ref": "Warning.schema.json"  }
     }
   },
-  "required": [ "data", "plottingMetadata", "warnings" ]
+  "required": [ "data", "plottingMetadata", "tableMetadata", "warnings" ]
 }

--- a/inst/schema/TableMetadata.schema.json
+++ b/inst/schema/TableMetadata.schema.json
@@ -5,6 +5,7 @@
     "table_preset": {
       "type": "object",
       "properties": {
+        "id": { "type": "string" },
         "label": { "type": "string" },
         "column": { "type": "string" },
         "row": { "type": "string" },
@@ -19,7 +20,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [ "label", "column", "row" ]
+      "required": [ "id", "label", "column", "row" ]
     }
   },
   "properties" : {

--- a/inst/schema/TableMetadata.schema.json
+++ b/inst/schema/TableMetadata.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "definitions": {
+    "table_preset": {
+      "type": "object",
+      "properties": {
+        "label": { "type": "string" },
+        "column": { "type": "string" },
+        "row": { "type": "string" },
+        "selected_filter_options": {
+          "type": "object",
+          "patternProperties": {
+            "^.*$": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [ "label", "column", "row" ]
+    }
+  },
+  "properties" : {
+    "presets" : {
+      "type": "array",
+      "items": { "$ref": "#/definitions/table_preset" }
+    },
+  },
+  "additionalProperties": false,
+  "required": [ "presets" ]
+}

--- a/inst/schema/TableMetadata.schema.json
+++ b/inst/schema/TableMetadata.schema.json
@@ -26,7 +26,7 @@
     "presets" : {
       "type": "array",
       "items": { "$ref": "#/definitions/table_preset" }
-    },
+    }
   },
   "additionalProperties": false,
   "required": [ "presets" ]

--- a/inst/schema/TableMetadata.schema.json
+++ b/inst/schema/TableMetadata.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "definitions": {
-    "table_preset": {
+    "table_defaults": {
       "type": "object",
       "properties": {
         "id": { "type": "string" },
@@ -21,6 +21,18 @@
       },
       "additionalProperties": false,
       "required": [ "id", "label", "column", "row" ]
+    },
+    "table_preset": {
+      "type": "object",
+      "properties": {
+        "filters" : {
+          "type": "array",
+          "items": { "$ref": "Filter.schema.json" }
+        },
+        "defaults": { "$ref": "#/definitions/table_defaults" }
+      },
+      "additionalProperties": false,
+      "required": [ "filters", "defaults" ]
     }
   },
   "properties" : {

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -67,6 +67,7 @@
     "OUTPUT_FILTER_SEX": "Sex",
     "OUTPUT_FILTER_AGE": "Age",
     "OUTPUT_FILTER_DATA_TYPE": "Data type",
+    "OUTPUT_FILTER_AREA_LEVEL": "Area level",
     "MODEL_RESULT_OLD": "Can't download {{type}}, please re-run model and try download again.",
     "OUTPUT_GENERATION_FAILED": "Failed to generate output",
     "INVALID_DOWNLOAD_TYPE": "Failed to generate download for {{type}} type, contact system admin.",

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -87,5 +87,7 @@
     "QUARTER_4": "Quarter 4",
     "VALIDATION_MULTIPLE_LEVELS_DETAIL": "year {{year}} has area levels {{levels}}",
     "VALIDATION_MULTIPLE_LEVELS": "Data can only be for regions at a single area level per year. In uploaded data {{detail}}.",
-    "FAILED_ZIP_REHYDRATE_SUBMIT": "Cannot load from this zip file, archive missing required information. Please regenerate output zip and try again."
+    "FAILED_ZIP_REHYDRATE_SUBMIT": "Cannot load from this zip file, archive missing required information. Please regenerate output zip and try again.",
+    "TABLE_SEX_BY_AREA": "Sex by area",
+    "TABLE_SEX_BY_5_YEAR_AGE_GROUP": "Sex by 5 year age group"
 }

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -67,6 +67,7 @@
     "OUTPUT_FILTER_SEX": "Sexe",
     "OUTPUT_FILTER_AGE": "Âge",
     "OUTPUT_FILTER_DATA_TYPE": "Type de données",
+    "OUTPUT_FILTER_AREA_LEVEL": "Niveau de la zone",
     "MODEL_RESULT_OLD": "Impossible de télécharger {{type}}, veuillez réexécuter le modèle et réessayer de télécharger.",
     "OUTPUT_GENERATION_FAILED": "Impossible de générer une sortie",
     "INVALID_DOWNLOAD_TYPE": "Impossible de générer le téléchargement pour le type de {{type}}, contactez l'administrateur système.",

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -88,5 +88,7 @@
     "QUARTER_4": "trimestre 4",
     "VALIDATION_MULTIPLE_LEVELS_DETAIL": "l'année {{year}} a des niveaux de zone {{levels}}",
     "VALIDATION_MULTIPLE_LEVELS": "Les données ne peuvent concerner que les régions à un seul niveau de zone par an. Dans les données téléchargées {{detail}}",
-    "FAILED_ZIP_REHYDRATE_SUBMIT": "Impossible de charger à partir de ce fichier zip, l'archive manque d'informations requises. Veuillez régénérer le zip de sortie et réessayer."
+    "FAILED_ZIP_REHYDRATE_SUBMIT": "Impossible de charger à partir de ce fichier zip, l'archive manque d'informations requises. Veuillez régénérer le zip de sortie et réessayer.",
+    "TABLE_SEX_BY_AREA": "Sexe par zone",
+    "TABLE_SEX_BY_5_YEAR_AGE_GROUP": "Sexe par tranche d'âge de 5 ans"
 }

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -27,6 +27,7 @@
     "OUTPUT_FILTER_AREA": "Área",
     "OUTPUT_FILTER_PERIOD": "Período",
     "OUTPUT_FILTER_SEX": "Género",
+    "OUTPUT_FILTER_AREA_LEVEL": "Nível de área",
     "PJNZ_INVALID_ZIP": "O zip não contém ficheiros PJNZ",
     "QUEUE_CACHE": "A criar cache",
     "QUEUE_CONNECTING": "A estabelecer ligação à redis em {{redis}}",

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -87,5 +87,7 @@
     "QUARTER_4": "trimestre 4",
     "VALIDATION_MULTIPLE_LEVELS_DETAIL": "ano {{year}} tem níveis de área {{levels}}",
     "VALIDATION_MULTIPLE_LEVELS": "Os dados só podem ser relativos a regiões a um único nível de área por ano. Em dados carregados {{detail}}",
-    "FAILED_ZIP_REHYDRATE_SUBMIT": "Não é possível carregar a partir deste ficheiro zip, faltando informação necessária ao arquivo. Por favor, regenerar zip de saída e tentar novamente."
+    "FAILED_ZIP_REHYDRATE_SUBMIT": "Não é possível carregar a partir deste ficheiro zip, faltando informação necessária ao arquivo. Por favor, regenerar zip de saída e tentar novamente.",
+    "TABLE_SEX_BY_AREA": "Sexo por área",
+    "TABLE_SEX_BY_5_YEAR_AGE_GROUP": "Sexo por faixa etária de 5 anos"
 }

--- a/tests/testthat/integration-server.R
+++ b/tests/testthat/integration-server.R
@@ -316,13 +316,16 @@ test_that("real model can be run & calibrated by API", {
   response <- response_from_json(r)
   expect_equal(response$status, "success")
   expect_equal(response$errors, NULL)
-  expect_equal(names(response$data), c("data", "plottingMetadata", "warnings"))
+  expect_equal(names(response$data),
+               c("data", "plottingMetadata", "tableMetadata", "warnings"))
   expect_equal(names(response$data$data[[1]]),
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator", "mode", "mean", "lower", "upper"))
   expect_true(length(response$data$data) > 84042)
   expect_equal(names(response$data$plottingMetadata),
                c("barchart", "choropleth"))
+  expect_equal(names(response$data$tableMetadata),
+               c("presets"))
 
   ## Get path to result
   r <- test_server$request("GET", paste0("/calibrate/result/path/",

--- a/tests/testthat/test-03-run-model.R
+++ b/tests/testthat/test-03-run-model.R
@@ -12,9 +12,9 @@ test_that("model can be run & calibrated and filters extracted", {
   ## All table metadata rows and columns come from the data
   data_names <- names(res$data)
   for (preset in res$tableMetadata$presets) {
-    expect_true(preset$column %in% data_names,
+    expect_true(preset$defaults$column %in% data_names,
                 sprintf("Column '%s' not a valid data column", preset$column))
-    expect_true(preset$row %in% data_names,
+    expect_true(preset$defaults$row %in% data_names,
                 sprintf("Row '%s' not a valid data column", preset$row))
   }
 
@@ -323,6 +323,8 @@ test_that("mock model can be forced to error", {
 })
 
 test_that("table metadata has been translated", {
-  metadata <- build_output_table_metadata()
+  output <- naomi::read_hintr_output(mock_calibrate$plot_data_path)
+  filters <- get_model_output_filters(output)
+  metadata <- build_output_table_metadata(output, filters)
   expect_equal(metadata$presets[[1]]$label, scalar("Sex by area"))
 })

--- a/tests/testthat/test-03-run-model.R
+++ b/tests/testthat/test-03-run-model.R
@@ -8,6 +8,16 @@ test_that("model can be run & calibrated and filters extracted", {
                  "indicator", "mode", "mean", "lower", "upper"))
   expect_true(nrow(res$data) > 84042)
   expect_equal(names(res$tableMetadata), "presets")
+
+  ## All table metadata rows and columns come from the data
+  data_names <- names(res$data)
+  for (preset in res$tableMetadata$presets) {
+    expect_true(preset$column %in% data_names,
+                sprintf("Column '%s' not a valid data column", preset$column))
+    expect_true(preset$row %in% data_names,
+                sprintf("Row '%s' not a valid data column", preset$row))
+  }
+
   expect_equal(names(res$plottingMetadata), c("barchart", "choropleth"))
   barchart <- res$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters", "defaults"))

--- a/tests/testthat/test-03-run-model.R
+++ b/tests/testthat/test-03-run-model.R
@@ -326,5 +326,5 @@ test_that("table metadata has been translated", {
   output <- naomi::read_hintr_output(mock_calibrate$plot_data_path)
   filters <- get_model_output_filters(output)
   metadata <- build_output_table_metadata(output, filters)
-  expect_equal(metadata$presets[[1]]$label, scalar("Sex by area"))
+  expect_equal(metadata$presets[[1]]$default$label, scalar("Sex by area"))
 })

--- a/tests/testthat/test-03-run-model.R
+++ b/tests/testthat/test-03-run-model.R
@@ -1,11 +1,13 @@
 test_that("model can be run & calibrated and filters extracted", {
   test_mock_model_available()
   res <- process_result(mock_calibrate)
-  expect_equal(names(res), c("data", "plottingMetadata", "warnings"))
+  expect_equal(names(res),
+               c("data", "plottingMetadata", "tableMetadata", "warnings"))
   expect_equal(names(res$data),
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator", "mode", "mean", "lower", "upper"))
   expect_true(nrow(res$data) > 84042)
+  expect_equal(names(res$tableMetadata), "presets")
   expect_equal(names(res$plottingMetadata), c("barchart", "choropleth"))
   barchart <- res$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters", "defaults"))
@@ -74,13 +76,15 @@ test_that("model without national level results can be processed", {
   output_temp <- tempfile(fileext = ".rds")
   saveRDS(output, output_temp)
   res <- process_result(list(plot_data_path = output_temp))
-  expect_equal(names(res), c("data", "plottingMetadata", "warnings"))
+  expect_equal(names(res),
+               c("data", "plottingMetadata", "tableMetadata", "warnings"))
   expect_equal(names(res$data),
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator", "mode", "mean", "lower", "upper"))
   expect_true(nrow(res$data) > 84042)
   expect_equal(as.data.frame(res$data)[1, "area_id"], "MWI_1_1_demo",
                ignore_attr = TRUE)
+  expect_equal(names(res$tableMetadata), "presets")
   expect_equal(names(res$plottingMetadata), c("barchart", "choropleth"))
   barchart <- res$plottingMetadata$barchart
   expect_equal(names(barchart), c("indicators", "filters", "defaults"))
@@ -306,4 +310,9 @@ test_that("mock model can be forced to error", {
     run_model(data, options, tempdir()),
     "Mock model has errored because option 'mock_model_trigger_error' is TRUE"
   )
+})
+
+test_that("table metadata has been translated", {
+  metadata <- build_output_table_metadata()
+  expect_equal(metadata$presets[[1]]$label, scalar("Sex by area"))
 })

--- a/tests/testthat/test-05-calibrate.R
+++ b/tests/testthat/test-05-calibrate.R
@@ -153,7 +153,7 @@ test_that("can calibrate a model result", {
   expect_equal(names(result$tableMetadata), "presets")
   expect_length(result$tableMetadata$presets, 2)
   expect_equal(names(result$tableMetadata$presets[[1]]),
-               c("label", "column", "row"))
+               c("id", "label", "column", "row"))
 })
 
 test_that("model calibration fails is version out of date", {

--- a/tests/testthat/test-05-calibrate.R
+++ b/tests/testthat/test-05-calibrate.R
@@ -152,7 +152,7 @@ test_that("can calibrate a model result", {
   ## Table metadata is returned
   expect_equal(names(result$tableMetadata), "presets")
   expect_length(result$tableMetadata$presets, 2)
-  expect_names(result$tableMetadata$presets[[1]],
+  expect_equal(names(result$tableMetadata$presets[[1]]),
                c("label", "column", "area_id"))
 })
 

--- a/tests/testthat/test-05-calibrate.R
+++ b/tests/testthat/test-05-calibrate.R
@@ -52,7 +52,8 @@ test_that("can calibrate a model result", {
 
   get_result <- calibrate_result(q$queue)
   result <- get_result(res$id)
-  expect_equal(names(result), c("data", "plottingMetadata", "warnings"))
+  expect_equal(names(result),
+               c("data", "plottingMetadata", "tableMetadata", "warnings"))
   expect_equal(colnames(result$data),
                c("area_id", "sex", "age_group", "calendar_quarter",
                  "indicator", "mode", "mean", "lower", "upper"))
@@ -147,6 +148,12 @@ test_that("can calibrate a model result", {
                  "anc_clients", "anc_plhiv", "anc_already_art",
                  "anc_art_new", "anc_known_pos",
                  "anc_tested_pos", "anc_tested_neg"))
+
+  ## Table metadata is returned
+  expect_equal(names(result$tableMetadata), "presets")
+  expect_length(result$tableMetadata$presets, 2)
+  expect_names(result$tableMetadata$presets[[1]],
+               c("label", "column", "area_id"))
 })
 
 test_that("model calibration fails is version out of date", {

--- a/tests/testthat/test-05-calibrate.R
+++ b/tests/testthat/test-05-calibrate.R
@@ -152,8 +152,23 @@ test_that("can calibrate a model result", {
   ## Table metadata is returned
   expect_equal(names(result$tableMetadata), "presets")
   expect_length(result$tableMetadata$presets, 2)
-  expect_equal(names(result$tableMetadata$presets[[1]]),
+  expect_equal(names(result$tableMetadata$presets[[1]]$default),
                c("id", "label", "column", "row"))
+
+  table_filters1 <- result$tableMetadata$presets[[1]]$filters
+  filter_ids1 <- vcapply(table_filters1, "[[", "id")
+  expect_setequal(filter_ids1, c("area_level", "quarter", "sex", "age"))
+  area_level_filter <- table_filters1[filter_ids1 == "area_level"][[1]]
+  expect_equal(area_level_filter$column_id, scalar("area_level"))
+  expect_equal(area_level_filter$options[[1]],
+               list(id = scalar("0"), label = scalar("Country")))
+  other_table_filters <- table_filters1[filter_ids1 != "area_level"]
+  expect_true(all(other_table_filters %in% barchart$filters))
+
+  table_filters2 <- result$tableMetadata$presets[[2]]$filters
+  filter_ids2 <- vcapply(table_filters2, "[[", "id")
+  expect_setequal(filter_ids2, c("area", "quarter", "sex", "age"))
+  expect_equal(table_filters2, barchart$filters)
 })
 
 test_that("model calibration fails is version out of date", {

--- a/tests/testthat/test-05-calibrate.R
+++ b/tests/testthat/test-05-calibrate.R
@@ -153,7 +153,7 @@ test_that("can calibrate a model result", {
   expect_equal(names(result$tableMetadata), "presets")
   expect_length(result$tableMetadata$presets, 2)
   expect_equal(names(result$tableMetadata$presets[[1]]),
-               c("label", "column", "area_id"))
+               c("label", "column", "row"))
 })
 
 test_that("model calibration fails is version out of date", {

--- a/tests/testthat/test-filters.R
+++ b/tests/testthat/test-filters.R
@@ -246,7 +246,7 @@ test_that("error thrown for unknown type", {
 test_that("can get area filter option", {
   test_mock_model_available()
   output <- naomi::read_hintr_output(mock_calibrate$plot_data_path)
-  expect_equal(get_area_level_filter_option(output), list(
+  expect_equal(get_area_id_filter_default(output), list(
     list(
       id = scalar("MWI"),
       label = scalar("Malawi - Demo")
@@ -254,7 +254,7 @@ test_that("can get area filter option", {
   ))
 
   output$area_name[[1]] <- "test"
-  expect_equal(get_area_level_filter_option(output), list(
+  expect_equal(get_area_id_filter_default(output), list(
     list(
       id = scalar("MWI"),
       label = scalar("test")
@@ -262,7 +262,7 @@ test_that("can get area filter option", {
   ))
 
   output <- output[output$area_level != 0, ]
-  expect_equal(get_area_level_filter_option(output), list(
+  expect_equal(get_area_id_filter_default(output), list(
     list(
       id = scalar("MWI_1_1_demo"),
       label = scalar("Northern")


### PR DESCRIPTION
This PR will
* Add `tableMetadata` into the `/calibrate/result/metadata/<id>` and `/calibrate/result/<id>` endpoints which returns info related how the new output table should be displayed

Couple of things to note
* I added this to both endpoints because was keeping it up to date as I am still using it for some of the testing. Let me know if changing that causes a headache on your end. I'll make a ticket to rip that endpoint out entirely as I think it should no longer be being used?
* Compared to the spec, I've called the `filterSelections` `selected_filter_options` as this is what we do in the other endpoints which specify selected filters. Though worth noting the format here is slightly different, only returning IDs whereas the others return IDs and labels. I think I'll make a ticket to tidy that up in other places because no reason to return the label as that is duplicated info
* @EmmaLRussell slightly different than spec where we said we'd add a new endpoint, this is putting the data into an existing one. Any objections to that?