### PR TITLE
Add qs to duckdb migration code and script

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.1.17
+Version: 1.1.18
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.1.18
+
+* Add a function to migrate from naomi v 2.9.10 to 2.9.11. i.e. to migrate from plot data being stored as .qs files to being stored as duckdb database.
+
 # hintr 1.1.17
 
 * Add a dummy download endpoint of type "agyw" for generating AGYW (adolescent girls and young women) tool

--- a/R/migrations.R
+++ b/R/migrations.R
@@ -1,0 +1,93 @@
+run_migration <- function(queue, output_dir, from_version, to_version,
+                          dry_run = TRUE) {
+  output_dir <- normalizePath(output_dir, mustWork = TRUE)
+  tasks <- queue$queue$task_list()
+  status <- queue$queue$task_status(tasks)
+  completed_tasks <- tasks[status == "COMPLETE"]
+  migrations <- lapply(completed_tasks, migrate_task, queue,
+                       from_version, to_version, dry_run)
+  summary <- lapply(migrations, function(migration) {
+    list(
+      id = migration$id,
+      action = migration$action
+    )
+  })
+  summary <- do.call(rbind, summary)
+  summary_path <- file.path(output_dir, "summary.csv")
+  message(sprintf("Saving summary csv %s", summary_path))
+  output_path <- file.path(output_dir, "output.qs")
+  utils::write.csv(summary, summary_path, row.names = FALSE)
+  message(sprintf("Saving output qs %s", output_path))
+  qs::qsave(migrations, output_path, preset = "fast")
+  migrations
+}
+
+migrate_task <- function(task_id, queue, from_version, to_version, dry_run) {
+  message(sprintf("Migrating %s", task_id))
+  res <- queue$queue$task_result(task_id)
+  if (!naomi:::is_hintr_output(res) ||
+      !all(c("plot_data_path", "model_output_path") %in% names(res))) {
+    message(sprintf("Not migrating %s, invalid output format", task_id))
+    return(list(
+      id = task_id,
+      prev_res = res,
+      action = "No change - not migrateable"
+    ))
+  }
+  if (!is.null(res$version) &&
+      numeric_version(res$version) >= numeric_version(to_version)) {
+    message(sprintf("Not migrating %s, already up to date", task_id))
+    return(list(
+      id = task_id,
+      prev_res = res,
+      action = "No change - up to date"
+    ))
+  }
+  if (is.null(res$plot_data_path)) {
+    ## This will be null for model fits, only written out during calibrate
+    message(
+      sprintf("Not migrating %s, this result does not have plot data", task_id))
+    return(list(
+      id = task_id,
+      prev_res = res,
+      action = "No change - only migrating plot data and this result has none"
+    ))
+  }
+
+  new_res <- migrate(res, to_version, dry_run)
+  if (!dry_run) {
+    store <- rrq:::rrq_object_store(queue$queue$con,
+                                    r6_private(queue$queue)$keys)
+    hash <- store$set(new_res, task_id)
+    queue$queue$con$HSET(r6_private(queue$queue)$keys$task_result, task_id,
+                         hash)
+  }
+  out <- list(
+    id = task_id,
+    prev_res = res,
+    new_res = new_res,
+    from = from_version,
+    to = to_version,
+    action = "Successfully migrated"
+  )
+  message(sprintf("Successfully migrated %s", task_id))
+  out
+}
+
+migrate <- function(res, new_version, dry_run) {
+  plot_data <- naomi::read_hintr_output(res$plot_data_path)
+  new_plot_data_path <- tempfile("plot_data",
+                                 tmpdir = dirname(res$plot_data_path),
+                                 fileext = ".duckdb")
+  if (!dry_run) {
+    naomi:::hintr_save(plot_data, new_plot_data_path)
+    unlink(res$plot_data_path)
+  }
+  res$plot_data_path <- new_plot_data_path
+  res$version <- new_version
+  res
+}
+
+r6_private <- function(x) {
+  x[[".__enclos_env__"]]$private
+}

--- a/scripts/run_migration_2.9.10_2.9.11
+++ b/scripts/run_migration_2.9.10_2.9.11
@@ -1,0 +1,11 @@
+#!/usr/bin/env Rscript
+queue <- hintr:::Queue$new(workers = 0) ## Connect to running queue
+migrations_dir <- file.path("migrations")
+if (!file.exists(migrations_dir)) {
+  dir.create(migrations_dir)
+}
+path <- file.path(migrations_dir, "2.9.10-2.9.11")
+if (!file.exists(path)) {
+  dir.create(path)
+}
+hintr:::run_migration(queue, path, "2.9.10", "2.9.11")

--- a/scripts/run_migration_2.9.11
+++ b/scripts/run_migration_2.9.11
@@ -4,8 +4,8 @@ migrations_dir <- file.path("migrations")
 if (!file.exists(migrations_dir)) {
   dir.create(migrations_dir)
 }
-path <- file.path(migrations_dir, "2.9.10-2.9.11")
+path <- file.path(migrations_dir, "2.9.11")
 if (!file.exists(path)) {
   dir.create(path)
 }
-hintr:::run_migration(queue, path, "2.9.10", "2.9.11")
+hintr:::run_migration(queue, path, "2.9.11")

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -69,18 +69,41 @@ test_mock_model_available <- function() {
                  mock_calibrate$model_output_path, mock_spectrum$path,
                  mock_coarse_output$path, mock_summary$path)
   invisible(lapply(mock_data, function(x) {
-    if(!is.list(x) && !file.exists(x)) {
+    if (!is.list(x) && !file.exists(x)) {
       testthat::skip(sprintf(
         "Test data %s is missing - run ./scripts/build_test_data to create test data.", x))
     }
   }))
 }
 
+t_qs <- tempfile(fileext = ".qs")
+plot_data <- naomi::read_hintr_output(system.file("output", "malawi_calibrate_plot_data.duckdb", package = "hintr"))
+naomi:::hintr_save(plot_data, t_qs)
+
+## Model calibrate output as returned by
+## hintr version 1.0.8 to 1.1.15 and naomi version 2.5.6 to 2.9.10
+mock_calibrate_v1.1.15 <- list(
+  plot_data_path = t_qs,
+  model_output_path =
+    system.file("output", "malawi_calibrate_output.qs", package = "hintr"),
+  version = "2.9.10"
+)
+class(mock_calibrate) <- "hintr_output"
+
+## Model output as returned by
+## hintr version 0.1.39 to 1.0.7 and naomi version 2.4.3 to 2.5.4
+mock_model_v1.1.15 <- list(
+  plot_data_path = NULL,
+  model_output_path =
+    system.file("output", "malawi_model_output.qs", package = "hintr"),
+  version = "2.9.10"
+)
+class(mock_model) <- "hintr_output"
+
 ## Model calibrate output as returned by
 ## hintr version 0.1.39 to 1.0.7 and naomi version 2.4.3 to 2.5.6
 mock_calibrate_v1.0.7 <- list(
-  plot_data_path =
-    system.file("output", "malawi_calibrate_plot_data.duckdb", package = "hintr"),
+  plot_data_path = t_qs,
   model_output_path =
     system.file("output", "malawi_calibrate_output.qs", package = "hintr"),
   version = "2.5.6"
@@ -127,7 +150,8 @@ clone_model_output <- function(output) {
   file.copy(output$model_output_path, model_output_path)
   plot_data_path <- NULL
   if (!is.null(output$plot_data_path)) {
-    plot_data_path <- tempfile(fileext = ".duckdb")
+    fileext <- tools::file_ext(output$plot_data_path)
+    plot_data_path <- tempfile(fileext = paste0(".", fileext))
     file.copy(output$plot_data_path, plot_data_path)
   }
   out <- list(model_output_path = model_output_path,

--- a/tests/testthat/test-migrations.R
+++ b/tests/testthat/test-migrations.R
@@ -1,0 +1,236 @@
+test_that("single task can be migrated", {
+  test_mock_model_available()
+  q <- test_queue_result(model = mock_model_v1.1.15,
+                         calibrate = mock_calibrate_v1.1.15)
+  t <- tempfile()
+  dir.create(t)
+  expect_message(migrated <- migrate_task(q$calibrate_id, q$queue,
+                                          "2.9.10", "2.9.11", dry_run = FALSE),
+                 sprintf("Successfully migrated %s", q$calibrate_id))
+  expect_equal(migrated$id, q$calibrate_id)
+  expect_true(naomi:::is_hintr_output(migrated$new_res))
+  expect_equal(tools::file_ext(migrated$new_res$plot_data_path), "duckdb")
+  expect_true(file.exists(migrated$new_res$plot_data_path))
+  expect_equal(migrated$prev_res$model_output_path,
+               migrated$new_res$model_output_path)
+  expect_equal(migrated$new_res$version, "2.9.11")
+  expect_equal(migrated$from, "2.9.10")
+  expect_equal(migrated$to, "2.9.11")
+  expect_equal(migrated$action, "Successfully migrated")
+
+  ## Result has been migrated
+  res <- q$queue$result(q$calibrate_id)
+  expect_equal(res, migrated$new_res)
+
+  ## File is a duckdb file which can be read
+  expect_silent(naomi::read_hintr_output(migrated$new_res$plot_data_path))
+})
+
+test_that("already up to date task is not migrated", {
+  q <- test_queue_result()
+  t <- tempfile()
+  dir.create(t)
+  expect_message(migrated <- migrate_task(q$calibrate_id, q$queue,
+                                          "2.9.10", "2.9.11", dry_run = FALSE),
+                 sprintf("Not migrating %s, already up to date",
+                         q$calibrate_id))
+  expect_equal(migrated$id, q$calibrate_id)
+  expect_equal(migrated$prev_res, q$queue$result(q$calibrate_id))
+  expect_equal(migrated$action, "No change - up to date")
+})
+
+test_that("invalid output format is not migrated", {
+  test_mock_model_available()
+  q <- test_queue_result(model = mock_model_v0.1.2,
+                         calibrate = mock_model_v0.1.2,
+                         clone_output = FALSE)
+  t <- tempfile()
+  dir.create(t)
+  expect_message(migrated <- migrate_task(q$calibrate_id, q$queue,
+                                          "2.9.10", "2.9.11", dry_run = FALSE),
+                 sprintf("Not migrating %s, invalid output format",
+                         q$calibrate_id))
+  expect_equal(migrated$id, q$calibrate_id)
+  expect_equal(migrated$prev_res, q$queue$result(q$calibrate_id))
+  expect_equal(migrated$action, "No change - not migrateable")
+})
+
+test_that("model output is not migrated", {
+  test_mock_model_available()
+  q <- test_queue_result(model = mock_model_v1.1.15,
+                         calibrate = mock_calibrate_v1.1.15)
+  t <- tempfile()
+  dir.create(t)
+  expect_message(migrated <- migrate_task(q$model, q$queue,
+                                          "2.9.10", "2.9.11", dry_run = FALSE),
+                 sprintf(
+                   "Not migrating %s, this result does not have plot data",
+                   q$model_run_id))
+  expect_equal(migrated$id, q$model_run_id)
+  expect_equal(migrated$prev_res, q$queue$result(q$model_run_id))
+  expect_equal(migrated$action,
+               "No change - only migrating plot data and this result has none")
+})
+
+test_that("all tasks can be migrated", {
+  test_mock_model_available()
+  ## Get 4 task results, 1 mock run, 1 mock calibrate, 1 run, 1 calibrate
+  q <- test_queue_result(model = mock_model_v1.1.15,
+                         calibrate = mock_calibrate_v1.1.15)
+  model_payload <- setup_payload_submit()
+  model_submit <- submit_model(q$queue)
+  run_response <- model_submit(model_payload)
+  expect_true("id" %in% names(run_response))
+  result <- q$queue$queue$task_wait(run_response$id)
+
+  calibrate_payload <- setup_payload_calibrate()
+  model_calibrate <- submit_calibrate(q$queue)
+  calibrate_response <- model_calibrate(run_response$id, calibrate_payload)
+  expect_true("id" %in% names(calibrate_response))
+  result <- q$queue$queue$task_wait(calibrate_response$id)
+
+  ## Store some data we'll use for testing later
+  mock_run_result <- q$queue$result(q$model_run_id)
+  mock_calibrate_result <- q$queue$result(q$calibrate_id)
+  real_run_result <- q$queue$result(run_response$id)
+  real_calibrate_result <- q$queue$result(calibrate_response$id)
+
+  ## Run migration
+  t <- tempfile()
+  dir.create(t)
+  msg <- capture_messages(
+    migrate <- run_migration(q$queue, t, "2.9.10", "2.9.11", dry_run = FALSE))
+
+  expect_equal(sum(grepl("Migrating", msg)), 4) ## 4 Migrating messages
+  expect_equal(sum(grepl(sprintf(
+    "Not migrating %s", q$model_run_id), msg)), 1)
+  expect_equal(sum(grepl(sprintf(
+    "Successfully migrated %s", q$calibrate_id), msg)), 1)
+  expect_equal(sum(grepl(sprintf(
+    "Not migrating %s", run_response$id), msg)), 1)
+  expect_equal(sum(grepl(sprintf(
+    "Not migrating %s", calibrate_response$id), msg)), 1)
+  expect_equal(sum(grepl("Saving summary csv", msg)), 1)
+
+  expect_length(migrate, 4)
+  files <- list.files(t)
+  expect_length(files, 2)
+  summary <- read.csv(file.path(t, "summary.csv"))
+  expect_setequal(colnames(summary), c("id", "action"))
+  expect_equal(nrow(summary), 4)
+  expect_setequal(summary$id, c(q$model_run_id, q$calibrate_id, run_response$id,
+                                calibrate_response$id))
+  expect_setequal(
+    summary$action,
+    c("Successfully migrated", "No change - up to date",
+    "No change - only migrating plot data and this result has none"))
+
+  migration_output <- naomi::read_hintr_output(file.path(t, "output.qs"))
+  expect_equal(migration_output, migrate)
+
+  ## Data has been migrated
+  migrated_mock_run_result <- q$queue$result(q$model_run_id)
+  migrated_mock_calibrate_result <- q$queue$result(q$calibrate_id)
+  migrated_real_run_result <- q$queue$result(run_response$id)
+  migrated_real_calibrate_result <- q$queue$result(calibrate_response$id)
+
+  expect_equal(migrated_mock_run_result, mock_run_result)
+  expect_equal(names(mock_calibrate_result),
+               names(migrated_mock_calibrate_result))
+  expect_equal(mock_calibrate_result$model_output_path,
+               migrated_mock_calibrate_result$model_output_path)
+  expect_true(mock_calibrate_result$plot_data_path !=
+                migrated_mock_calibrate_result$plot_data_path)
+  expect_equal(tools::file_ext(migrated_mock_calibrate_result$plot_data_path),
+               "duckdb")
+  expect_equal(migrated_real_run_result, real_run_result)
+  expect_equal(migrated_real_calibrate_result, real_calibrate_result)
+})
+
+test_that("only completed tasks are migrated", {
+  test_mock_model_available()
+  ## Setup errored model run
+  queue <- MockQueue$new()
+  payload <- setup_payload_submit()
+  model_submit <- submit_model(queue)
+  response <- model_submit(payload)
+  expect_true("id" %in% names(response))
+  out <- queue$queue$task_wait(response$id)
+
+  expect_equal(out$status, "ERROR")
+
+  t <- tempfile()
+  dir.create(t)
+  msg <- capture_messages(migrated <- run_migration(queue, t, "2.9.10",
+                                                    "2.9.11", dry_run = FALSE))
+  expect_equal(sum(grepl("Migrating", msg)), 0) ## Nothing was migrated
+  expect_equal(migrated, list())
+})
+
+test_that("migration can be run in dry-run mode", {
+  test_mock_model_available()
+  ## Get 34task results, 1 mock run, 1 mock calibrate, 1 run, 1 calibrate
+  q <- test_queue_result(model = mock_model_v1.1.15,
+                         calibrate = mock_calibrate_v1.1.15)
+  model_payload <- setup_payload_submit()
+  model_submit <- submit_model(q$queue)
+  run_response <- model_submit(model_payload)
+  expect_true("id" %in% names(run_response))
+  result <- q$queue$queue$task_wait(run_response$id)
+
+  calibrate_payload <- setup_payload_calibrate()
+  model_calibrate <- submit_calibrate(q$queue)
+  calibrate_response <- model_calibrate(run_response$id, calibrate_payload)
+  expect_true("id" %in% names(calibrate_response))
+  result <- q$queue$queue$task_wait(calibrate_response$id)
+
+  ## Store some data we'll use for testing later
+  mock_run_result <- q$queue$result(q$model_run_id)
+  mock_calibrate_result <- q$queue$result(q$calibrate_id)
+  real_run_result <- q$queue$result(run_response$id)
+  real_calibrate_result <- q$queue$result(calibrate_response$id)
+
+  ## Run migration
+  t <- tempfile()
+  dir.create(t)
+  msg <- capture_messages(migrate <- run_migration(q$queue, t, "2.9.10",
+                                                   "2.9.11", dry_run = TRUE))
+
+  expect_equal(sum(grepl("Migrating", msg)), 4) ## 4 Migrating messages
+  expect_equal(sum(grepl(sprintf(
+    "Not migrating %s", q$model_run_id), msg)), 1)
+  expect_equal(sum(grepl(sprintf(
+    "Successfully migrated %s", q$calibrate_id), msg)), 1)
+  expect_equal(sum(grepl(sprintf(
+    "Not migrating %s", run_response$id), msg)), 1)
+  expect_equal(sum(grepl(sprintf(
+    "Not migrating %s", calibrate_response$id), msg)), 1)
+  expect_equal(sum(grepl("Saving summary csv", msg)), 1)
+
+  expect_length(migrate, 4)
+  files <- list.files(t)
+  expect_length(files, 2)
+  summary <- read.csv(file.path(t, "summary.csv"))
+  expect_setequal(colnames(summary), c("id", "action"))
+  expect_equal(nrow(summary), 4)
+  expect_setequal(summary$id, c(q$model_run_id, q$calibrate_id, run_response$id,
+                                calibrate_response$id))
+  expect_setequal(
+    summary$action,
+    c("Successfully migrated", "No change - up to date",
+      "No change - only migrating plot data and this result has none"))
+
+  migration_output <- qs::qread(file.path(t, "output.qs"))
+  expect_equal(migration_output, migrate)
+
+  ## Data has not been migrated
+  migrated_mock_run_result <- q$queue$result(q$model_run_id)
+  migrated_mock_calibrate_result <- q$queue$result(q$calibrate_id)
+  migrated_real_run_result <- q$queue$result(run_response$id)
+  migrated_real_calibrate_result <- q$queue$result(calibrate_response$id)
+
+  expect_equal(migrated_mock_run_result, mock_run_result)
+  expect_equal(migrated_mock_calibrate_result, mock_calibrate_result)
+  expect_equal(migrated_real_run_result, real_run_result)
+  expect_equal(migrated_real_calibrate_result, real_calibrate_result)
+})


### PR DESCRIPTION
This PR will add some migration code to migrate from v2.9.10 to 2.9.11 and a script to run it. I've setup the code in a way that we could extend with more migrations in the future, though will need a little work to actually switch out the function which does the migration work, but should be decent start point. (Thinking we'll have to write one to migrate to duckdb 1.0.0 whenever that is released). The migration is quite chatty, and it will save out a qs file with a log of what happened during running so we should be able to see why things might be skipped.

This is a little hairy in places. The actual migration is fairly simple, read a file into memory and write it back out. But there is lots of book keeping around it. Happy to chat through if helpful.

My plan for running this would be
* Locate a project with a duckdb fit, and one with a qs fit
* Kill the front end
* Do a backup (with privateer or otherwise)
* Run migration
* Restart app
* Check both projects still load

