### PR TITLE
Ensure options passed in by updating schema

### DIFF
--- a/R/model_options.R
+++ b/R/model_options.R
@@ -187,10 +187,10 @@ get_survey_options <- function(survey_data, metadata, indicator) {
                                        indicator)
   if (nrow(indicator_data) == 0) {
     ## Gets serialised to JSON and requires an obj
-    ## for options NULL -> {}
+    ## for options list -> []
     ## a string for default values
     return(list(
-      options = NULL,
+      options = list(),
       default = scalar("")
     ))
   }

--- a/inst/schema/ModelRunOptions.schema.json
+++ b/inst/schema/ModelRunOptions.schema.json
@@ -28,7 +28,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [ "name", "type", "required" ]
+      "required": [ "name", "type", "required", "options" ]
     },
     "multiselectControl": {
       "type": "object",
@@ -65,7 +65,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [ "name", "type", "required" ]
+      "required": [ "name", "type", "required", "options" ]
     },
     "numberControl": {
       "type": "object",


### PR DESCRIPTION
Not quite sure how this was ever working but we have some issues with options at the moment. 

We're getting some options coming through as e.g.

```
"controls": [
            {"name":"survey_recently_infected","type":"multiselect","required":false,"value":""}
          ]
```

Now having empty string value is valid and until (some point) has been interpreted as no item selected. So that is some unrelated issue I am looking at fixing. But spotted this other potential issue whilst I was at it. vue-next-dynamic-form expects the options to always exist but it that isn't guaranteed by the schema at the moment. So I've updated that to ensure that the schema says it must exist, though it still could be empty