### PR TITLE
Add label and id to table metadata for column and row

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.1.20
+Version: 1.1.21
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# hintr 1.1.21
+
+* Update `tableMetadata` to return `id` and `label` for `row` and `column` values.
+
 # hintr 1.1.20
 
-* Add `tableMetadata` into the `calibrate/result/<id>` and `calibrate/result/metadata/<id>` endpoints for controling how the new output table feature will look
+* Add `tableMetadata` into the `calibrate/result/<id>` and `calibrate/result/metadata/<id>` endpoints for controlling how the new output table feature will look
 
 # hintr 1.1.19
 

--- a/R/filters.R
+++ b/R/filters.R
@@ -217,7 +217,7 @@ get_area_level_filter <- function(data) {
   list(
     id = scalar("area_level"),
     column_id = scalar("area_level"),
-    label = scalar(t_("OUTPUT_FILTER_AREA_LEVEL")),
+    label = scalar(t_("OUTPUT_FILTER_DETAIL_LEVEL")),
     options = get_area_level_filters(data)
   )
 }

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -119,8 +119,14 @@ build_output_table_metadata <- function(output, filters) {
     defaults = list(
       id = scalar("sex_by_area"),
       label = scalar(t_("TABLE_SEX_BY_AREA")),
-      column = scalar("sex"),
-      row = scalar("area_id")
+      column = list(
+        id = scalar("sex"),
+        label = scalar(t_("OUTPUT_FILTER_SEX"))
+      ),
+      row = list(
+        id = scalar("area_id"),
+        label = scalar(t_("OUTPUT_COLUMN_DETAIL_LEVEL"))
+      )
     )
   )
   sex_by_5_year_age_group <- list(
@@ -128,8 +134,14 @@ build_output_table_metadata <- function(output, filters) {
     defaults = list(
       id = scalar("sex_by_5_year_age_group"),
       label = scalar(t_("TABLE_SEX_BY_5_YEAR_AGE_GROUP")),
-      column = scalar("sex"),
-      row = scalar("age_group"),
+      column = list(
+        id = scalar("sex"),
+        label = scalar(t_("OUTPUT_FILTER_SEX"))
+      ),
+      row = list(
+        id = scalar("age_group"),
+        label = scalar(t_("OUTPUT_FILTER_AGE"))
+      ),
       selected_filter_options = list(
         age = naomi::get_five_year_age_groups()
       )

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -125,7 +125,7 @@ build_output_table_metadata <- function(output, filters) {
       ),
       row = list(
         id = scalar("area_id"),
-        label = scalar(t_("OUTPUT_COLUMN_DETAIL_LEVEL"))
+        label = scalar(t_("OUTPUT_FILTER_AREA"))
       )
     )
   )

--- a/inst/schema/TableMetadata.schema.json
+++ b/inst/schema/TableMetadata.schema.json
@@ -7,8 +7,24 @@
       "properties": {
         "id": { "type": "string" },
         "label": { "type": "string" },
-        "column": { "type": "string" },
-        "row": { "type": "string" },
+        "column": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "label": { "type": "string" }
+          },
+          "additionalProperties": false,
+          "required": [ "id", "label" ]
+        },
+        "row": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "label": { "type": "string" }
+          },
+          "additionalProperties": false,
+          "required": [ "id", "label" ]
+        },
         "selected_filter_options": {
           "type": "object",
           "patternProperties": {

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -62,7 +62,7 @@
     "QUEUE_STOPPING_WORKERS": "Stopping workers",
     "QUEUE_ID_NOT_SET": "Environment variable 'HINTR_QUEUE_ID' is not set",
     "METADATA_BUILD_INDICATOR": "Expected only 1 row for indicator, data type, plot type combination.\nCheck each combination is unique in configuration.",
-    "OUTPUT_COLUMN_DETAIL_LEVEL": "Detail",
+    "OUTPUT_FILTER_DETAIL_LEVEL": "Detail",
     "OUTPUT_FILTER_AREA": "Area",
     "OUTPUT_FILTER_PERIOD": "Period",
     "OUTPUT_FILTER_SEX": "Sex",

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -62,6 +62,7 @@
     "QUEUE_STOPPING_WORKERS": "Stopping workers",
     "QUEUE_ID_NOT_SET": "Environment variable 'HINTR_QUEUE_ID' is not set",
     "METADATA_BUILD_INDICATOR": "Expected only 1 row for indicator, data type, plot type combination.\nCheck each combination is unique in configuration.",
+    "OUTPUT_COLUMN_DETAIL_LEVEL": "Detail",
     "OUTPUT_FILTER_AREA": "Area",
     "OUTPUT_FILTER_PERIOD": "Period",
     "OUTPUT_FILTER_SEX": "Sex",

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -62,6 +62,7 @@
     "QUEUE_STOPPING_WORKERS": "Arrêt des travailleurs",
     "QUEUE_ID_NOT_SET": "La variable d'environnement « HINTR_QUEUE_ID » n'est pas définie",
     "METADATA_BUILD_INDICATOR": "1 ligne seule est attendue pour l'indicateur, le type de données, la combinaison de type de graphique.\nVérifiez que chaque combinaison est unique dans sa configuration.",
+    "OUTPUT_COLUMN_DETAIL_LEVEL": "Détail",
     "OUTPUT_FILTER_AREA": "Zone",
     "OUTPUT_FILTER_PERIOD": "Période",
     "OUTPUT_FILTER_SEX": "Sexe",

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -62,7 +62,7 @@
     "QUEUE_STOPPING_WORKERS": "Arrêt des travailleurs",
     "QUEUE_ID_NOT_SET": "La variable d'environnement « HINTR_QUEUE_ID » n'est pas définie",
     "METADATA_BUILD_INDICATOR": "1 ligne seule est attendue pour l'indicateur, le type de données, la combinaison de type de graphique.\nVérifiez que chaque combinaison est unique dans sa configuration.",
-    "OUTPUT_COLUMN_DETAIL_LEVEL": "Détail",
+    "OUTPUT_FILTER_DETAIL_LEVEL": "Détail",
     "OUTPUT_FILTER_AREA": "Zone",
     "OUTPUT_FILTER_PERIOD": "Période",
     "OUTPUT_FILTER_SEX": "Sexe",

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -23,6 +23,7 @@
     "MODEL_RESULT_OLD": "Não é possível descarregar {{type}}, por favor, volte a executar o modelo e tente descarregar novamente.",
     "MODEL_RUN_CANCELLED": "A execução do modelo foi cancelada pelo utilizador",
     "MODEL_SUBMIT_OLD": "A tentar executar o modelo com uma versão antiga das opções. Atualizar opções de execução do modelo",
+    "OUTPUT_COLUMN_DETAIL_LEVEL": "Detalhe",
     "OUTPUT_FILTER_AGE": "Idade",
     "OUTPUT_FILTER_AREA": "Área",
     "OUTPUT_FILTER_PERIOD": "Período",

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -23,7 +23,7 @@
     "MODEL_RESULT_OLD": "Não é possível descarregar {{type}}, por favor, volte a executar o modelo e tente descarregar novamente.",
     "MODEL_RUN_CANCELLED": "A execução do modelo foi cancelada pelo utilizador",
     "MODEL_SUBMIT_OLD": "A tentar executar o modelo com uma versão antiga das opções. Atualizar opções de execução do modelo",
-    "OUTPUT_COLUMN_DETAIL_LEVEL": "Detalhe",
+    "OUTPUT_FILTER_DETAIL_LEVEL": "Detalhe",
     "OUTPUT_FILTER_AGE": "Idade",
     "OUTPUT_FILTER_AREA": "Área",
     "OUTPUT_FILTER_PERIOD": "Período",

--- a/tests/testthat/test-03-run-model.R
+++ b/tests/testthat/test-03-run-model.R
@@ -12,9 +12,9 @@ test_that("model can be run & calibrated and filters extracted", {
   ## All table metadata rows and columns come from the data
   data_names <- names(res$data)
   for (preset in res$tableMetadata$presets) {
-    expect_true(preset$defaults$column %in% data_names,
+    expect_true(preset$defaults$column$id %in% data_names,
                 sprintf("Column '%s' not a valid data column", preset$column))
-    expect_true(preset$defaults$row %in% data_names,
+    expect_true(preset$defaults$row$id %in% data_names,
                 sprintf("Row '%s' not a valid data column", preset$row))
   }
 

--- a/tests/testthat/test-validation-asserts.R
+++ b/tests/testthat/test-validation-asserts.R
@@ -308,7 +308,8 @@ test_that("can check for non NA values", {
 test_that("can assert data has to have 1 area level", {
   testthat::skip_on_covr()
   data <- read_csv("testdata/programme.csv")
-  shape_regions <- read_geojson_data(list(path = "testdata/malawi.geojson"))
+  shape_regions <- read_geojson_data(list(path = "testdata/malawi.geojson",
+                                          hash = "123"))
   expect_true(assert_single_level_per_year(shape_regions, data))
   data$area_id[1] <- "MWI_2_1_demo"
   data$area_id[3] <- "MWI_2_1_demo"


### PR DESCRIPTION
Change `column` and `row` in the table metadata from a string to an object with `id` and `label` fields. `id` used for finding the values in the raw data and the `label` is what should be displayed