### PR TITLE
Remove hardcoded default for ANC time 2 values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.1.21
+Version: 1.1.22
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hintr 1.1.22
+
+* Remove hardcoded year2 value for ANC prevalance and ANC ART coverage
+
 # hintr 1.1.21
 
 * Update `tableMetadata` to return `id` and `label` for `row` and `column` values.

--- a/R/model_options.R
+++ b/R/model_options.R
@@ -91,7 +91,7 @@ do_endpoint_model_options <- function(shape, survey, programme, anc) {
     survey_prevalence = survey_prevalence_options$default,
     survey_art_coverage = survey_art_coverage_options$default,
     anc_prevalence_year1 = anc_year1_default,
-    anc_art_coverage_year1 = anc_year1_default,
+    anc_art_coverage_year1 = anc_year1_default
   )
 
   additional_control_groups <- NULL

--- a/R/model_options.R
+++ b/R/model_options.R
@@ -56,7 +56,6 @@ do_endpoint_model_options <- function(shape, survey, programme, anc) {
   ## ANC options
   anc_year_options <- NULL
   anc_year1_default <- scalar("")
-  anc_year2_default <- scalar("")
   if (has_anc) {
     anc_data <- as.data.frame(naomi::read_anc_testing(anc$path))
     anc_years <- get_years(anc_data)
@@ -64,9 +63,6 @@ do_endpoint_model_options <- function(shape, survey, programme, anc) {
       list(id = scalar(as.character(year)),
            label = scalar(as.character(year)))
     })
-    if (2022 %in% anc_years) {
-      anc_year2_default <- scalar(as.character(2022))
-    }
     survey_year <- naomi::calendar_quarter_to_year(most_recent_survey_quarter)
     if (survey_year %in% anc_years) {
       anc_year1_default <- scalar(as.character(survey_year))
@@ -95,9 +91,7 @@ do_endpoint_model_options <- function(shape, survey, programme, anc) {
     survey_prevalence = survey_prevalence_options$default,
     survey_art_coverage = survey_art_coverage_options$default,
     anc_prevalence_year1 = anc_year1_default,
-    anc_prevalence_year2 = anc_year2_default,
     anc_art_coverage_year1 = anc_year1_default,
-    anc_art_coverage_year2 = anc_year2_default
   )
 
   additional_control_groups <- NULL

--- a/tests/testthat/test-endpoints-model-options.R
+++ b/tests/testthat/test-endpoints-model-options.R
@@ -1,10 +1,10 @@
 gc()
 
 test_that("endpoint_model_options returns model options", {
-  input <- model_options_input(file.path("testdata", "malawi.geojson"),
-                               file.path("testdata", "survey.csv"),
-                               file.path("testdata", "programme.csv"),
-                               file.path("testdata", "anc.csv"))
+  input <- model_options_input(test_path("testdata", "malawi.geojson"),
+                               test_path("testdata", "survey.csv"),
+                               test_path("testdata", "programme.csv"),
+                               test_path("testdata", "anc.csv"))
   response <- model_options(input)
   json <- jsonlite::parse_json(response)
 

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -77,16 +77,13 @@ test_that("do_endpoint_model_options correctly builds options and fallbacks", {
                   c("area_scope",
                     "calendar_quarter_t1", "survey_prevalence",
                     "survey_art_coverage", "anc_prevalence_year1",
-                    "anc_prevalence_year2", "anc_art_coverage_year1",
-                    "anc_art_coverage_year2"))
+                    "anc_art_coverage_year1"))
   expect_equal(overrides$area_scope, scalar("MWI"))
   expect_equal(overrides$calendar_quarter_t1, scalar("CY2016Q1"))
   expect_equal(overrides$survey_prevalence, scalar("DEMO2016PHIA"))
   expect_equal(overrides$survey_art_coverage, scalar("DEMO2016PHIA"))
   expect_equal(overrides$anc_prevalence_year1, scalar("2016"))
-  expect_equal(overrides$anc_prevalence_year2, scalar(""))
   expect_equal(overrides$anc_art_coverage_year1, scalar("2016"))
-  expect_equal(overrides$anc_art_coverage_year2, scalar(""))
 })
 
 test_that("do_endpoint_model_options without programme data", {
@@ -156,10 +153,10 @@ test_that("do_endpoint_model_options without programme data", {
 })
 
 test_that("do_endpoint_model_options overrides anc year2 to 2022 if in data", {
-  shape <- file_object(file.path("testdata", "malawi.geojson"))
-  survey <- file_object(file.path("testdata", "survey.csv"))
-  art <- file_object(file.path("testdata", "programme.csv"))
-  anc <- file_object(file.path("testdata", "anc.csv"))
+  shape <- file_object(test_path("testdata", "malawi.geojson"))
+  survey <- file_object(test_path("testdata", "survey.csv"))
+  art <- file_object(test_path("testdata", "programme.csv"))
+  anc <- file_object(test_path("testdata", "anc.csv"))
 
   mock_get_controls_json <- mockery::mock('"{"test"}')
   mock_get_years <- mockery::mock(c(2022, 2021, 2020, 2019))
@@ -169,8 +166,6 @@ test_that("do_endpoint_model_options overrides anc year2 to 2022 if in data", {
     args <- mockery::mock_args(mock_get_controls_json)
   })
   overrides <- args[[1]][[4]]
-  expect_equal(overrides$anc_prevalence_year2, scalar("2022"))
-  expect_equal(overrides$anc_art_coverage_year2, scalar("2022"))
   ## Year 1 defaults are NULL as survey year not in ANC years
   expect_equal(overrides$anc_prevalence_year1, scalar(""))
   expect_equal(overrides$anc_art_coverage_year1, scalar(""))


### PR DESCRIPTION
As requested by Rachel after Uganda workshop, see https://teams.microsoft.com/l/message/19:83f74f91587b4848a35c45bca0c3a2b1@thread.tacv2/1702549272427?tenantId=2b897507-ee8c-4575-830b-4f8267c3d307&groupId=e24ac85e-dd9e-4505-8b9e-047b3a5fa6f0&parentMessageId=1702549272427&teamName=HIV%20Inference%20Group%20-%20WP&channelName=Naomi&createdTime=1702549272427&allowXTenantAccess=false