### PR TITLE
mrc-5119: Improve error message handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,6 +45,7 @@ Suggests:
     redux,
     ssh,
     testthat (>= 2.1.0),
+    tidyselect,
     withr
 Remotes:
     mrc-ide/geojsonio,

--- a/R/adr_metadata.R
+++ b/R/adr_metadata.R
@@ -2,11 +2,11 @@ adr_metadata <- function(queue) {
   function(id) {
     tryCatch({
       res <- queue$result(id)
-      if (is_error(res) || is.null(res$path)) {
-        msg <- res$message
-        if (is.null(msg)) {
-          msg <- t_("FAILED_ADR_METADATA")
-        }
+      if (is_error(res)) {
+        msg <- api_error_msg(res)
+        hintr_error(msg, "OUTPUT_GENERATION_FAILED")
+      } else if (is.null(res$path)) {
+        msg <- t_("FAILED_ADR_METADATA")
         hintr_error(msg, "OUTPUT_GENERATION_FAILED")
       }
       list(type = scalar(res$metadata$type),
@@ -16,7 +16,7 @@ adr_metadata <- function(queue) {
       if (is_porcelain_error(e)) {
         stop(e)
       } else {
-        hintr_error(e$message, "FAILED_TO_RETRIEVE_RESULT")
+        hintr_error(api_error_msg(e), "FAILED_TO_RETRIEVE_RESULT")
       }
     })
   }

--- a/R/adr_metadata.R
+++ b/R/adr_metadata.R
@@ -1,14 +1,7 @@
 adr_metadata <- function(queue) {
   function(id) {
     tryCatch({
-      res <- queue$result(id)
-      if (is_error(res)) {
-        msg <- api_error_msg(res)
-        hintr_error(msg, "OUTPUT_GENERATION_FAILED")
-      } else if (is.null(res$path)) {
-        msg <- t_("FAILED_ADR_METADATA")
-        hintr_error(msg, "OUTPUT_GENERATION_FAILED")
-      }
+      res <- get_download_result(queue, id, "FAILED_ADR_METADATA")
       list(type = scalar(res$metadata$type),
            description = scalar(res$metadata$description))
     },

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -390,17 +390,22 @@ download_submit <- function(queue) {
   }
 }
 
+get_download_result <- function(queue, id, error_message) {
+  res <- queue$result(id)
+  if (is_error(res)) {
+    msg <- api_error_msg(res)
+    hintr_error(msg, "OUTPUT_GENERATION_FAILED")
+  } else if (is.null(res$path)) {
+    msg <- t_(error_message)
+    hintr_error(msg, "OUTPUT_GENERATION_FAILED")
+  }
+  res
+}
+
 download_result <- function(queue) {
   function(id) {
     tryCatch({
-      res <- queue$result(id)
-      if (is_error(res)) {
-        msg <- api_error_msg(res)
-        hintr_error(msg, "OUTPUT_GENERATION_FAILED")
-      } else if (is.null(res$path)) {
-        msg <- t_("FAILED_DOWNLOAD")
-        hintr_error(msg, "OUTPUT_GENERATION_FAILED")
-      }
+      res <- get_download_result(queue, id, "FAILED_DOWNLOAD")
       filename <- switch(res$metadata$type,
                          spectrum = "naomi-output",
                          coarse_output = "coarse-output",

--- a/R/endpoints.R
+++ b/R/endpoints.R
@@ -25,7 +25,7 @@ model_options <- function(input) {
     ## Get the cache for no reason as this seems to prevent flaky test failure
     ## due to caching, see https://buildkite.com/mrc-ide/hintr/builds/1619
     cache <- get_cache(NULL)
-    hintr_error(e$message, "INVALID_OPTIONS")
+    hintr_error(api_error_msg(e), "INVALID_OPTIONS")
   })
 }
 
@@ -34,7 +34,7 @@ calibration_options <- function(iso3) {
     json_verbatim(
       get_controls_json("calibration", iso3, NULL, NULL))
   }, error = function(e) {
-    hintr_error(e$message, "INVALID_CALIBRATION_OPTIONS")
+    hintr_error(api_error_msg(e), "INVALID_CALIBRATION_OPTIONS")
   })
 }
 
@@ -60,7 +60,7 @@ validate_baseline <- function(input) {
     input_response(validate_func(input$file), input$type, input$file)
   },
   error = function(e) {
-    hintr_error(e$message, "INVALID_FILE")
+    hintr_error(api_error_msg(e), "INVALID_FILE")
   })
 }
 
@@ -79,7 +79,7 @@ validate_baseline_combined <- function(input) {
                          as_file_object(input$population))
   },
   error = function(e) {
-    hintr_error(e$message, "INVALID_BASELINE")
+    hintr_error(api_error_msg(e), "INVALID_BASELINE")
   })
 }
 
@@ -98,7 +98,7 @@ validate_survey_programme <- function(input, strict = TRUE) {
       validate_func(input$file, shape, strict), input$type, input$file)
   },
   error = function(e) {
-    hintr_error(e$message, "INVALID_FILE")
+    hintr_error(api_error_msg(e), "INVALID_FILE")
   })
 }
 
@@ -123,7 +123,7 @@ input_time_series <- function(type, input) {
     get_time_series_data(file, input$data$shape)
   },
   error = function(e) {
-    hintr_error(e$message, "FAILED_TO_GENERATE_TIME_SERIES")
+    hintr_error(api_error_msg(e), "FAILED_TO_GENERATE_TIME_SERIES")
   })
 }
 
@@ -145,7 +145,7 @@ model_options_validate <- function(input) {
     valid$warnings <- warnings_scalar(valid$warnings)
     valid
   }, error = function(e) {
-    hintr_error(e$message, "INVALID_OPTIONS")
+    hintr_error(api_error_msg(e), "INVALID_OPTIONS")
   })
 }
 
@@ -162,7 +162,7 @@ submit_model <- function(queue) {
     tryCatch(
       list(id = scalar(queue$submit_model_run(input$data, input$options))),
       error = function(e) {
-        hintr_error(e$message, "FAILED_TO_QUEUE")
+        hintr_error(api_error_msg(e), "FAILED_TO_QUEUE")
       }
     )
   }
@@ -177,7 +177,7 @@ queue_status <- function(queue) {
       prepare_status_response(out, id)
     },
     error = function(e) {
-      hintr_error(e$message, "FAILED_TO_RETRIEVE_STATUS")
+      hintr_error(api_error_msg(e), "FAILED_TO_RETRIEVE_STATUS")
     })
   }
 }
@@ -207,7 +207,7 @@ submit_calibrate <- function(queue) {
       list(id = scalar(queue$submit_calibrate(queue$result(id),
                                               calibration_options$options))),
       error = function(e) {
-        hintr_error(e$message, "FAILED_TO_QUEUE")
+        hintr_error(api_error_msg(e), "FAILED_TO_QUEUE")
       }
     )
   }
@@ -317,7 +317,8 @@ verify_result_available <- function(queue, id, version = NULL) {
     naomi:::assert_model_output_version(result, version = version)
   } else if (task_status == "ERROR") {
     result <- queue$result(id)
-    hintr_error(result$message, "MODEL_RUN_FAILED", job_id = scalar(id))
+    hintr_error(api_error_msg(result), "MODEL_RUN_FAILED",
+                job_id = scalar(id))
   } else if (task_status == "DIED") {
     hintr_error(t_("MODEL_RESULT_CRASH"), "MODEL_RUN_FAILED")
   } else if (task_status == "CANCELLED") {
@@ -334,7 +335,7 @@ model_cancel <- function(queue) {
       json_null()
     },
     error = function(e) {
-      hintr_error(e$message, "FAILED_TO_CANCEL")
+      hintr_error(api_error_msg(e), "FAILED_TO_CANCEL")
     })
   }
 }
@@ -343,7 +344,7 @@ plotting_metadata <- function(iso3 = NULL) {
   tryCatch(
     do_plotting_metadata(iso3),
     error = function(e) {
-      hintr_error(e$message, "FAILED_TO_GET_METADATA")
+      hintr_error(api_error_msg(e), "FAILED_TO_GET_METADATA")
     }
   )
 }
@@ -383,7 +384,7 @@ download_submit <- function(queue) {
       list(id = scalar(
         queue$submit_download(queue$result(id), type, prepared_input))),
       error = function(e) {
-        hintr_error(e$message, "FAILED_TO_QUEUE")
+        hintr_error(api_error_msg(e), "FAILED_TO_QUEUE")
       }
     )
   }
@@ -393,11 +394,11 @@ download_result <- function(queue) {
   function(id) {
     tryCatch({
       res <- queue$result(id)
-      if (is_error(res) || is.null(res$path)) {
-        msg <- res$message
-        if (is.null(msg)) {
-          msg <- t_("FAILED_ADR_METADATA")
-        }
+      if (is_error(res)) {
+        msg <- api_error_msg(res)
+        hintr_error(msg, "OUTPUT_GENERATION_FAILED")
+      } else if (is.null(res$path)) {
+        msg <- t_("FAILED_DOWNLOAD")
         hintr_error(msg, "OUTPUT_GENERATION_FAILED")
       }
       filename <- switch(res$metadata$type,
@@ -423,7 +424,7 @@ download_result <- function(queue) {
       if (is_porcelain_error(e)) {
         stop(e)
       } else {
-        hintr_error(e$message, "FAILED_TO_RETRIEVE_RESULT")
+        hintr_error(api_error_msg(e), "FAILED_TO_RETRIEVE_RESULT")
       }
     })
   }
@@ -493,7 +494,7 @@ download_model_debug <- function(queue) {
       if (is_porcelain_error(e)) {
         stop(e)
       } else {
-        hintr_error(e$message, "INVALID_TASK")
+        hintr_error(api_error_msg(e), "INVALID_TASK")
       }
     })
   }

--- a/R/rehydrate.R
+++ b/R/rehydrate.R
@@ -26,7 +26,7 @@ rehydrate_submit <- function(queue) {
       assert_file_exists(input$file$path)
       list(id = scalar(queue$submit_rehydrate(input$file)))
     }, error = function(e) {
-      hintr_error(e$message, "REHYDRATE_SUBMIT_FAILED")
+      hintr_error(api_error_msg(e), "REHYDRATE_SUBMIT_FAILED")
     })
   }
 }
@@ -35,7 +35,7 @@ rehydrate_result <- function(queue) {
   function(id) {
     res <- queue$result(id)
     if (is_error(res)) {
-      hintr_error(res$message, "PROJECT_REHYDRATE_FAILED")
+      hintr_error(api_error_msg(res), "PROJECT_REHYDRATE_FAILED")
     }
     res
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -164,3 +164,11 @@ assert_names <- function(items, required, optional,
 r6_private <- function(x) {
   x[[".__enclos_env__"]]$private
 }
+
+## We want to be able to format both rlang_error type errors, hintr
+## errors and standard errors in a way that in an issue report it will
+## be easily readable.
+## In particular tidyselect returns error messages without a $message.
+api_error_msg <- function(e) {
+  cli::ansi_strip(conditionMessage(e))
+}

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -73,6 +73,7 @@
     "OUTPUT_GENERATION_FAILED": "Failed to generate output",
     "INVALID_DOWNLOAD_TYPE": "Failed to generate download for {{type}} type, contact system admin.",
     "FAILED_ADR_METADATA": "Failed to generate metadata, output format is invalid",
+    "FAILED_DOWNLOAD": "Failed to generate download, output format is invalid",
     "UNKNOWN_OUTPUT_TYPE": "Model run returned unknown output type, please contact support.",
     "INVALID_TIME_SERIES_INPUT_TYPE": "Time series data can only be returned for {{types}}, received '{{type}}'.",
     "INPUT_TIME_SERIES_COLUMN_PLOT_TYPE": "Plot type",

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -73,6 +73,7 @@
     "OUTPUT_GENERATION_FAILED": "Impossible de générer une sortie",
     "INVALID_DOWNLOAD_TYPE": "Impossible de générer le téléchargement pour le type de {{type}}, contactez l'administrateur système.",
     "FAILED_ADR_METADATA": "Échec de la génération des métadonnées, le format de sortie n'est pas valide.",
+    "FAILED_DOWNLOAD": "Échec de la génération du téléchargement, le format de sortie n'est pas valide",
     "UNKNOWN_OUTPUT_TYPE": "L'exécution du modèle a renvoyé un type de sortie inconnu, veuillez contacter le support.",
     "INVALID_TIME_SERIES_INPUT_TYPE": "Les données de séries chronologiques ne peuvent être retournées que pour {{types}}, reçu '{{type}}'.",
     "INPUT_TIME_SERIES_COLUMN_PLOT_TYPE": "Type de parcelle",

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -73,6 +73,7 @@
     "OUTPUT_GENERATION_FAILED": "Falha em gerar resultados",
     "INVALID_DOWNLOAD_TYPE": "Falha em gerar o download para o tipo {{type}}, contactar o administrador do sistema.",
     "FAILED_ADR_METADATA": "Falha na geração de metadados, o formato de saída é inválido",
+    "FAILED_DOWNLOAD": "Falha ao gerar a transferência, o formato de saída é inválido",
     "INVALID_TIME_SERIES_INPUT_TYPE": "Os dados das séries cronológicas só podem ser devolvidos para {{types}}, recebidos '{{type}}'.",
     "INPUT_TIME_SERIES_COLUMN_PLOT_TYPE": "Tipo de terreno",
     "INPUT_TIME_SERIES_COLUMN_AREA_LEVEL": "Nível de área",

--- a/tests/testthat/helper-queue.R
+++ b/tests/testthat/helper-queue.R
@@ -14,7 +14,7 @@ MockQueue <- R6::R6Class(
   cloneable = FALSE,
   public = list(
     submit = function(job, queue, environment = parent.frame()) {
-      self$queue$enqueue_(quote(stop("test error")))
+      self$queue$enqueue_(quote(cli::cli_abort("test error")))
     },
 
     submit_model = function(data, options) {

--- a/tests/testthat/test-01-endpoints-download.R
+++ b/tests/testthat/test-01-endpoints-download.R
@@ -375,7 +375,7 @@ test_that("trying to get download with invalid result returns error", {
   out <- endpoint$run(q$calibrate_id)
   expect_equal(out$error$data[[1]]$error, scalar("OUTPUT_GENERATION_FAILED"))
   expect_match(out$error$data[[1]]$detail,
-               scalar("Failed to generate metadata, output format is invalid"))
+               scalar("Failed to generate download, output format is invalid"))
   expect_equal(out$status_code, 400)
 })
 

--- a/tests/testthat/test-endpoints-upload.R
+++ b/tests/testthat/test-endpoints-upload.R
@@ -47,7 +47,7 @@ test_that("api can upload input files", {
   res2 <- api$request("POST", "/internal/upload/input/survey_data.csv",
                       body = charToRaw(file))
 
-  expect_equal(res, res2)
+  expect_equal(res$body, res2$body)
 
   ## File has not been uploaded
   expect_length(list.files(inputs_dir), 1)
@@ -73,7 +73,7 @@ test_that("can upload output files", {
   ## Uploading again
   res2 <- endpoint$run(charToRaw(file), "survey_data.csv")
 
-  expect_equal(res, res2)
+  expect_equal(res$body, res2$body)
 
   ## File has not been uploaded
   expect_length(list.files(results_dir), 1)
@@ -102,7 +102,7 @@ test_that("api can upload output files", {
   res2 <- api$request("POST", "/internal/upload/result/survey_data.csv",
                       body = charToRaw(file))
 
-  expect_equal(res, res2)
+  expect_equal(res$body, res2$body)
 
   ## File has not been uploaded
   expect_length(list.files(results_dir), 1)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -123,3 +123,22 @@ test_that("assert_names", {
                "Unknown item(s) five are included in input",
                fixed = TRUE)
 })
+
+
+test_that("can format error messages", {
+  test_error <- function(x) {
+    tryCatch(
+      force(x),
+      error = function(e) {
+        api_error_msg(e)
+      })
+  }
+
+  d <- data.frame(x = c(1, 2))
+  expect_match(test_error(tidyselect::eval_select("y", d)),
+               "Column `y` doesn't exist.")
+  expect_equal(test_error(stop("test error")), "test error")
+  expect_equal(test_error(cli::cli_abort("test error")), "test error")
+  expect_equal(test_error(hintr_error("test error", "MY_ERR")),
+               "porcelain_error:\n  * MY_ERR: test error")
+})


### PR DESCRIPTION
To deal with the case where errors from tidyselect are coming through without a message.

See notes in the ticket for context here. We've had an issue report with no error message, this is because the code here was just pulling out the message. This PR uses `conditionMessage` to build the message and strips any ANSI escape characters from it, which should work better with rlang errors.