### PR TITLE
Metadata defaults

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,9 +2,9 @@ name: Build Docker Image
 
 on:
   push:
-    branches: [main, master, tmp-epic-plot-cleanup-input, comparison-metadata]
+    branches: [main, master, tmp-epic-plot-cleanup-input, comparison-metadata, table-metadata]
   pull_request:
-    branches: [main, master, tmp-epic-plot-cleanup-input, comparison-metadata]
+    branches: [main, master, tmp-epic-plot-cleanup-input, comparison-metadata, table-metadata]
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,9 +2,9 @@ name: Build Docker Image
 
 on:
   push:
-    branches: [main, master, tmp-epic-plot-cleanup-input, comparison-metadata, table-metadata]
+    branches: [main, master, tmp-epic-plot-cleanup-input]
   pull_request:
-    branches: [main, master, tmp-epic-plot-cleanup-input, comparison-metadata, table-metadata]
+    branches: [main, master, tmp-epic-plot-cleanup-input]
 
 jobs:
   docker:

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -99,22 +99,54 @@ get_choropleth_settings <- function(filter_types) {
 }
 
 get_barchart_settings <- function(filter_types) {
-  base_filter_ids <- c("period", "sex", "age")
-  default_filter_ids <- c("indicator", "area", base_filter_ids)
-  all_filter_ids <- c("indicator", "detail", "area", base_filter_ids)
-
-  x_axis_or_disagg_by_options <- lapply(base_filter_ids,
-                                        get_x_axis_or_disagg_by_option)
+  default_filter_ids <- c("indicator", "area", "period", "sex", "age")
+  all_filter_ids <- c("indicator", "detail", "area", "period", "sex", "age")
   default_filters <- lapply(default_filter_ids, get_filter_from_id)
   all_filters <- lapply(all_filter_ids, get_filter_from_id)
 
-  area_x_axis_disaggregate_effect <- list(
+  area_effect <- list(
     id = scalar("area"),
     label = scalar(get_label_for_id("area")),
     effect = list(
       setMultiple = "area",
       setFilters = all_filters
     )
+  )
+  age_effect <- list(
+    id = scalar("age"),
+    label = scalar(get_label_for_id("age")),
+    effect = list(
+      setMultiple = "age",
+      setFilterValues = list(
+        age = naomi::get_five_year_age_groups()
+      )
+    )
+  )
+  period_effect <- list(
+    id = scalar("period"),
+    label = scalar(get_label_for_id("period")),
+    effect = list(
+      setMultiple = "period",
+      setFilterValues = list(
+        period = get_filter_option_ids(filter_types, "period")
+      )
+    )
+  )
+  sex_effect <- list(
+    id = scalar("sex"),
+    label = scalar(get_label_for_id("sex")),
+    effect = list(
+      setMultiple = "sex",
+      setFilterValues = list(
+        sex = c("male", "female")
+      )
+    )
+  )
+  x_axis_or_disagg_by_options <- list(
+    area_effect,
+    period_effect,
+    sex_effect,
+    age_effect
   )
 
   list(
@@ -123,23 +155,20 @@ get_barchart_settings <- function(filter_types) {
       setFilterValues = list(
         indicator = c("prevalence"),
         period = get_filter_option_ids(filter_types, "period")[2],
-        sex = c("male", "female"),
-        age = naomi::get_five_year_age_groups()
+        sex = c("both")
       )
     ),
     plotSettings = list(
       list(
         id = scalar("x_axis"),
         label = scalar(t_("OUTPUT_BARCHART_X_AXIS")),
-        options = c(list(area_x_axis_disaggregate_effect),
-                    x_axis_or_disagg_by_options),
+        options = x_axis_or_disagg_by_options,
         value = scalar("age")
       ),
       list(
         id = scalar("disagg_by"),
         label = scalar(t_("OUTPUT_BARCHART_DISAGG_BY")),
-        options = c(list(area_x_axis_disaggregate_effect),
-                    x_axis_or_disagg_by_options),
+        options = x_axis_or_disagg_by_options,
         value = scalar("sex")
       )
     )
@@ -199,12 +228,41 @@ get_comparison_plot_settings_control <- function(filter_types) {
 }
 
 get_comparison_plot_settings <- function(filter_types) {
-  x_axis_filters <- c("period", "sex", "age")
-  default_filter_ids <- c("source", "indicator", "area", x_axis_filters)
+  default_filter_ids <- c("source", "indicator", "area", "age", "period", "sex")
   all_filter_ids <- c("source", "indicator", "detail", "area")
   default_filters <- lapply(default_filter_ids, get_filter_from_id)
   all_filters <- lapply(all_filter_ids, get_filter_from_id)
 
+  period_x_axis_effect <- list(
+    id = scalar("period"),
+    label = scalar(get_label_for_id("period")),
+    effect = list(
+      setMultiple = "period",
+      setFilterValues = list(
+        period = get_filter_option_ids(filter_types, "period")
+      )
+    )
+  )
+  sex_x_axis_effect <- list(
+    id = scalar("sex"),
+    label = scalar(get_label_for_id("sex")),
+    effect = list(
+      setMultiple = "sex",
+      setFilterValues = list(
+        sex = get_filter_option_ids(filter_types, "sex")
+      )
+    )
+  )
+  age_x_axis_effect <- list(
+    id = scalar("age"),
+    label = scalar(get_label_for_id("age")),
+    effect = list(
+      setMultiple = "age",
+      setFilterValues = list(
+        age = naomi::get_five_year_age_groups()
+      )
+    )
+  )
   area_x_axis_effect <- list(
     id = scalar("area"),
     label = scalar(get_label_for_id("area")),
@@ -212,6 +270,12 @@ get_comparison_plot_settings <- function(filter_types) {
       setMultiple = "area",
       setFilters = all_filters
     )
+  )
+  x_axis_settings <- list(
+    area_x_axis_effect,
+    period_x_axis_effect,
+    sex_x_axis_effect,
+    age_x_axis_effect
   )
   ## TODO: In current plot when you change indicator, it updates
   ## the filters. We could support this same behaviour by making
@@ -225,8 +289,7 @@ get_comparison_plot_settings <- function(filter_types) {
       setFilters = default_filters,
       setFilterValues = list(
         indicator = c("prevalence"),
-        period = get_filter_option_ids(filter_types, "period")[2],
-        age = naomi::get_five_year_age_groups()
+        period = get_filter_option_ids(filter_types, "period")[2]
       ),
       setHidden = c(
         "source"
@@ -238,8 +301,7 @@ get_comparison_plot_settings <- function(filter_types) {
       list(
         id = scalar("x_axis"),
         label = scalar(t_("OUTPUT_BARCHART_X_AXIS")),
-        options = c(lapply(x_axis_filters, get_x_axis_or_disagg_by_option),
-                    list(area_x_axis_effect)),
+        options = x_axis_settings,
         value = scalar("age")
       ),
       list(

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -99,14 +99,14 @@ get_choropleth_settings <- function(filter_types) {
 }
 
 get_barchart_settings <- function(filter_types) {
-  base_filter_ids <- c("area", "period", "sex", "age")
-  default_filter_ids <- c("indicator", base_filter_ids)
-  all_filter_ids <- c(c("indicator", "detail"), base_filter_ids)
+  base_filter_ids <- c("period", "sex", "age")
+  default_filter_ids <- c("indicator", "area", base_filter_ids)
+  all_filter_ids <- c("indicator", "detail", "area", base_filter_ids)
 
   x_axis_or_disagg_by_options <- lapply(base_filter_ids,
                                         get_x_axis_or_disagg_by_option)
   default_filters <- lapply(default_filter_ids, get_filter_from_id)
-  all_filters <- c(default_filters, list(get_filter_from_id("detail")))
+  all_filters <- lapply(all_filter_ids, get_filter_from_id)
 
   area_x_axis_disaggregate_effect <- list(
     id = scalar("area"),
@@ -131,15 +131,15 @@ get_barchart_settings <- function(filter_types) {
       list(
         id = scalar("x_axis"),
         label = scalar(t_("OUTPUT_BARCHART_X_AXIS")),
-        options = c(x_axis_or_disagg_by_options,
-                    list(area_x_axis_disaggregate_effect)),
+        options = c(list(area_x_axis_disaggregate_effect),
+                    x_axis_or_disagg_by_options),
         value = scalar("age")
       ),
       list(
         id = scalar("disagg_by"),
         label = scalar(t_("OUTPUT_BARCHART_DISAGG_BY")),
-        options = c(x_axis_or_disagg_by_options,
-                    list(area_x_axis_disaggregate_effect)),
+        options = c(list(area_x_axis_disaggregate_effect),
+                    x_axis_or_disagg_by_options),
         value = scalar("sex")
       )
     )
@@ -200,8 +200,8 @@ get_comparison_plot_settings_control <- function(filter_types) {
 
 get_comparison_plot_settings <- function(filter_types) {
   x_axis_filters <- c("period", "sex", "age")
-  default_filter_ids <- c(c("source", "indicator", "area"), x_axis_filters)
-  all_filter_ids <- c(c("source", "indicator", "detail", "area"))
+  default_filter_ids <- c("source", "indicator", "area", x_axis_filters)
+  all_filter_ids <- c("source", "indicator", "detail", "area")
   default_filters <- lapply(default_filter_ids, get_filter_from_id)
   all_filters <- lapply(all_filter_ids, get_filter_from_id)
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -200,10 +200,10 @@ get_comparison_plot_settings_control <- function(filter_types) {
 
 get_comparison_plot_settings <- function(filter_types) {
   x_axis_filters <- c("period", "sex", "age")
-  default_filter_ids <- c(c("indicator", "area", "source"),
-                          x_axis_filters)
+  default_filter_ids <- c(c("source", "indicator", "area"), x_axis_filters)
+  all_filter_ids <- c(c("source", "indicator", "detail", "area"))
   default_filters <- lapply(default_filter_ids, get_filter_from_id)
-  all_filters <- c(default_filters, list(get_filter_from_id("detail")))
+  all_filters <- lapply(all_filter_ids, get_filter_from_id)
 
   area_x_axis_effect <- list(
     id = scalar("area"),

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -100,12 +100,26 @@ get_choropleth_settings <- function(filter_types) {
 
 get_barchart_settings <- function(filter_types) {
   base_filter_ids <- c("area", "period", "sex", "age")
+  default_filter_ids <- c("indicator", base_filter_ids)
   all_filter_ids <- c(c("indicator", "detail"), base_filter_ids)
+
   x_axis_or_disagg_by_options <- lapply(base_filter_ids,
                                         get_x_axis_or_disagg_by_option)
+  default_filters <- lapply(default_filter_ids, get_filter_from_id)
+  all_filters <- c(default_filters, list(get_filter_from_id("detail")))
+
+  area_x_axis_disaggregate_effect <- list(
+    id = scalar("area"),
+    label = scalar(get_label_for_id("area")),
+    effect = list(
+      setMultiple = "area",
+      setFilters = all_filters
+    )
+  )
+
   list(
     defaultEffect = list(
-      setFilters = lapply(all_filter_ids, get_filter_from_id),
+      setFilters = default_filters,
       setFilterValues = list(
         indicator = c("prevalence"),
         period = get_filter_option_ids(filter_types, "period")[2],
@@ -117,13 +131,15 @@ get_barchart_settings <- function(filter_types) {
       list(
         id = scalar("x_axis"),
         label = scalar(t_("OUTPUT_BARCHART_X_AXIS")),
-        options = x_axis_or_disagg_by_options,
+        options = c(x_axis_or_disagg_by_options,
+                    list(area_x_axis_disaggregate_effect)),
         value = scalar("age")
       ),
       list(
         id = scalar("disagg_by"),
         label = scalar(t_("OUTPUT_BARCHART_DISAGG_BY")),
-        options = x_axis_or_disagg_by_options,
+        options = c(x_axis_or_disagg_by_options,
+                    list(area_x_axis_disaggregate_effect)),
         value = scalar("sex")
       )
     )

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -75,43 +75,56 @@ get_country_iso3 <- function(area_ids) {
 
 get_output_plot_settings_control <- function(filter_types) {
   list(
-    choropleth = get_choropleth_settings(),
-    barchart = get_barchart_settings(),
+    choropleth = get_choropleth_settings(filter_types),
+    barchart = get_barchart_settings(filter_types),
     table = get_table_settings(filter_types),
-    bubble = get_bubble_settings()
+    bubble = get_bubble_settings(filter_types)
   )
 }
 
-get_choropleth_settings <- function() {
+get_choropleth_settings <- function(filter_types) {
   filter_ids <- c("indicator", "detail", "area", "period", "sex", "age")
+  detail_options <- get_filter_option_ids(filter_types, "detail")
   list(
     defaultEffect = list(
       setFilters = lapply(filter_ids, get_filter_from_id),
-      setMultiple = "area"
+      setMultiple = "area",
+      setFilterValues = list(
+        indicator = c("prevalence"),
+        detail = detail_options[length(detail_options)]
+      )
     ),
     plotSettings = list()
   )
 }
 
-get_barchart_settings <- function() {
+get_barchart_settings <- function(filter_types) {
   base_filter_ids <- c("area", "period", "sex", "age")
   all_filter_ids <- c(c("indicator", "detail"), base_filter_ids)
   x_axis_or_disagg_by_options <- lapply(base_filter_ids,
                                         get_x_axis_or_disagg_by_option)
   list(
     defaultEffect = list(
-      setFilters = lapply(all_filter_ids, get_filter_from_id)
+      setFilters = lapply(all_filter_ids, get_filter_from_id),
+      setFilterValues = list(
+        indicator = c("prevalence"),
+        period = get_filter_option_ids(filter_types, "period")[2],
+        sex = c("male", "female"),
+        age = naomi::get_five_year_age_groups()
+      )
     ),
     plotSettings = list(
       list(
         id = scalar("x_axis"),
         label = scalar(t_("OUTPUT_BARCHART_X_AXIS")),
-        options = x_axis_or_disagg_by_options
+        options = x_axis_or_disagg_by_options,
+        value = scalar("age")
       ),
       list(
         id = scalar("disagg_by"),
         label = scalar(t_("OUTPUT_BARCHART_DISAGG_BY")),
-        options = x_axis_or_disagg_by_options
+        options = x_axis_or_disagg_by_options,
+        value = scalar("sex")
       )
     )
   )
@@ -191,7 +204,6 @@ get_comparison_plot_settings <- function(filter_types) {
   ## actually used for filtering the data. But let's check what we
   ## actually want to do. Would have to set the x-axis too, which I don't
   ## think we can support yet.
-  ## TODO: Set the x-axis default value to "age"
   list(
     defaultEffect = list(
       setFilters = default_filters,
@@ -211,7 +223,8 @@ get_comparison_plot_settings <- function(filter_types) {
         id = scalar("x_axis"),
         label = scalar(t_("OUTPUT_BARCHART_X_AXIS")),
         options = c(lapply(x_axis_filters, get_x_axis_or_disagg_by_option),
-                    list(area_x_axis_effect))
+                    list(area_x_axis_effect)),
+        value = scalar("age")
       ),
       list(
         id = scalar("disagg_by"),
@@ -311,25 +324,31 @@ get_table_presets <- function(filter_types) {
   )
 }
 
-get_bubble_settings <- function() {
+get_bubble_settings <- function(filter_types) {
   indicators <- list(
-    list(
-      filterId = scalar("indicator"),
-      label = scalar(t_("OUTPUT_BUBBLE_SIZE_INDICATOR")),
-      stateFilterId = scalar("sizeIndicator")
-    ),
     list(
       filterId = scalar("indicator"),
       label = scalar(t_("OUTPUT_BUBBLE_COLOUR_INDICATOR")),
       stateFilterId = scalar("colourIndicator")
+    ),
+    list(
+      filterId = scalar("indicator"),
+      label = scalar(t_("OUTPUT_BUBBLE_SIZE_INDICATOR")),
+      stateFilterId = scalar("sizeIndicator")
     )
   )
   base_filter_ids <- lapply(c("detail", "area", "period", "sex", "age"),
                             get_filter_from_id)
+  detail_options <- get_filter_option_ids(filter_types, "detail")
   list(
     defaultEffect = list(
       setFilters = c(indicators, base_filter_ids),
-      setMultiple = "area"
+      setMultiple = "area",
+      setFilterValues = list(
+        colourIndicator = c("prevalence"),
+        sizeIndicator = c("plhiv"),
+        detail = detail_options[length(detail_options)]
+      )
     ),
     plotSettings = list()
   )

--- a/inst/schema/PlotSetting.schema.json
+++ b/inst/schema/PlotSetting.schema.json
@@ -12,6 +12,9 @@
             "type": "array",
             "items": { "$ref": "PlotSettingOption.schema.json" }
         },
+        "value": {
+            "type": "string"
+        },
         "hidden": {
             "type": "boolean"
         }


### PR DESCRIPTION
This PR will
* Set defaults to more closely match current prod, there are some deviations still but these are deliberate e.g. in the table. But let's review this with Jeff and Rachel and see if they want anything updated.
* Adds a new "value" into the PlotSetting this is where we want to a set a default value which is not the first from the dropdown. In particular useful in the bubble plot where having the colour and the size indicators set to the same thing isn't very useful.
* Hides the "detail" whenever "area" is a single-select. With both filters shown, it made these quite hard to use. If you changed a single select area, you would have to update the detail level to be lower than or equal to the area you had selected, which was a bit clumsy. Feels like a simpler UI to just select the area if it is a single select