### PR TITLE
Add validation check for spectrum region code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hintr
 Title: R API for calling naomi district level HIV model
-Version: 1.2.20
+Version: 1.2.21
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# hintr 1.2.21
+
+* Add validation check for spectrum_region_code in the shape file. It must:
+   * Be set for every feature
+   * Be all 0 or if for a country that uses subnational PJNZ have NA for national level and be unique for every level 1 area.
+
 # hintr 1.2.20
 
 * Improve error message when a worker crashes.

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -66,10 +66,7 @@ do_validate_shape <- function(shape) {
   assert_single_parent_region(json)
   assert_single_country(json, "shape")
   assert_properties_exist(json, c("area_id", "area_level_label", "area_level"))
-  ## TODO: Add region code validation see mrc-1305
-  # Then we have to *reread* the file now that we know that it is
-  # valid, but but this is not too slow, especially as the file is now
-  # in cache (but still ~1/20s)
+  assert_region_codes_valid(json)
   list(data = json_verbatim(read_string(shape$path)),
        filters = list("regions" = get_region_filters(json),
                       "level_labels" = get_level_labels(json)))

--- a/R/validation_asserts.R
+++ b/R/validation_asserts.R
@@ -223,6 +223,33 @@ assert_region_codes_valid <- function(json) {
   if (missing_count > 1) {
     stop(t_("VALIDATION_REGION_CODES_VALID", list(count = missing_count)))
   }
+
+  region_code_level <- lapply(json$features, function(x) {
+    list(
+      spectrum_region_code = x$properties$spectrum_region_code,
+      area_level = x$properties$area_level
+    )
+  })
+  # For national spectrum files, all region codes should be 0
+  # for subnational, the "national" level area region code should be NA
+  # and all levels below this should have different region code
+  # So check, either all 0
+  # or if at area_level = 0, spectrum_region_code is NA then at
+  # area_level = 1, all spectrum_region_codes are different
+  region_codes <- unique(vnapply(region_code_level, "[[", "spectrum_region_code"))
+  if (any(region_codes != 0)) {
+    area_levels <- vnapply(region_code_level, "[[", "area_level")
+    level_0_region_codes <- region_code_level[area_levels == 0]
+    if (length(level_0_region_codes) != 1 || !is.na(level_0_region_codes[[1]]$spectrum_region_code)) {
+      stop("Invalid spectrum_region_code for subnational area file. National level must be NA. Please raise a troubleshooting issue.")
+    }
+    level_1_region_codes <- region_code_level[area_levels == 1]
+    unique_region_codes <- unique(level_1_region_codes)
+    if (length(unique_region_codes) != length(level_1_region_codes)) {
+      stop("Duplicate spectrum_region_code for subnational Spectrum files. Please raise a troubleshooting issue.")
+    }
+  }
+
   invisible(TRUE)
 }
 

--- a/tests/testthat/test-validation-asserts.R
+++ b/tests/testthat/test-validation-asserts.R
@@ -181,6 +181,39 @@ test_that("can check region file spectrum codes are valid", {
   features_contain_property = mock_contains_property)
 })
 
+test_that("can check region codes for subnational spectrum countries are valid", {
+  shape <- file_object(file.path("testdata", "malawi.geojson"))
+  json <- hintr_geojson_read(shape)
+
+  # Set region code of 1 of the level 1 areas to something other than 0
+  # so this is interpreted as a shape file for a subnational spectrum country
+  json$features[[2]]$properties$spectrum_region_code <- 1
+  expect_error(
+    assert_region_codes_valid(json),
+    paste("Invalid spectrum_region_code for subnational area file.",
+          "National level must be NA. Please raise a troubleshooting issue."),
+    fixed = TRUE)
+
+  ## and a subnational file with NA at national level and not different levels
+  ## at level 1
+  json$features[[1]]$properties$spectrum_region_code <- NA
+  expect_error(
+    assert_region_codes_valid(json),
+    paste("Duplicate spectrum_region_code for subnational Spectrum files.",
+          "Please raise a troubleshooting issue"),
+    fixed = TRUE)
+
+  ## Set spectrum_region_code correctly
+  ## Note regions below level 1 are not well formed, but we don't check those
+  level <- vnapply(json$features, function(x) x$properties$area_level)
+  i <- 0
+  for (idx in which(level == 1)) {
+    json$features[[idx]]$properties$spectrum_region_code <- i
+    i <- i + 1
+  }
+  expect_true(assert_region_codes_valid(json))
+})
+
 test_that("can check a column for expected values", {
   data <- data_frame(
     age_group = c("Y000_004", "Y005_009", "Y010_014"),


### PR DESCRIPTION
See NEWS for a description of changes. This came from issue with Kenya who have moved from a subnational PJNZ to a national PJNZ this year. As part of that move, the shape file was malformed and it got through validation.